### PR TITLE
feat(board): double-click to create text node + solid editor surface

### DIFF
--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
-import { hitTestAny, type CanvasStore, type Renderer } from "@canvas-harness/core"
+import { hitTestAny, type CanvasStore, type NodeId, type Renderer } from "@canvas-harness/core"
+import { createDefaultNote } from "@/features/board/types/note"
+import { noteToNode } from "../convert/note-to-node"
+import { applyStyleMemory } from "./use-create-handlers"
+import { createHarnessTextareaEditor } from "./text-editor-adapter"
 import { setAgentBridge } from "../agent/agent-bridge"
 import { applyLinkOutput, applyNoteOutput } from "../agent/apply-tool-output"
 import { useHarnessApplyMindMap } from "../agent/use-harness-apply-mindmap"
@@ -146,27 +150,48 @@ export function HarnessCanvas() {
   // beginEdit. Lib fires beginEdit BEFORE the consumer onDoubleClick,
   // so cancel here runs synchronously in the same tick — no editor
   // frame is rendered.
+  //
+  // Double-clicking on empty canvas in the select tool drops a text
+  // node and immediately enters edit mode — matches the playground's
+  // quick-text affordance.
   const handleDoubleClick = useCallback(
     (e: CanvasPointerEvent): void => {
       const camera = store.getCamera()
       const hit = hitTestAny(store, e.world, camera.z)
-      if (!hit || !("nodeId" in hit)) return
-      const node = store.getNode(hit.nodeId)
-      if (!node) return
-      if (!CUSTOM_NODE_TYPES.has(node.type)) return
-      store.cancelEdit()
-      if (node.type === "folder" && boardId) {
-        navigate({
-          to: "/boards/$id",
-          params: { id: boardId },
-          search: (prev: Record<string, unknown>) => ({
-            ...prev,
-            root_id: node.id,
-          }),
-        })
+
+      if (hit && "nodeId" in hit) {
+        const node = store.getNode(hit.nodeId)
+        if (!node) return
+        if (!CUSTOM_NODE_TYPES.has(node.type)) return
+        store.cancelEdit()
+        if (node.type === "folder" && boardId) {
+          navigate({
+            to: "/boards/$id",
+            params: { id: boardId },
+            search: (prev: Record<string, unknown>) => ({
+              ...prev,
+              root_id: node.id,
+            }),
+          })
+        }
+        return
       }
+
+      // Empty space: quick text node + edit. Only in the select tool —
+      // other tools have their own click semantics.
+      if (e.tool !== "select" || !canEdit || !boardId) return
+      const note = createDefaultNote({ boardId, nodeType: "text" })
+      if (rootId) note.parentId = rootId
+      const size = note.properties.nodeSize?.size ?? { width: 150, height: 20 }
+      note.properties.nodePosition = {
+        type: "position",
+        position: { x: e.world.x - size.width / 2, y: e.world.y - size.height / 2 },
+      }
+      const styled = applyStyleMemory(noteToNode(note), styleMemory)
+      store.addNode(styled)
+      store.beginEdit(styled.id as NodeId)
     },
-    [store, boardId, navigate],
+    [store, boardId, rootId, canEdit, navigate, styleMemory],
   )
 
   // Hydrate on scope change. `cancelled` guards against late-arriving fetches
@@ -277,6 +302,7 @@ function HarnessCanvasInner({
             selectionColor={theme.selectionColor}
             background={theme.background}
             renderCustomNodeView={renderView}
+            editorAdapter={createHarnessTextareaEditor}
             arrowDefaults={arrowDefaults}
             onCreateDrag={onCreateDrag}
             onClick={onClick}

--- a/webui/src/features/board/harness/canvas/text-editor-adapter.ts
+++ b/webui/src/features/board/harness/canvas/text-editor-adapter.ts
@@ -1,0 +1,208 @@
+import {
+  FONT_FAMILY_MAP,
+  FONT_SIZE_MAP,
+  LINE_HEIGHT_MAP,
+  handleEnter,
+  insertLink,
+  toggleBold,
+  toggleCode,
+  toggleItalic,
+  toggleStrike,
+  toggleUnderline,
+  type EditorAdapter,
+  type EditorAdapterFactory,
+} from "@canvas-harness/core"
+
+
+/**
+ * Custom in-place editor adapter for canvas-harness. Behaviour matches
+ * the lib's `createDefaultTextareaEditor` (autosize, markdown shortcuts,
+ * commit on Esc / Cmd+Enter / blur) with one tweak: when the node's
+ * background is transparent (text nodes default to that), the editor
+ * wrap uses `var(--card)` so the textarea has an opaque surface that
+ * hides whatever's painted under it. Without this, the canvas-rendered
+ * text bleeds through and is hard to read while typing.
+ */
+
+
+/** True for any hex / keyword that paints zero opacity. */
+const isTransparent = (color: string | undefined): boolean => {
+  if (!color) return true
+  if (color === "transparent") return true
+  if (color.length === 9 && color.startsWith("#") && color.slice(7, 9).toLowerCase() === "00") {
+    return true
+  }
+  if (color.length === 5 && color.startsWith("#") && color[4] === "0") return true
+  return false
+}
+
+
+export const createHarnessTextareaEditor: EditorAdapterFactory = ({
+  node,
+  container,
+  camera,
+  onCommit,
+  onCancel,
+}): EditorAdapter => {
+  void onCancel
+  const style = node.style ?? {}
+  const fontSize = style.fontSize ?? "M"
+  const fontFamily = style.fontFamily ?? "handwriting"
+  const align = style.textAlign ?? "center"
+  // Theme-aware foreground so dark mode doesn't render text in near-
+  // invisible on the card surface.
+  const color = style.textColor && !isTransparent(style.textColor)
+    ? style.textColor
+    : "var(--card-foreground)"
+
+  const fontPx = FONT_SIZE_MAP[fontSize]
+  const lineHeightPx = LINE_HEIGHT_MAP[fontSize]
+
+  const screenX = (node.x - camera.x) * camera.z
+  const screenY = (node.y - camera.y) * camera.z
+  const screenW = node.w * camera.z
+  const screenH = node.h * camera.z
+
+  const alignToFlex: Record<string, string> = {
+    left: "flex-start",
+    center: "center",
+    right: "flex-end",
+  }
+
+  // Solid surface — use the node's bg when it has one, otherwise fall
+  // back to `var(--card)`. The transparent fallback is the one that
+  // matters in practice (text nodes), but routing all "no bg" nodes
+  // through bg-card also helps shapes that ship with transparent fills.
+  const wrapBg = isTransparent(style.backgroundColor)
+    ? "var(--card)"
+    : style.backgroundColor
+
+  const wrap = document.createElement("div")
+  wrap.style.position = "absolute"
+  wrap.style.left = `${screenX}px`
+  wrap.style.top = `${screenY}px`
+  wrap.style.width = `${screenW}px`
+  wrap.style.minHeight = `${screenH}px`
+  wrap.style.display = "flex"
+  wrap.style.flexDirection = "column"
+  wrap.style.justifyContent = "center"
+  wrap.style.alignItems = alignToFlex[align] ?? "center"
+  wrap.style.boxSizing = "border-box"
+  wrap.style.border = "1px solid var(--ring, #3b82f6)"
+  wrap.style.borderRadius = "4px"
+  wrap.style.background = wrapBg ?? "var(--card)"
+  wrap.style.zIndex = "20"
+
+  const ta = document.createElement("textarea")
+  ta.value = node.content ?? ""
+  ta.spellcheck = false
+  ta.style.width = "100%"
+  ta.style.padding = "6px"
+  ta.style.margin = "0"
+  ta.style.boxSizing = "border-box"
+  ta.style.border = "none"
+  ta.style.outline = "none"
+  ta.style.resize = "none"
+  ta.style.overflow = "hidden"
+  ta.style.background = "transparent"
+  ta.style.color = color
+  ta.style.fontFamily = FONT_FAMILY_MAP[fontFamily]
+  ta.style.fontSize = `${fontPx * camera.z}px`
+  ta.style.lineHeight = `${lineHeightPx * camera.z}px`
+  ta.style.textAlign = align
+  ta.style.whiteSpace = "pre-wrap"
+  ta.style.wordBreak = "break-word"
+
+  const autosize = (): void => {
+    ta.style.height = "auto"
+    ta.style.height = `${ta.scrollHeight}px`
+  }
+
+  const commitNow = (): void => onCommit(ta.value)
+
+  const applyTransform = (t: { value: string; selStart: number; selEnd: number }): void => {
+    ta.value = t.value
+    ta.setSelectionRange(t.selStart, t.selEnd)
+    autosize()
+  }
+
+  const onInput = (): void => autosize()
+  const onBlur = (): void => commitNow()
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape") {
+      e.preventDefault()
+      commitNow()
+      return
+    }
+    const meta = e.metaKey || e.ctrlKey
+    if (meta && e.key === "Enter") {
+      e.preventDefault()
+      commitNow()
+      return
+    }
+    if (meta && !e.shiftKey && (e.key === "b" || e.key === "B")) {
+      e.preventDefault()
+      applyTransform(toggleBold(ta.value, ta.selectionStart, ta.selectionEnd))
+      return
+    }
+    if (meta && !e.shiftKey && (e.key === "i" || e.key === "I")) {
+      e.preventDefault()
+      applyTransform(toggleItalic(ta.value, ta.selectionStart, ta.selectionEnd))
+      return
+    }
+    if (meta && !e.shiftKey && (e.key === "u" || e.key === "U")) {
+      e.preventDefault()
+      applyTransform(toggleUnderline(ta.value, ta.selectionStart, ta.selectionEnd))
+      return
+    }
+    if (meta && e.shiftKey && (e.key === "x" || e.key === "X")) {
+      e.preventDefault()
+      applyTransform(toggleStrike(ta.value, ta.selectionStart, ta.selectionEnd))
+      return
+    }
+    if (meta && !e.shiftKey && (e.key === "e" || e.key === "E")) {
+      e.preventDefault()
+      applyTransform(toggleCode(ta.value, ta.selectionStart, ta.selectionEnd))
+      return
+    }
+    if (meta && !e.shiftKey && (e.key === "k" || e.key === "K")) {
+      e.preventDefault()
+      const url = window.prompt("URL") ?? ""
+      applyTransform(insertLink(ta.value, ta.selectionStart, ta.selectionEnd, url))
+      return
+    }
+    if (e.key === "Enter" && !e.shiftKey && !meta) {
+      const t = handleEnter(ta.value, ta.selectionStart, ta.selectionEnd)
+      if (t) {
+        e.preventDefault()
+        applyTransform(t)
+      }
+    }
+  }
+
+  ta.addEventListener("input", onInput)
+  ta.addEventListener("blur", onBlur)
+  ta.addEventListener("keydown", onKeyDown)
+  wrap.appendChild(ta)
+  container.appendChild(wrap)
+  requestAnimationFrame(() => {
+    ta.focus()
+    ta.setSelectionRange(ta.value.length, ta.value.length)
+    autosize()
+  })
+
+  return {
+    focus: () => ta.focus(),
+    getValue: () => ta.value,
+    setValue: (text: string) => {
+      ta.value = text
+      autosize()
+    },
+    destroy: () => {
+      ta.removeEventListener("input", onInput)
+      ta.removeEventListener("blur", onBlur)
+      ta.removeEventListener("keydown", onKeyDown)
+      wrap.remove()
+    },
+  }
+}

--- a/webui/src/features/board/harness/canvas/use-create-handlers.ts
+++ b/webui/src/features/board/harness/canvas/use-create-handlers.ts
@@ -49,7 +49,7 @@ const isShapeTool = (tool: string): boolean => SHAPE_TOOLS.has(tool)
  * `data._storedColors` is refreshed so save round-trips the picked
  * colors, not their dark-mode shadows.
  */
-const applyStyleMemory = (node: Node, styleMemory: StyleMemoryApi): Node => {
+export const applyStyleMemory = (node: Node, styleMemory: StyleMemoryApi): Node => {
   if (!isStylableNodeType(node.type)) return node
   if (node.type === "frame") return node
   const remembered = styleMemory.getNodeStyle()


### PR DESCRIPTION
Double-clicking empty canvas in the select tool now drops a text Note at the click point and enters edit mode, matching the canvas-harness playground's quick-text affordance. Reuses applyStyleMemory so the new text picks up sticky font / colors and dark-mode projection.

Adds a custom in-place editor adapter that swaps the lib default's hardcoded #ffffff wrap background for var(--card) when the node's backgroundColor is transparent or unset — text nodes had no opaque surface during edit, letting the canvas-painted text bleed through. Text color + border also picked up from theme tokens.