### PR TITLE
chore(webui): bump canvas-harness to 0.1.3

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "webui",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.2",
-        "@canvas-harness/react": "^0.1.2",
+        "@canvas-harness/core": "^0.1.3",
+        "@canvas-harness/react": "^0.1.3",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1916,9 +1916,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-QpTb8JODKh+z9eAaZQutK2ZSHFGhU/2K8rgtkTLfeSix1ASbaSiHNjoiPDsImWTijgvp86tdNPqWQzBFbvwlVw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-5nq4G+X0L6RWSZo+MRwrhDD6vJ3ctkeX4FYN5J252iNiMKKaeeg8FKnJ44AGSshyxRgn7+QWTqqjHwDPXIBkaQ==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1927,12 +1927,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.2.tgz",
-      "integrity": "sha512-9eCLUG48LOmALWwi7/J2x2sQT1KEGD9QyXjHI+EAN971ACVdFIQtY9KwBeWSOTSE+o//1r/UJuOpM8ncZLwwzw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.3.tgz",
+      "integrity": "sha512-RMxE0R0RMvQyHTc/dPj/FUKwnOrXrQZL+h0S2hfyCZhFUdbZl4BhpBJaufnkudYlDuYpBVI0iROtSYcyoKC0QA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.2"
+        "@canvas-harness/core": "0.1.3"
       },
       "peerDependencies": {
         "react": ">=18",

--- a/webui/package.json
+++ b/webui/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.2",
-    "@canvas-harness/react": "^0.1.2",
+    "@canvas-harness/core": "^0.1.3",
+    "@canvas-harness/react": "^0.1.3",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
Upstream release. No webui-side changes needed.