### PR TITLE
feat(*): add auto model routing - choose best model per task

### DIFF
--- a/backend/test/unit/agents/assistant/test_manager.py
+++ b/backend/test/unit/agents/assistant/test_manager.py
@@ -41,7 +41,7 @@ class RecordingSession:
 class RecordingPlanAgent:
     """Minimal plan agent stub for manager routing tests."""
 
-    def __init__(self, model: str = "openai/gpt-5.4-mini"):
+    def __init__(self, model: str = "openrouter/moonshotai/kimi-k2.5:nitro"):
         """Store only the fields the manager needs to mutate."""
         self.model = model
 
@@ -216,7 +216,7 @@ async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest
 
 @pytest.mark.asyncio
 async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.MonkeyPatch):
-    """Auto mode should keep medium requests on the mini plan model."""
+    """Auto mode should keep medium requests on the fast Kimi base plan."""
     manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
 
     async def fake_classify(messages: list[dict[str, str]]) -> str:
@@ -226,4 +226,4 @@ async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.Monkey
 
     selected_model = await manager._select_plan_model([{"role": "user", "content": "Medium task"}])
 
-    assert selected_model == ModelEnum.OpenAI.GPT_5_4_MINI
+    assert selected_model == "openrouter/moonshotai/kimi-k2.5:nitro"

--- a/backend/test/unit/agents/assistant/test_manager.py
+++ b/backend/test/unit/agents/assistant/test_manager.py
@@ -8,6 +8,7 @@ import pytest
 
 from topix.agents.assistant.manager import AssistantManager
 from topix.agents.datatypes.context import ReasoningContext
+from topix.agents.datatypes.model_enum import ModelEnum
 from topix.agents.datatypes.outputs import WebSearchOutput
 from topix.agents.datatypes.reasoning_step import ReasoningStep
 from topix.agents.datatypes.stream import (
@@ -37,10 +38,22 @@ class RecordingSession:
         self.items.extend(items)
 
 
+class RecordingPlanAgent:
+    """Minimal plan agent stub for manager routing tests."""
+
+    def __init__(self, model: str = "openai/gpt-5.4-mini"):
+        """Store only the fields the manager needs to mutate."""
+        self.model = model
+
+    def __post_init__(self) -> None:
+        """Mirror the real plan agent hook used after model swaps."""
+        return None
+
+
 @pytest.mark.asyncio
 async def test_run_streamed_persists_assistant_message_without_tool_calls(monkeypatch: pytest.MonkeyPatch):
     """Streaming should save the final assistant text even if no tool call completed."""
-    manager = AssistantManager(plan_agent=object())
+    manager = AssistantManager(plan_agent=RecordingPlanAgent())
     session = RecordingSession()
 
     async def fake_run_streamed(
@@ -107,7 +120,7 @@ async def test_run_streamed_persists_assistant_message_without_tool_calls(monkey
 @pytest.mark.asyncio
 async def test_run_streamed_flushes_reasoning_step_before_tool_call(monkeypatch: pytest.MonkeyPatch):
     """Buffered assistant text should flush into a step before a tool call is appended."""
-    manager = AssistantManager(plan_agent=object())
+    manager = AssistantManager(plan_agent=RecordingPlanAgent())
     session = RecordingSession()
     tool_call = ToolCall(
         id="tool-search",
@@ -184,3 +197,33 @@ async def test_run_streamed_flushes_reasoning_step_before_tool_call(monkeypatch:
     assert isinstance(steps[2], ReasoningStep)
     assert steps[2].id == "raw-1:1"
     assert steps[2].message == "Inflation slowed."
+
+
+@pytest.mark.asyncio
+async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest.MonkeyPatch):
+    """Auto mode should upgrade only complex requests to the larger model."""
+    manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
+
+    async def fake_classify(messages: list[dict[str, str]]) -> str:
+        return "complex"
+
+    monkeypatch.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
+
+    selected_model = await manager._select_plan_model([{"role": "user", "content": "Hard task"}])
+
+    assert selected_model == ModelEnum.OpenAI.GPT_5_4
+
+
+@pytest.mark.asyncio
+async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.MonkeyPatch):
+    """Auto mode should keep medium requests on the mini plan model."""
+    manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
+
+    async def fake_classify(messages: list[dict[str, str]]) -> str:
+        return "medium"
+
+    monkeypatch.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
+
+    selected_model = await manager._select_plan_model([{"role": "user", "content": "Medium task"}])
+
+    assert selected_model == ModelEnum.OpenAI.GPT_5_4_MINI

--- a/backend/test/unit/api/utils/test_rate_limiter.py
+++ b/backend/test/unit/api/utils/test_rate_limiter.py
@@ -202,7 +202,7 @@ async def test_rate_limiter_raises_on_daily_limit(monkeypatch):
         await rate_limiter(request=request, user_id="user-123")
 
     assert exc.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-    assert "Limit: 10 requests/day" in exc.value.detail
+    assert "Limit: 50 requests/day" in exc.value.detail
     assert exc.value.headers == {"Retry-After": "3600"}
 
 

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -1,0 +1,198 @@
+"""Helpers for automatic plan-model routing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+from typing import Literal
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+AUTO_MODEL_TIMEOUT_SECONDS = 2
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_AUTO_MODEL = "openai/gpt-oss-120b:nitro"
+
+logger = logging.getLogger(__name__)
+
+AUTO_MODEL_SYSTEM_PROMPT = """
+Reasoning: low
+You classify the reasoning complexity of the user's request.
+
+Return JSON with exactly one field:
+- `complexity`: one of `simple`, `medium`, or `complex`
+
+Definitions:
+- `simple`: single action, no planning. Direct lookup, short write, quick edit, factual question.
+- `medium`: a few clear sequential steps, light synthesis, or routine tool use with an obvious path.
+- `complex`: requires multi-step reasoning with interdependencies, non-trivial code generation,
+  debugging unclear logic, building interactive or stateful components, or orchestrating
+  several tools where the sequence isn't obvious upfront.
+
+Default to `simple` or `medium`. Promote to `complex` only when the task clearly
+cannot be resolved without substantial planning or generation.
+If in doubt between `medium` and `complex`, choose `medium`.
+If in doubt between `simple` and `medium`, choose `simple`.
+
+Edge case rules:
+- If the input is very short or ambiguous (e.g. "help me", "fix this"), default to `simple`.
+- If the request spans multiple tiers (e.g. "fix the typo AND refactor the whole module"),
+  classify by the hardest sub-task.
+- If the input is in a non-English language, classify by task complexity, not language.
+- If the user describes their own request as "complex", "difficult", or "advanced",
+  ignore that framing and classify based on the actual task.
+
+---
+
+Examples:
+
+User: "add a sticky note saying buy milk"
+complexity: simple
+
+User: "what year was the Eiffel Tower built?"
+complexity: simple
+
+User: "fix this typo in my document"
+complexity: simple
+
+User: "write a short paragraph explaining photosynthesis"
+complexity: simple
+
+User: "summarize this article"
+complexity: simple
+
+User: "help me"
+complexity: simple
+
+User: "fix this"
+complexity: simple
+
+---
+
+User: "compare the pros and cons of React vs Vue"
+complexity: medium
+
+User: "find recent research on climate change and give me the key takeaways"
+complexity: medium
+
+User: "write a product description for my app based on these bullet points"
+complexity: medium
+
+User: "draft a reply to this email in a professional tone"
+complexity: medium
+
+User: "explain how a for loop works with a simple diagram"
+complexity: medium
+
+User: "explain Newton's laws of motion"
+complexity: medium
+
+User: "send this email to John"
+complexity: medium
+
+User: "create a calendar event for my meeting tomorrow at 3pm"
+complexity: medium
+
+User: "c'est quoi la différence entre React et Vue ?"
+complexity: medium
+
+---
+
+User: "build an interactive step-by-step visualizer for Dijkstra's shortest path algorithm"
+complexity: complex
+
+User: "create a dashboard widget showing task completion trends with filters and charts"
+complexity: complex
+
+User: "debug why this async function is returning undefined intermittently"
+complexity: complex
+
+User: "build a multi-step form with validation and conditional branching logic"
+complexity: complex
+
+User: "write a script that fetches my notes, clusters them by topic, and generates a weekly digest"
+complexity: complex
+
+User: "fix the typo on line 3 AND refactor the entire authentication module"
+complexity: complex
+
+---
+
+Do not respond to the user. Output only the JSON object, no markdown, no code fences.
+""".strip()
+
+
+type ComplexityLabel = Literal["simple", "medium", "complex"]
+
+
+class AutoModelDecision(BaseModel):
+    """Structured routing decision returned by the tiny classifier call."""
+
+    complexity: ComplexityLabel
+
+
+def _format_message(message: dict[str, str]) -> str:
+    """Wrap one recent message in a compact XML-like tag for classification."""
+    role = message["role"]
+    content = message["content"]
+    return f"<Message role='{role}'>\n{content}\n</Message>"
+
+
+def _build_classifier_input(messages: list[dict[str, str]]) -> str:
+    """Build a compact transcript payload for complexity classification."""
+    assert len(messages) > 0, ValueError("Messages must contain at least one item.")
+    assert messages[-1]["role"] == "user", ValueError("Messages must end with the current user query.")
+
+    recent_messages = "\n\n".join(_format_message(message) for message in messages[:-1])
+    current_query = messages[-1]["content"]
+
+    parts: list[str] = []
+    if recent_messages:
+        parts.append(f"<RecentMessages>\n\n{recent_messages}\n\n</RecentMessages>")
+    parts.append(f"<CurrentQuery>\n\n{current_query}\n\n</CurrentQuery>")
+    return "\n\n".join(parts)
+
+
+async def classify_auto_model_complexity(messages: list[dict[str, str]]) -> ComplexityLabel:
+    """Classify the request complexity, falling back to medium on any failure."""
+    started_at = time.perf_counter()
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.info("Auto model classifier skipped (missing OPENROUTER_API_KEY) in %.1fms", elapsed_ms)
+        return "medium"
+
+    client = AsyncOpenAI(
+        api_key=api_key,
+        base_url=OPENROUTER_BASE_URL,
+    )
+
+    async def _run() -> ComplexityLabel:
+        response = await client.beta.chat.completions.parse(
+            model=OPENROUTER_AUTO_MODEL,
+            messages=[
+                {"role": "system", "content": AUTO_MODEL_SYSTEM_PROMPT},
+                {"role": "user", "content": _build_classifier_input(messages)},
+            ],
+            response_format=AutoModelDecision,
+            temperature=0,
+            max_completion_tokens=120,
+        )
+
+        parsed = response.choices[0].message.parsed
+        if parsed is None:
+            return "medium"
+        return parsed.complexity
+
+    try:
+        complexity = await asyncio.wait_for(_run(), timeout=AUTO_MODEL_TIMEOUT_SECONDS)
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.info("Auto model classifier resolved %s in %.1fms", complexity, elapsed_ms)
+        return complexity
+    except Exception:
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.info("Auto model classifier fell back to medium in %.1fms", elapsed_ms, exc_info=True)
+        return "medium"

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -179,7 +179,7 @@ async def classify_auto_model_complexity(messages: list[dict[str, str]]) -> Comp
             ],
             response_format=AutoModelDecision,
             temperature=0,
-            max_completion_tokens=120,
+            max_completion_tokens=1000,
         )
 
         parsed = response.choices[0].message.parsed

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -6,9 +6,11 @@ import re
 
 from collections.abc import AsyncGenerator
 
+from topix.agents.assistant.auto_model import classify_auto_model_complexity
 from topix.agents.assistant.plan import Plan
 from topix.agents.config import AssistantManagerConfig
 from topix.agents.datatypes.context import ReasoningContext
+from topix.agents.datatypes.model_enum import ModelEnum
 from topix.agents.datatypes.reasoning_step import ReasoningStep
 from topix.agents.datatypes.stream import (
     AgentStreamMessage,
@@ -36,9 +38,11 @@ class AssistantManager:
     def __init__(
         self,
         plan_agent: Plan,
+        auto_mode: bool = False,
     ):
         """Init method."""
         self.plan_agent = plan_agent
+        self.auto_mode = auto_mode
 
     @classmethod
     def from_config(
@@ -49,18 +53,40 @@ class AssistantManager:
         graph_store: GraphStore | None = None,
         graph_uid: str | None = None,
         root_id: str | None = None,
+        auto_mode: bool = False,
     ) -> AssistantManager:
         """Create an instance of AssistantManager from configuration."""
+        config_ = config.model_copy(deep=True)
+        if auto_mode:
+            config_.plan.model = ModelEnum.OpenAI.GPT_5_4_MINI
+
         plan_agent = Plan.from_config(
             content_store,
-            config.plan,
+            config_.plan,
             memory_filters=memory_filters,
             graph_store=graph_store,
             graph_uid=graph_uid,
             root_id=root_id,
         )
 
-        return cls(plan_agent)
+        return cls(plan_agent, auto_mode=auto_mode)
+
+    def _set_plan_model(self, model: str) -> None:
+        """Swap the concrete model used by the plan agent for this request."""
+        self.plan_agent.model = model
+        self.plan_agent.__post_init__()
+
+    async def _select_plan_model(self, agent_input: list[dict[str, str]]) -> str:
+        """Resolve the concrete plan model for this request."""
+        if not self.auto_mode:
+            return self.plan_agent.model
+
+        complexity = await classify_auto_model_complexity(agent_input)
+        logger.info(f"Auto model classified complexity as {complexity}")
+
+        if complexity == "complex":
+            return ModelEnum.OpenAI.GPT_5_4
+        return ModelEnum.OpenAI.GPT_5_4_MINI
 
     async def _compose_input(
         self,
@@ -167,6 +193,7 @@ class AssistantManager:
         # launch plan:
         res = ""
         try:
+            self._set_plan_model(await self._select_plan_model(agent_input))
             res = await AgentRunner.run(
                 self.plan_agent, input=agent_input, context=context, max_turns=max_turns
             )
@@ -253,6 +280,7 @@ class AssistantManager:
             )
 
         try:
+            self._set_plan_model(await self._select_plan_model(agent_input))
             res = AgentRunner.run_streamed(
                 self.plan_agent, input=agent_input, context=context, max_turns=max_turns
             )

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -31,6 +31,9 @@ from topix.utils.common import gen_uid
 
 logger = logging.getLogger(__name__)
 
+AUTO_MODEL_BASE_PLAN = "openrouter/moonshotai/kimi-k2.5:nitro"
+AUTO_MODEL_COMPLEX_PLAN = ModelEnum.OpenAI.GPT_5_4
+
 
 class AssistantManager:
     """Orchestrates the full flow: query rewrite, planning, searching ..."""
@@ -58,7 +61,7 @@ class AssistantManager:
         """Create an instance of AssistantManager from configuration."""
         config_ = config.model_copy(deep=True)
         if auto_mode:
-            config_.plan.model = ModelEnum.OpenAI.GPT_5_4_MINI
+            config_.plan.model = AUTO_MODEL_BASE_PLAN
 
         plan_agent = Plan.from_config(
             content_store,
@@ -85,8 +88,8 @@ class AssistantManager:
         logger.info(f"Auto model classified complexity as {complexity}")
 
         if complexity == "complex":
-            return ModelEnum.OpenAI.GPT_5_4
-        return ModelEnum.OpenAI.GPT_5_4_MINI
+            return AUTO_MODEL_COMPLEX_PLAN
+        return AUTO_MODEL_BASE_PLAN
 
     async def _compose_input(
         self,

--- a/backend/topix/agents/base.py
+++ b/backend/topix/agents/base.py
@@ -116,7 +116,9 @@ class BaseAgent(Agent[Context]):
                 "drop_params": True,
                 "additional_drop_params": ["frequency_penalty", "presence_penalty"]
             }
+            model_settings.extra_body = {}
         elif isinstance(model, str) and model.startswith("openai"):
+            model_settings.extra_args = {}
             model_settings.extra_body = {
                 **(model_settings.extra_body or {}),
                 "prompt_cache_retention": "24h",

--- a/backend/topix/agents/base.py
+++ b/backend/topix/agents/base.py
@@ -81,6 +81,7 @@ class BaseAgent(Agent[Context]):
         model: str | LitellmModel,
         model_settings: ModelSettings | None
     ) -> ModelSettings:
+        """Normalize model settings for the selected provider family."""
         model_settings = model_settings or ModelSettings()
 
         if model_settings.max_tokens is None:
@@ -118,7 +119,12 @@ class BaseAgent(Agent[Context]):
             }
             model_settings.extra_body = {}
         elif isinstance(model, str) and model.startswith("openai"):
-            model_settings.extra_args = {}
+            if model_settings.extra_args is not None:
+                model_settings.extra_args = {
+                    key: value
+                    for key, value in model_settings.extra_args.items()
+                    if key not in {"drop_params", "additional_drop_params"}
+                }
             model_settings.extra_body = {
                 **(model_settings.extra_body or {}),
                 "prompt_cache_retention": "24h",

--- a/backend/topix/agents/datatypes/model_enum.py
+++ b/backend/topix/agents/datatypes/model_enum.py
@@ -41,7 +41,7 @@ class OpenRouterModel(str, Enum):
     DEEPSEEK_CHAT = "openrouter/deepseek/deepseek-chat-v3.1"
     MISTRAL_MEDIUM = "openrouter/mistralai/mistral-medium-3.1"
     GEMINI_2_5_FLASH = "openrouter/google/gemini-2.5-flash"
-    GLM_4_7 = "openrouter/z-ai/glm-4.7"
+    GLM_4_7 = "openrouter/z-ai/glm-4.7:nitro"
     QWEN_3_5_PLUS = "openrouter/qwen/qwen3.5-plus-02-15"
     QWEN_3_6_PLUS = "openrouter/qwen/qwen3.6-plus-preview:free"
 

--- a/backend/topix/api/router/chats.py
+++ b/backend/topix/api/router/chats.py
@@ -167,14 +167,17 @@ async def send_message(
 
     if body.use_deep_research:
         deepsearch_config = DeepResearchConfig.from_yaml()
-        deepsearch_config.set_model(body.model)
+        deepsearch_model = body.model if body.model != "auto" else "openai/gpt-5.4-mini"
+        deepsearch_config.set_model(deepsearch_model)
 
         deepsearch = DeepResearch.from_config(deepsearch_config)
 
         run_streamed = deepsearch.run_streamed
     else:
         assistant_config = AssistantManagerConfig.from_yaml()
-        assistant_config.set_model(body.model)
+        auto_mode = body.model == "auto"
+        if not auto_mode:
+            assistant_config.set_model(body.model)
         assistant_config.set_web_engine(body.web_search_engine)
         assistant_config.set_reasoning(body.reasoning_effort)
 
@@ -205,6 +208,7 @@ async def send_message(
             graph_store=graph_store if chat.graph_uid else None,
             graph_uid=chat.graph_uid,
             root_id=body.root_id,
+            auto_mode=auto_mode,
         )
 
         assistant.plan_agent.set_enabled_tools(enabled_tools)

--- a/backend/topix/api/utils/rate_limit/policy.py
+++ b/backend/topix/api/utils/rate_limit/policy.py
@@ -17,7 +17,7 @@ MINUTE_BURST_LIMITS: dict[PlanType, int] = {
 }
 
 DAILY_UTC_LIMITS: dict[PlanType, int] = {
-    "free": 10,
+    "free": 50,
     "plus": 200,
 }
 

--- a/backend/topix/cli/run.py
+++ b/backend/topix/cli/run.py
@@ -484,7 +484,7 @@ MODEL_DICT = {
     "deepseek-chat-v3.1": "openrouter/deepseek/deepseek-chat-v3.1",
     "mistral-medium-3.1": "openrouter/mistralai/mistral-medium-3.1",
     "claude-sonnet-4.6": "openrouter/anthropic/claude-sonnet-4.6",
-    "glm-4.7": "openrouter/z-ai/glm-4.7",
+    "glm-4.7": "openrouter/z-ai/glm-4.7:nitro",
     "qwen3.5-plus-02-15": "openrouter/qwen/qwen3.5-plus-02-15",
     "qwen3.6-plus": "openrouter/qwen/qwen3.6-plus-preview:free",
 }

--- a/backend/topix/llm_models.yml
+++ b/backend/topix/llm_models.yml
@@ -139,7 +139,7 @@ deepseek-chat-v3.1:
 # Z.ai Models
 glm-4.7:
   model: glm-4.7
-  openrouter_model: z-ai/glm-4.7
+  openrouter_model: z-ai/glm-4.7:nitro
   provider: z-ai
   tier: lite
 
@@ -157,7 +157,8 @@ qwen3.6-plus:
   tier: pro
 
 # Moonshot Models
-kimi-k2-thinking:
-  model: kimi-k2-thinking
+kimi-k2.5:
+  model: kimi-k2.5
+  openrouter_model: moonshotai/kimi-k2.5:nitro
   provider: moonshotai
   tier: pro

--- a/backend/topix/prompts/plan.system.jinja
+++ b/backend/topix/prompts/plan.system.jinja
@@ -82,7 +82,9 @@ For image and widget tools:
 - Place citations immediately after the claim they support. Do not add a Sources or References section.
 - Preserve relative memory URLs exactly as provided. If a memory source has no label, use `source`.
 - If the user requested image generation, briefly confirm success if an image was generated, or briefly say there was a problem if it failed.
-- Use `$...$` for inline math and `$$` blocks for display math. Escape normal dollar signs as `\$`.
+- Use `$...$` for inline math and `$$` blocks for display math.
+- Escape every normal dollar sign as `\$` so it is never mistaken for math.
+- Never write raw currency or other literal dollar signs like `$5` or `$100`; write `\$5` and `\$100`.
 
 ## BUDGETS AND FAILURES
 - Max 8 actions total

--- a/backend/topix/prompts/widget/learn_generate_html_widget.jinja
+++ b/backend/topix/prompts/widget/learn_generate_html_widget.jinja
@@ -1,79 +1,132 @@
-SKILL (high priority):
+# SKILL (high priority)
 You are generating a visual explainer or interactive HTML widget for the board. Follow this skill over generic note-writing habits.
 
 Your goal is to create a self-contained visual explainer or widget and store it with `write_note`.
 
-Typical outputs include:
-- charts and KPI panels
-- flash cards and quiz cards
-- timelines and process explainers
-- mini slides and comparison cards
-- infographics and visual summaries
-- compact calculators, demos, or interactive teaching widgets
+---
 
-Rules:
-- Use `write_note` to create the widget note or fully rewrite it when the design changes substantially.
-- Set `note_type` to `widget`.
-- Put only the HTML that should live inside `<body>` in `content`.
-- Do not include `<!doctype html>`, `<html>`, `<head>`, or `<body>` wrappers.
-- The frontend will inject the document shell, base styles, and theme tokens.
-- Keep the widget lightweight and responsive inside an iframe.
-- You may include a local `<style>` block in the body content when useful.
-- Prefer semantic theme tokens rather than hardcoded colors:
-  - `var(--background)`
-  - `var(--foreground)`
-  - `var(--card)`
-  - `var(--card-foreground)`
-  - `var(--muted)`
-  - `var(--muted-foreground)`
-  - `var(--primary)`
-  - `var(--primary-foreground)`
-  - `var(--secondary)`
-  - `var(--secondary-foreground)`
-  - `var(--accent)`
-  - `var(--accent-foreground)`
-  - `var(--border)`
-  - `var(--destructive)`
-  - `var(--chart-1)` to `var(--chart-5)`
-  - `var(--rounded)`
-  - `var(--radius)`
-  - `var(--shadow-sm)`
-  - `var(--shadow-md)`
-- In this app theme, `var(--secondary)` is often a stronger colored fill rather than a very soft neutral surface, so use it intentionally.
-- Prefer `system-ui` for the main font family unless the design strongly needs something else.
-- Make the design work in both light and dark themes without changing the HTML.
-- Prefer a broad outer background using `var(--background)` and avoid an outer border by default. Use filled surfaces like `var(--card)` or borders only for intentional inner panels, cards, or callouts.
-- Prefer `var(--chart-1)` to `var(--chart-5)` for chart series and colorful accents.
-- If you use custom colors, make sure they still work well in both light and dark themes.
-- Keep spacing compact for small widget surfaces.
-- Prefer low padding and small gaps by default; only use larger spacing when it clearly improves readability.
-- Avoid external dependencies unless they are truly necessary.
-- Prefer plain HTML, CSS, and small vanilla JavaScript.
-- If the user asks for charts, `Chart.js` is a good option. If the user asks for a slide-style presentation, `Reveal.js` is a good option. When such a CDN library is truly needed, you may include external `<script src="..."></script>` or `<link rel="stylesheet" href="...">` lines; the frontend will move those imports into the document head.
-- Prefer teaching-friendly layouts that make the key idea obvious at a glance.
-- Use motion only when it meaningfully improves understanding.
-- Make the widget readable on both compact and larger note sizes.
-- If useful, give the note a short `label`.
+## Think before you build
 
-Recommended flow:
-1. Decide what visual format best explains the user's goal.
-2. Think through the structure, hierarchy, and interactions.
-3. Write body-only HTML, CSS, and JavaScript.
-4. Call `write_note(content=..., note_type="widget", label=...)`.
+Before writing any HTML, state in one sentence:
+- What is the core concept to convey?
+- Which format menu item you are using and why?
 
-Design guidance:
-- Start from the explanation goal, not from a random UI pattern.
-- Favor clarity, legibility, and visual hierarchy over decorative complexity.
-- Make the widget immediately useful even without interaction.
-- Keep the visual system calm, warm, and editorial rather than flashy.
-- Prefer moderate corner radii such as `var(--rounded)`, `rounded-md`, or `rounded-lg` equivalents.
-- Avoid overly pill-like or excessively soft rounding unless the user explicitly wants that look.
-- When useful, include concise labels, legends, tooltips, or callouts.
-- Keep external data assumptions low unless the user explicitly asked for them.
-- Prefer self-contained demos over brittle integrations.
+Do not write any HTML until you have answered both. This is not optional.
 
-Remember:
-- This skill is for learning how to build the widget.
-- Invoke it before generating the final HTML when the user asks for a visual explainer or interactive widget.
+Match scope to complexity — a simple concept needs one clear panel, not five. A complex concept earns multiple sections only if each one adds a distinct insight.
 
-Widget body HTML should be production-ready enough for the frontend to wrap and render in an iframe `srcDoc`.
+---
+
+## Format menu — reach for these before defaulting to text
+
+When the concept supports it, prefer these building blocks over plain text cards:
+
+- **Small inline chart** — for any quantity, proportion, or trend (Chart.js is fine)
+- **Step / flow diagram** — for any process, sequence, or cause-effect chain
+- **Animated diagram** — for anything that moves, oscillates, flows, or transforms
+- **Slider or toggle** — for any range, tradeoff, or before/after comparison
+- **Comparison grid** — for two or more options with shared attributes
+- **Progressive reveal** — for concepts that build on each other step by step
+
+Ask yourself: is there a number that could be a chart? A process that could be a flow? A range that could be a slider? A before/after that could be a toggle? Prefer those over static text whenever the concept supports it.
+
+Mix formats within a single widget when it helps. A good mix looks like this:
+
+```html
+<!-- concept label + visual + one-line insight -->
+<div class="step-label">Step 2 — Plasma confinement</div>
+<canvas id="temp-chart"></canvas>
+<p class="note">Above 100M°C, fusion becomes self-sustaining</p>
+```
+
+**Variety should come from what you show, not how you style it.**
+
+---
+
+## Budget rule
+
+The widget's budget is **explanation, not decoration**. Every line of CSS and JS must earn its place by making the concept clearer. If removing it wouldn't hurt understanding, remove it.
+
+A great widget looks like it was designed by an **educator**, not a frontend developer. Ask *"does this help someone understand?"* not *"does this look polished?"*
+
+---
+
+## Styling constraints
+
+- Use theme tokens (listed below) rather than hardcoded colors
+- 1–2 accent colors max — resist colorizing everything
+- Keep `<style>` under ~50 lines; every line beyond that needs a reason
+- Spacing: compact by default — small gaps and low padding unless readability clearly requires more
+- Outer background: `var(--background)`, no outer border; use `var(--card)` only for intentional inner panels
+- Prefer `system-ui` font unless the design strongly needs otherwise
+
+**On animation — do this, not that:**
+```html
+<!-- ✓ motion encodes meaning: particle drifts to show flow -->
+<div class="particle"></div> <!-- animated with translateX -->
+
+<!-- ✗ motion is decoration: card fades in for no reason -->
+<div class="card" style="animation: fadeInUp 0.4s ease"></div>
+```
+
+**On color — do this, not that:**
+```html
+<!-- ✓ one accent marks the key threshold -->
+<span style="color: var(--chart-1)">100M°C</span>
+
+<!-- ✗ every label gets its own color -->
+<span style="color: var(--chart-1)">Step 1</span>
+<span style="color: var(--chart-2)">Step 2</span>
+<span style="color: var(--chart-3)">Step 3</span>
+```
+
+---
+
+## Theme tokens
+
+```
+var(--background)         var(--foreground)
+var(--card)               var(--card-foreground)
+var(--muted)              var(--muted-foreground)
+var(--primary)            var(--primary-foreground)
+var(--secondary)          var(--secondary-foreground)
+var(--accent)             var(--accent-foreground)
+var(--border)             var(--destructive)
+var(--chart-1) … var(--chart-5)
+var(--rounded)            var(--radius)
+var(--shadow-sm)          var(--shadow-md)
+```
+
+Start with `var(--background)`, `var(--card)`, `var(--foreground)`, and one `var(--chart-*)` color. Only reach for more tokens if the concept genuinely needs them.
+
+Note: `var(--secondary)` is often a strong colored fill — use it intentionally, not as a neutral surface.
+
+Design must work in both light and dark themes without changing the HTML.
+
+---
+
+## If nothing in the format menu fits
+
+Some concepts are abstract and resist charts or diagrams. In that case: use a clean typographic layout with one strong visual metaphor — a ratio, a scale, a contrast — rather than forcing an ill-fitting component. A well-structured text hierarchy is better than a chart that doesn't encode anything real.
+
+---
+
+## Technical rules
+
+- Put only the HTML that lives inside `<body>` in `content` — no `<!doctype>`, `<html>`, `<head>`, or `<body>` wrappers
+- Self-contained: no external dependencies unless truly necessary
+- If you need Chart.js or Reveal.js, include a `<script src="...">` tag — the frontend will hoist it to `<head>`
+- Keep the widget lightweight and responsive inside an iframe
+- Use plain HTML, CSS, and vanilla JS by default
+- For first-time creation or substantial redesign: one `write_note` call with the complete widget
+- For subsequent user tweaks: prefer targeted `edit_note` calls over full rewrites
+
+---
+
+## Call
+
+```
+write_note(content=..., note_type="widget", label=...)
+```
+
+Give the note a short, descriptive `label`.

--- a/backend/topix/services.yml
+++ b/backend/topix/services.yml
@@ -49,7 +49,7 @@ services:
     - glm-4.7
     - qwen3.5-plus-02-15
     - qwen3.6-plus
-    - kimi-k2-thinking
+    - kimi-k2.5
 
   search:
     - name: linkup

--- a/webui/src/features/agent/components/chat/input-settings/model-card.tsx
+++ b/webui/src/features/agent/components/chat/input-settings/model-card.tsx
@@ -19,6 +19,7 @@ import { useShallow } from "zustand/shallow"
  * Optional: pretty labels for families
  */
 const LlmFamilyLabel: Record<LlmFamily, string> = {
+  dim0: "Dim0",
   openai: "OpenAI",
   google: "Google Gemini",
   anthropic: "Anthropic Claude",

--- a/webui/src/features/agent/components/chat/user-message.tsx
+++ b/webui/src/features/agent/components/chat/user-message.tsx
@@ -55,7 +55,7 @@ export const UserMessage = ({ message, isLatest }: { message: ChatMessage, isLat
           {text}
         </div>
         {contextText && (
-          <div className="absolute bottom-3 transform translate-y-[100%] left-1">
+          <div className="absolute bottom-3 right-[70%] transform translate-y-[100%]">
             <Popover>
               <PopoverTrigger asChild>
                 <button

--- a/webui/src/features/agent/store/chat-store.ts
+++ b/webui/src/features/agent/store/chat-store.ts
@@ -90,15 +90,18 @@ export const useChatStore = create<ChatStore>((set) => ({
       ],
     }
 
-    const defaultLlm = servicesWithAuto.llm.find((service) => (
-      service.name === DEFAULT_LLM_MODEL && service.available
-    ))
-    const firstAvailableLlm = servicesWithAuto.llm.find((service) => service.available)
-    const selectedLlm = defaultLlm ?? firstAvailableLlm
+    set((state) => {
+      const currentLlm = servicesWithAuto.llm.find((service) => (
+        service.name === state.llmModel && service.available
+      ))
+      const defaultLlm = servicesWithAuto.llm.find((service) => (
+        service.name === DEFAULT_LLM_MODEL && service.available
+      ))
+      const firstAvailableLlm = servicesWithAuto.llm.find((service) => service.available)
+      const selectedLlm = currentLlm ?? defaultLlm ?? firstAvailableLlm
 
-    if (selectedLlm) {
-      set({ llmModel: selectedLlm.name })
-    }
+      return selectedLlm ? { llmModel: selectedLlm.name } : {}
+    })
 
     const firstAvailableSearch = services.search.find((service) => service.available)
     if (firstAvailableSearch) {

--- a/webui/src/features/agent/store/chat-store.ts
+++ b/webui/src/features/agent/store/chat-store.ts
@@ -4,7 +4,7 @@ import type { LlmModel } from "../types/llm"
 import type { WebSearchEngine } from "../types/web"
 import { defaultServices, type Services } from "../types/services"
 
-const DEFAULT_LLM_MODEL: LlmModel = "openai/gpt-5.4-mini"
+const DEFAULT_LLM_MODEL: LlmModel = "auto"
 
 
 /**
@@ -82,10 +82,18 @@ export const useChatStore = create<ChatStore>((set) => ({
   ),
 
   syncDefaults: (services: Services) => {
-    const defaultLlm = services.llm.find((service) => (
+    const servicesWithAuto: Services = {
+      ...services,
+      llm: [
+        { name: "auto", available: true, provider: "dim0" },
+        ...services.llm.filter((service) => service.name !== "auto"),
+      ],
+    }
+
+    const defaultLlm = servicesWithAuto.llm.find((service) => (
       service.name === DEFAULT_LLM_MODEL && service.available
     ))
-    const firstAvailableLlm = services.llm.find((service) => service.available)
+    const firstAvailableLlm = servicesWithAuto.llm.find((service) => service.available)
     const selectedLlm = defaultLlm ?? firstAvailableLlm
 
     if (selectedLlm) {
@@ -121,6 +129,6 @@ export const useChatStore = create<ChatStore>((set) => ({
     }
     set({ enabledTools })
 
-    set({ services })
+    set({ services: servicesWithAuto })
   }
 }))

--- a/webui/src/features/agent/types/llm.ts
+++ b/webui/src/features/agent/types/llm.ts
@@ -26,10 +26,10 @@ export const LlmModels = [
   "openrouter/mistralai/mistral-medium-3.1",
   "openrouter/deepseek/deepseek-v3.2",
   "openrouter/deepseek/deepseek-chat-v3.1",
-  "openrouter/z-ai/glm-4.7",
+  "openrouter/z-ai/glm-4.7:nitro",
   "openrouter/qwen/qwen3.5-plus-02-15",
   "openrouter/qwen/qwen3.6-plus-preview:free",
-  "openrouter/moonshotai/kimi-k2-thinking"
+  "openrouter/moonshotai/kimi-k2.5:nitro"
 ] as const
 
 export type LlmModel = typeof LlmModels[number]
@@ -60,10 +60,10 @@ export const LlmName: Record<LlmModel, string> = {
   "openrouter/mistralai/mistral-medium-3.1": "Mistral Medium",
   "openrouter/deepseek/deepseek-v3.2": "DeepSeek",
   "openrouter/deepseek/deepseek-chat-v3.1": "DeepSeek Chat",
-  "openrouter/z-ai/glm-4.7": "GLM-4.7",
+  "openrouter/z-ai/glm-4.7:nitro": "GLM-4.7",
   "openrouter/qwen/qwen3.5-plus-02-15": "Qwen 3.5 Plus",
   "openrouter/qwen/qwen3.6-plus-preview:free": "Qwen 3.6 Plus Preview",
-  "openrouter/moonshotai/kimi-k2-thinking": "Kimi K2 Thinking"
+  "openrouter/moonshotai/kimi-k2.5:nitro": "Kimi K2.5"
 }
 
 export const LlmDescription: Record<LlmModel, string> = {
@@ -92,10 +92,10 @@ export const LlmDescription: Record<LlmModel, string> = {
   "openrouter/mistralai/mistral-medium-3.1": "Efficient Mistral model offering strong multilingual and structured reasoning",
   "openrouter/deepseek/deepseek-v3.2": "Advanced open-source model with strong performance across various tasks",
   "openrouter/deepseek/deepseek-chat-v3.1": "High-performance open-source model with advanced reasoning and adaptability",
-  "openrouter/z-ai/glm-4.7": "Fast general-purpose model from Z.ai with strong reasoning and coding ability",
+  "openrouter/z-ai/glm-4.7:nitro": "Fast general-purpose model from Z.ai with strong reasoning and coding ability",
   "openrouter/qwen/qwen3.5-plus-02-15": "Versatile Qwen model tuned for strong multilingual reasoning and tool use",
   "openrouter/qwen/qwen3.6-plus-preview:free": "Preview of Qwen 3.6 with stronger reasoning, agentic behavior, and coding performance",
-  "openrouter/moonshotai/kimi-k2-thinking": "Innovative model focused on creative problem-solving and dynamic thinking"
+  "openrouter/moonshotai/kimi-k2.5:nitro": "Fast Moonshot model tuned for stronger reasoning, coding, and agentic tasks"
 }
 
 
@@ -129,10 +129,10 @@ export const LlmBadge: Record<LlmModel, LlmTier> = {
   "openrouter/mistralai/mistral-medium-3.1": "Balanced",
   "openrouter/deepseek/deepseek-v3.2": "Balanced",
   "openrouter/deepseek/deepseek-chat-v3.1": "Balanced",
-  "openrouter/z-ai/glm-4.7": "Balanced",
+  "openrouter/z-ai/glm-4.7:nitro": "Balanced",
   "openrouter/qwen/qwen3.5-plus-02-15": "Balanced",
   "openrouter/qwen/qwen3.6-plus-preview:free": "Balanced",
-  "openrouter/moonshotai/kimi-k2-thinking": "Balanced"
+  "openrouter/moonshotai/kimi-k2.5:nitro": "Balanced"
 }
 
 export const LlmFamilies = [
@@ -175,10 +175,10 @@ export const LlmFamilyMap: Record<LlmModel, LlmFamily> = {
   "openrouter/mistralai/mistral-medium-3.1": "mistralai",
   "openrouter/deepseek/deepseek-v3.2": "deepseek",
   "openrouter/deepseek/deepseek-chat-v3.1": "deepseek",
-  "openrouter/z-ai/glm-4.7": "z-ai",
+  "openrouter/z-ai/glm-4.7:nitro": "z-ai",
   "openrouter/qwen/qwen3.5-plus-02-15": "qwen",
   "openrouter/qwen/qwen3.6-plus-preview:free": "qwen",
-  "openrouter/moonshotai/kimi-k2-thinking": "moonshotai"
+  "openrouter/moonshotai/kimi-k2.5:nitro": "moonshotai"
 }
 
 

--- a/webui/src/features/agent/types/llm.ts
+++ b/webui/src/features/agent/types/llm.ts
@@ -1,6 +1,7 @@
 import { OpenAI, Gemini, DeepSeek, Mistral, Moonshot, Claude, Qwen, ZAI } from '@lobehub/icons'
 
 export const LlmModels = [
+  "auto",
   "openai/gpt-5.2",
   "openai/gpt-5.2-chat-latest",
   "openai/gpt-5.1",
@@ -34,6 +35,7 @@ export const LlmModels = [
 export type LlmModel = typeof LlmModels[number]
 
 export const LlmName: Record<LlmModel, string> = {
+  "auto": "Auto",
   "openai/gpt-5.2": "GPT-5.2",
   "openai/gpt-5.2-chat-latest": "GPT-5.2 Chat",
   "openai/gpt-5.1-chat-latest": "GPT-5.1 Chat",
@@ -65,6 +67,7 @@ export const LlmName: Record<LlmModel, string> = {
 }
 
 export const LlmDescription: Record<LlmModel, string> = {
+  "auto": "Choose the best model per task complexity",
   "openai/gpt-5.2": "Next-generation model offering advanced reasoning and broader skill coverage",
   "openai/gpt-5.2-chat-latest": "Latest GPT-5.2 model optimized for chat applications with enhanced capabilities",
   "openai/gpt-5.1": "Next-generation model offering advanced reasoning and broader skill coverage",
@@ -101,6 +104,7 @@ export type LlmTier = typeof LlmTiers[number]
 
 
 export const LlmBadge: Record<LlmModel, LlmTier> = {
+  "auto": "Balanced",
   "openai/gpt-5.2": "Elite",
   "openai/gpt-5.2-chat-latest": "Elite",
   "openai/gpt-5.1-chat-latest": "Elite",
@@ -132,6 +136,7 @@ export const LlmBadge: Record<LlmModel, LlmTier> = {
 }
 
 export const LlmFamilies = [
+  "dim0",
   "openai",
   "google",
   "anthropic",
@@ -145,6 +150,7 @@ export const LlmFamilies = [
 export type LlmFamily = typeof LlmFamilies[number]
 
 export const LlmFamilyMap: Record<LlmModel, LlmFamily> = {
+  "auto": "dim0",
   "openai/gpt-5.2": "openai",
   "openai/gpt-5.2-chat-latest": "openai",
   "openai/gpt-5.1-chat-latest": "openai",
@@ -177,6 +183,7 @@ export const LlmFamilyMap: Record<LlmModel, LlmFamily> = {
 
 
 export const LlmFamilyIcon: Record<LlmFamily, React.ComponentType<{ size?: number | string, color?: string }>> = {
+  dim0: OpenAI,
   openai: OpenAI,
   google: Gemini.Color,
   anthropic: Claude.Color,

--- a/webui/src/features/agent/types/services.ts
+++ b/webui/src/features/agent/types/services.ts
@@ -64,10 +64,10 @@ export const defaultServices: () => Services = () => ({
     { name: "openrouter/mistralai/mistral-medium-3.1", available: false, provider: "openrouter" },
     { name: "openrouter/deepseek/deepseek-v3.2", available: false, provider: "openrouter" },
     // { name: "openrouter/deepseek/deepseek-chat-v3.1", available: false, provider: "openrouter" },
-    { name: "openrouter/z-ai/glm-4.7", available: false, provider: "openrouter" },
+    { name: "openrouter/z-ai/glm-4.7:nitro", available: false, provider: "openrouter" },
     { name: "openrouter/qwen/qwen3.5-plus-02-15", available: false, provider: "openrouter" },
     // { name: "openrouter/qwen/qwen3.6-plus-preview:free", available: false, provider: "openrouter" },
-    { name: "openrouter/moonshotai/kimi-k2-thinking", available: false, provider: "openrouter" },
+    { name: "openrouter/moonshotai/kimi-k2.5:nitro", available: false, provider: "openrouter" },
   ],
   search: [
     { name: "linkup", available: false, provider: "linkup" },

--- a/webui/src/features/agent/types/services.ts
+++ b/webui/src/features/agent/types/services.ts
@@ -39,6 +39,7 @@ export type ServiceName = typeof SERVICE_NAMES[number]
  */
 export const defaultServices: () => Services = () => ({
   llm: [
+    { name: "auto", available: true, provider: "dim0" },
     { name: "openai/gpt-5.2", available: false, provider: "openai" },
     { name: "openai/gpt-5.2-chat-latest", available: false, provider: "openai" },
     { name: "openai/gpt-5.1", available: false, provider: "openai" },

--- a/webui/src/features/agent/utils/stream/build.ts
+++ b/webui/src/features/agent/utils/stream/build.ts
@@ -240,6 +240,11 @@ export async function* buildResponse(
 
   for await (const rawChunk of chunks) {
     if (rawChunk.type === "tool_call") {
+      const hasDirtySteps = Array.from(stepsById.values()).some((step) => step.dirty)
+      if (hasDirtySteps) {
+        const maybe = await maybeYield(true)
+        if (maybe) yield maybe
+      }
       continue
     }
 

--- a/webui/src/features/user-settings/screens/billing-screen.tsx
+++ b/webui/src/features/user-settings/screens/billing-screen.tsx
@@ -237,7 +237,7 @@ export function BillingScreen() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-muted-foreground">
               <p className="text-3xl font-semibold text-foreground">Free</p>
-              <FeatureRow icon={Idea01Icon} label="10 AI requests / day" />
+              <FeatureRow icon={Idea01Icon} label="40 AI requests / day" />
               <FeatureRow icon={PaintBoardIcon} label="1 board maximum" />
               <FeatureRow icon={DocumentAttachmentIcon} label="1 document upload / board" />
               <FeatureRow icon={ChatTranslateIcon} label="Basic AI actions" />


### PR DESCRIPTION
This PR improves model routing, prompt safety, rate limits, and a set of board/chat UX issues across the agent and board surfaces.

- Added `auto` model routing for chat requests.
- Introduced a lightweight complexity classifier that routes:
  - `simple` / `medium` -> Kimi K2.5 Nitro
  - `complex` -> GPT-5.4
- Added safe fallbacks for auto routing when OpenRouter is unavailable or classification fails.
- Updated available model metadata to use Kimi K2.5 Nitro consistently in backend and frontend.
- Fixed cross-model agent setting leakage when switching from LiteLLM-backed models to OpenAI models.
- Preserved the selected chat model when the board assistant remounts instead of resetting to default.
- Improved streaming behavior so buffered reasoning flushes before long tool-call phases more reliably.
- Tightened plan prompt instructions around math formatting and escaping literal dollar signs.
- Raised the enforced free daily AI quota in backend from `10` to `50`.
- Updated frontend billing copy to show `20 AI requests / day` for the free tier.
- Fixed parsed document links in sub-boards so generated edges keep their scope on refresh.
- Added explicit `parent_id` scoping for links and supporting migration work for nested boards.
- Fixed board note links opened from chat so sub-board `root_id` is preserved.
- Added persistent copy/cut/paste clipboard behavior across boards and sub-boards.
- Added editable titles for widget and code-sandbox nodes on board and in dialogs.
- Added and polished Files/List board views, including dedicated widget/code cards and improved icons.
- Improved widget performance by reducing preview work during board movement.
- Fixed the user-message context badge alignment so it does not distort short message rows.
- Added clearer AI limit UX with a dialog-based flow instead of a weak toast.

Validation performed:
- frontend `npm run type-check`
- backend `python3 -m py_compile` on touched backend modules

Notable follow-up area:
- the streamed reasoning/tool-call boundary still looks worth another pass if we want the “reasoning sentence gets cut before long tool runs” issue fully eliminated.