### PR TITLE
fix(webui): preserve transparent picks for node colors

### DIFF
--- a/webui/src/features/board/components/style-panel/panel.tsx
+++ b/webui/src/features/board/components/style-panel/panel.tsx
@@ -2,6 +2,7 @@ import { useReactFlow } from '@xyflow/react'
 import {
   SloppyPresets,
   StrokeWidthPresets,
+  TRANSPARENT_HEX,
   type FillStyle,
   type FontFamily,
   type FontSize,
@@ -319,7 +320,7 @@ export function StylePanel<T extends StyleLike>({
   )
 
   function pickColor<K extends keyof T>(key: K, v: T[K] | null): void {
-    const next = { [key]: (v ?? undefined) } as Partial<T>
+    const next = { [key]: (v ?? TRANSPARENT_HEX) } as Partial<T>
     onStyleChange(next)
   }
   const settingContent: Record<SettingKey, React.ReactNode> = {

--- a/webui/src/features/board/types/style.ts
+++ b/webui/src/features/board/types/style.ts
@@ -171,7 +171,7 @@ export interface LinkStyle extends BaseStyle {
 }
 
 
-const TRANSPARENT_HEX = "#00000000"
+export const TRANSPARENT_HEX = "#00000000"
 
 
 const BLACK_HEX = "#000000"


### PR DESCRIPTION
Picker emitted null/undefined for transparent, which JSON.stringify dropped during PATCH serialization, so the server kept the previous color. Emit the canonical TRANSPARENT_HEX (#00000000) instead — same value the default styles already use.