### PR TITLE
fix(agents): inherit root_id as parent_id for new links

### DIFF
--- a/backend/test/unit/agents/assistant/test_note_tools.py
+++ b/backend/test/unit/agents/assistant/test_note_tools.py
@@ -393,8 +393,33 @@ async def test_link_notes_tool_creates_link_with_label() -> None:
     assert created_link.source == "src"
     assert created_link.target == "dst"
     assert created_link.graph_uid == "graph-1"
+    assert created_link.parent_id is None  # no folder scope -> top-level
     assert created_link.label is not None
     assert created_link.label.markdown == "causes"
+
+
+@pytest.mark.asyncio
+async def test_link_notes_tool_inherits_root_id_as_parent() -> None:
+    """The new link must inherit root_id as its parent_id when a folder scope is set.
+
+    Without this the link is filtered by the board's scope query on reload and only
+    appears at the top-level board, even though both endpoints live in the folder.
+    """
+    graph_store = DummyGraphStore()
+    graph_store.get_nodes.return_value = [
+        Note(id="src", graph_uid="graph-1"),
+        Note(id="dst", graph_uid="graph-1"),
+    ]
+
+    tool = create_link_notes_tool(graph_store, "graph-1", root_id="folder-1")
+    await tool.on_invoke_tool(
+        RunContextWrapper(Context()),
+        json.dumps({"source_id": "src", "target_id": "dst"}),
+    )
+
+    created_link = graph_store.add_links.await_args.args[0][0]
+    assert created_link.parent_id == "folder-1"
+    assert created_link.graph_uid == "graph-1"
 
 
 @pytest.mark.asyncio

--- a/backend/topix/agents/assistant/plan.py
+++ b/backend/topix/agents/assistant/plan.py
@@ -89,7 +89,7 @@ class Plan(BaseAgent):
             tools.append(create_write_note_tool(graph_store, graph_uid, root_id=root_id))
             tools.append(create_edit_note_tool(graph_store, graph_uid))
             tools.append(create_get_note_tool(graph_store, graph_uid))
-            tools.append(create_link_notes_tool(graph_store, graph_uid))
+            tools.append(create_link_notes_tool(graph_store, graph_uid, root_id=root_id))
 
         if config.navigate:
             tools.append(fetch_url_content_tool)

--- a/backend/topix/agents/notes/tools.py
+++ b/backend/topix/agents/notes/tools.py
@@ -296,8 +296,9 @@ def create_get_note_tool(
 def create_link_notes_tool(
     graph_store: GraphStore,
     graph_uid: str,
+    root_id: str | None = None,
 ) -> FunctionTool:
-    """Build a link-notes tool bound to the current board scope."""
+    """Build a link-notes tool bound to the current board and folder scope."""
 
     async def link_notes(
         _wrapper: RunContextWrapper[Context],
@@ -338,6 +339,7 @@ def create_link_notes_tool(
             source=source_id,
             target=target_id,
             graph_uid=graph_uid,
+            parent_id=root_id,
             label=RichText(markdown=label) if label else None,
         )
         await graph_store.add_links([link])


### PR DESCRIPTION
Links created by the link_notes tool now carry parent_id = root_id, matching what create_write_note_tool already does for new notes. Without this, a link created inside a folder scope was persisted with parent_id = None and got silently filtered by the board's scope query (_link_is_visible_in_scope) on every reload. The new edge would render once via the post-stream getBoardLink fetch, then disappear as soon as the folder reloaded — visually the agent's notes ended up on the right level but the arrows between them migrated to the top-level board.

The fix threads root_id through create_link_notes_tool the same way create_write_note_tool already does, and Plan.from_config registers the link tool with root_id in scope.