### PR TITLE
fix(agents): scope rearrange anchor to current folder, not root board

### DIFF
--- a/backend/test/unit/agents/notes/test_layout.py
+++ b/backend/test/unit/agents/notes/test_layout.py
@@ -56,7 +56,14 @@ class _FakeGraphStore:
         return [link for link in self.links if link.id in requested]
 
     async def get_graph(self, graph_uid: str, root_id: str | None = None) -> _FakeGraph:
-        scoped_nodes = [n for n in self.notes.values() if n.graph_uid == graph_uid]
+        scoped_nodes = [
+            n for n in self.notes.values()
+            if n.graph_uid == graph_uid
+            and (
+                (root_id is None and n.parent_id is None)
+                or (root_id is not None and n.parent_id == root_id)
+            )
+        ]
         scoped_links = [link for link in self.links if link.graph_uid == graph_uid]
         return _FakeGraph(nodes=scoped_nodes, edges=scoped_links)
 
@@ -347,6 +354,48 @@ async def test_rearrange_anchors_below_existing_board_content() -> None:
     assert positions["a"]["x"] == pytest.approx(100.0)  # anchor min_x
     assert positions["a"]["y"] == pytest.approx(250.0 + DEFAULT_NOTE_GAP)
     assert positions["b"]["y"] == pytest.approx(positions["a"]["y"])  # same row
+
+
+@pytest.mark.asyncio
+async def test_rearrange_anchors_below_folder_content_when_scoped() -> None:
+    """Inside a folder, the anchor must use folder content, not the root-level board.
+
+    Without root_id propagation, _board_tail_origin would query the top-level board
+    and place the new tiles relative to root-level nodes — far from where the user
+    actually is. With root_id, only folder-1's existing notes contribute.
+    """
+    from topix.agents.notes.service import DEFAULT_NOTE_GAP
+
+    folder_existing = _make_note(
+        "folder-existing", x=200.0, y=300.0, width=200.0, height=100.0,
+    )
+    folder_existing.parent_id = "folder-1"
+    root_existing = _make_note(
+        "root-existing", x=10.0, y=5000.0, width=200.0, height=100.0,
+    )
+    new_a = _make_note("new-a", width=200.0, height=100.0)
+    new_a.parent_id = "folder-1"
+    new_b = _make_note("new-b", width=200.0, height=100.0)
+    new_b.parent_id = "folder-1"
+
+    store = _FakeGraphStore(
+        notes={
+            "folder-existing": folder_existing,
+            "root-existing": root_existing,
+            "new-a": new_a,
+            "new-b": new_b,
+        },
+    )
+
+    await rearrange_created_notes(
+        store, "graph-1", ["new-a", "new-b"], root_id="folder-1",
+    )
+
+    positions = {nid: _patched_position(store, nid) for nid in ["new-a", "new-b"]}
+    # Anchored below folder-existing (bottom edge at 400), not below root-existing (5000+).
+    assert positions["new-a"]["x"] == pytest.approx(200.0)
+    assert positions["new-a"]["y"] == pytest.approx(400.0 + DEFAULT_NOTE_GAP)
+    assert positions["new-b"]["y"] == pytest.approx(positions["new-a"]["y"])
 
 
 # -----------------------------

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -46,12 +46,14 @@ class AssistantManager:
         auto_mode: bool = False,
         graph_store: GraphStore | None = None,
         graph_uid: str | None = None,
+        root_id: str | None = None,
     ):
         """Init method."""
         self.plan_agent = plan_agent
         self.auto_mode = auto_mode
         self.graph_store = graph_store
         self.graph_uid = graph_uid
+        self.root_id = root_id
 
     @classmethod
     def from_config(
@@ -83,6 +85,7 @@ class AssistantManager:
             auto_mode=auto_mode,
             graph_store=graph_store,
             graph_uid=graph_uid,
+            root_id=root_id,
         )
 
     def _set_plan_model(self, model: str) -> None:
@@ -190,6 +193,7 @@ class AssistantManager:
                 self.graph_uid,
                 created_ids,
                 created_link_ids=created_link_ids,
+                root_id=self.root_id,
             )
         except Exception:
             logger.exception(

--- a/backend/topix/agents/notes/layout.py
+++ b/backend/topix/agents/notes/layout.py
@@ -191,14 +191,17 @@ async def _board_tail_origin(
     graph_store: GraphStore,
     graph_uid: str,
     exclude_ids: set[str],
+    root_id: str | None = None,
 ) -> tuple[float, float]:
     """Return an origin just below existing board content, ignoring the given ids.
 
     `exclude_ids` keeps the newly-created notes (still at their stacked default
     position) from contributing to the board's bottom edge, which would otherwise
-    push the new layout down arbitrarily.
+    push the new layout down arbitrarily. `root_id` scopes the lookup to a folder
+    so the anchor reflects the user's actual viewport context rather than the
+    top-level board.
     """
-    graph = await graph_store.get_graph(graph_uid)
+    graph = await graph_store.get_graph(graph_uid, root_id=root_id)
     if graph is None:
         return 0.0, 0.0
 
@@ -326,6 +329,7 @@ async def rearrange_created_notes(  # noqa: C901
     graph_uid: str,
     created_ids: list[str],
     created_link_ids: list[str] | None = None,
+    root_id: str | None = None,
     max_row_width: float = MAX_ROW_WIDTH,
     h_gap: float = TILE_GAP_X,
     v_gap: float = TILE_GAP_Y,
@@ -346,6 +350,8 @@ async def rearrange_created_notes(  # noqa: C901
         created_ids: Ids of notes created in the current turn. Only these are moved.
         created_link_ids: Ids of links created in the current turn. Used to pull old
             anchor nodes into their components. Empty/None means singletons-only.
+        root_id: Folder scope. When set, the "below existing board content" anchor
+            uses only nodes that share this folder instead of the top-level board.
         max_row_width: Width budget for a row before wrapping to the next.
         h_gap: Horizontal gap between flex-wrap tiles in the same row.
         v_gap: Vertical gap between flex-wrap rows.
@@ -454,7 +460,9 @@ async def rearrange_created_notes(  # noqa: C901
             free_tiles.append((positions, width, height))
 
     if free_tiles:
-        origin_x, origin_y = await _board_tail_origin(graph_store, graph_uid, movable_set)
+        origin_x, origin_y = await _board_tail_origin(
+            graph_store, graph_uid, movable_set, root_id=root_id,
+        )
         cursor_x = origin_x
         cursor_y = origin_y
         row_width = 0.0


### PR DESCRIPTION
_board_tail_origin called graph_store.get_graph(graph_uid) without a root_id, which the scope filter treats as "top-level only" — so when the user was inside a folder, the rearrange anchor was computed against the root board's bottom edge instead of the folder's. New free-floating tiles ended up at coordinates that looked sensible relative to root content but were offset from where the user actually was.

The fix threads root_id from AssistantManager (which already receives it via from_config) into rearrange_created_notes and on into _board_tail_origin, where it's passed to get_graph. Anchored components were never affected because they use each anchor's stored absolute position, which is independent of scope.

Sibling note: this is the second folder-scope leak in two days, after the link_notes parent_id miss. The audit of agents/-side get_graph callsites comes back clean otherwise — compute_note_position already threads parent_id correctly.