### PR TITLE
fix(board): close board-switch race that swapped content between boards

### DIFF
--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -204,7 +204,11 @@ export function HarnessCanvas() {
     let cancelled = false
     setReady(false)
     setIsLoading(true)
-    hydrateBoardStore(store, { boardId, rootId: rootId ?? undefined })
+    hydrateBoardStore(store, {
+      boardId,
+      rootId: rootId ?? undefined,
+      isCancelled: () => cancelled,
+    })
       .then(({ graph, canEdit }) => {
         if (cancelled) return
         setCanEdit(canEdit)

--- a/webui/src/features/board/harness/persist/snapshot-load.test.ts
+++ b/webui/src/features/board/harness/persist/snapshot-load.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest"
+import { asNodeId, type Node } from "@canvas-harness/core"
+import { createBoardStore } from "../store/create-board-store"
+import type { Graph } from "@/features/board/types/board"
+
+
+// Mock the network layer so we can drive resolution timing from the test.
+const getBoardMock = vi.fn<
+  (boardId: string, rootId?: string) => Promise<{ graph: Graph; canEdit: boolean }>
+>()
+
+
+vi.mock("@/features/board/api/get-board", () => ({
+  getBoard: (boardId: string, rootId?: string) => getBoardMock(boardId, rootId),
+}))
+
+
+// Import the SUT after the mock is registered so its closure uses the
+// mocked `getBoard`.
+import { hydrateBoardStore } from "./snapshot-load"
+
+
+const seedNode = (id: string): Node => ({
+  id: asNodeId(id),
+  type: "rect",
+  x: 0,
+  y: 0,
+  w: 10,
+  h: 10,
+  angle: 0,
+  z: 0,
+  groups: [],
+  content: "",
+  style: {},
+})
+
+
+const emptyGraph = (): Graph =>
+  ({
+    label: "test",
+    visibility: "private",
+    nodes: [],
+    edges: [],
+  }) as unknown as Graph
+
+
+describe("hydrateBoardStore — cancel safety", () => {
+  it("happy path: mutates the store with the fetched graph", async () => {
+    getBoardMock.mockResolvedValueOnce({ graph: emptyGraph(), canEdit: true })
+    const store = createBoardStore()
+    store.addNode(seedNode("pre-existing"))
+
+    await hydrateBoardStore(store, { boardId: "b1" })
+
+    // Pre-existing node was wiped, fetched graph (empty) was loaded.
+    expect(store.getAllNodes()).toHaveLength(0)
+  })
+
+  it("skips the store mutation when isCancelled() flips true before the batch", async () => {
+    let cancelled = false
+    // Resolve the fetch only after we've flipped the cancel flag.
+    const resolvers: { resolve?: () => void } = {}
+    const fetchPromise = new Promise<{ graph: Graph; canEdit: boolean }>((res) => {
+      resolvers.resolve = () => res({ graph: emptyGraph(), canEdit: true })
+    })
+    getBoardMock.mockImplementationOnce(() => fetchPromise)
+
+    const store = createBoardStore()
+    const preNode = seedNode("survives")
+    store.addNode(preNode)
+
+    const hydration = hydrateBoardStore(store, {
+      boardId: "b2",
+      isCancelled: () => cancelled,
+    })
+
+    // Simulate "user navigated away" before the fetch lands.
+    cancelled = true
+    resolvers.resolve?.()
+    await hydration
+
+    // Pre-existing node is still there: the stale hydrate skipped its
+    // store mutation entirely.
+    expect(store.getAllNodes()).toHaveLength(1)
+    expect(store.getAllNodes()[0].id as unknown as string).toBe("survives")
+  })
+
+  it("respects cancellation between two interleaved hydrates", async () => {
+    // Two hydrates in flight; first one will be cancelled, second wins.
+    const aResolvers: { resolve?: () => void } = {}
+    const bResolvers: { resolve?: () => void } = {}
+    const fetchA = new Promise<{ graph: Graph; canEdit: boolean }>((res) => {
+      aResolvers.resolve = () =>
+        res({
+          graph: { ...emptyGraph(), nodes: [{ id: "from-a" } as never] } as Graph,
+          canEdit: true,
+        })
+    })
+    const fetchB = new Promise<{ graph: Graph; canEdit: boolean }>((res) => {
+      bResolvers.resolve = () => res({ graph: emptyGraph(), canEdit: true })
+    })
+    getBoardMock.mockImplementationOnce(() => fetchA).mockImplementationOnce(() => fetchB)
+
+    const store = createBoardStore()
+
+    let cancelledA = false
+    const hydrationA = hydrateBoardStore(store, {
+      boardId: "a",
+      isCancelled: () => cancelledA,
+    })
+    const hydrationB = hydrateBoardStore(store, { boardId: "b" })
+
+    // User navigated A → B before A resolved.
+    cancelledA = true
+
+    // B resolves first (empty), then A resolves (would have content
+    // "from-a"). The cancel guard on A keeps it from clobbering.
+    bResolvers.resolve?.()
+    await hydrationB
+    aResolvers.resolve?.()
+    await hydrationA
+
+    // Store reflects B (empty), not A's stale content.
+    expect(store.getAllNodes()).toHaveLength(0)
+  })
+})

--- a/webui/src/features/board/harness/persist/snapshot-load.ts
+++ b/webui/src/features/board/harness/persist/snapshot-load.ts
@@ -19,13 +19,30 @@ export type HydrateResult = {
  *
  * Returns the raw graph metadata (label, visibility, canEdit) for the
  * caller to push into the board-app store.
+ *
+ * `isCancelled` is checked once after the network resolves: if the
+ * caller has navigated to a different scope while the fetch was in
+ * flight, we skip the store mutation entirely. Without this guard, the
+ * shared store would get clobbered by stale content — and the save
+ * loop would then persist the wrong board's nodes/edges back to the
+ * current board id.
  */
 export const hydrateBoardStore = async (
   store: CanvasStore,
-  opts: { boardId: string; rootId?: string },
+  opts: {
+    boardId: string
+    rootId?: string
+    isCancelled?: () => boolean
+  },
 ): Promise<HydrateResult> => {
-  const { boardId, rootId } = opts
+  const { boardId, rootId, isCancelled } = opts
   const { graph, canEdit } = await getBoard(boardId, rootId)
+
+  // Bail before any conversion or store mutation if a newer scope has
+  // taken over. We still return the fetched graph so the caller's
+  // (also-cancelled) `.then` doesn't NPE in unusual shapes.
+  if (isCancelled?.()) return { graph, canEdit }
+
   const notes = graph.nodes ?? []
   const links = graph.edges ?? []
 

--- a/webui/src/features/board/harness/persist/use-debounced-save.ts
+++ b/webui/src/features/board/harness/persist/use-debounced-save.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import type { CanvasStore } from "@canvas-harness/core"
-import { diffSnapshots, EMPTY_SNAPSHOT, type Snapshot } from "./diff-snapshots"
+import { diffSnapshots, type Snapshot } from "./diff-snapshots"
 import { flushApiCalls } from "./flush-api-calls"
 
 
@@ -11,6 +11,16 @@ export type UseBoardDebouncedSaveOptions = {
   /** Idle delay between the last commit and the next flush. Default 500ms. */
   debounceMs?: number
 }
+
+
+/**
+ * `lastSavedRef`'s payload is tagged with the boardId it was captured
+ * from. Diffs only run when the tag matches the effect's current
+ * boardId — a guard against a rebase from a previous board's effect
+ * leaking into a flush queued by a later effect (see Fix 3 in the
+ * board-switch-race investigation).
+ */
+type LastSaved = { snapshot: Snapshot; boardId: string }
 
 
 /**
@@ -34,6 +44,13 @@ export type UseBoardDebouncedSaveOptions = {
  *
  * Pass `boardId = null` (e.g. during route transitions) to suspend
  * saving without unmounting the host.
+ *
+ * **Board-switch safety.** The cleanup clears any pending debounce
+ * timer so a flush queued before navigation can't fire afterward, and
+ * `lastSavedRef` carries the boardId it represents — `flush()` refuses
+ * to compute a diff against a baseline from a different board, even
+ * if the closure's `boardId` somehow disagrees with the current
+ * baseline (defense in depth).
  */
 export const useBoardDebouncedSave = (
   store: CanvasStore,
@@ -43,26 +60,37 @@ export const useBoardDebouncedSave = (
 ): SaveStatus => {
   const debounceMs = options.debounceMs ?? 500
   const [status, setStatus] = useState<SaveStatus>("idle")
-  const lastSavedRef = useRef<Snapshot>(EMPTY_SNAPSHOT)
+  const lastSavedRef = useRef<LastSaved | null>(null)
 
   useEffect(() => {
     if (!boardId || !ready) return
     let timer: ReturnType<typeof setTimeout> | null = null
 
-    // Re-baseline once hydration declares the scene in sync with the server.
+    // Re-baseline once hydration declares the scene in sync with the
+    // server. The boardId tag pins this baseline to the right board.
     lastSavedRef.current = {
-      nodes: store.getAllNodes(),
-      edges: store.getAllEdges(),
+      snapshot: {
+        nodes: store.getAllNodes(),
+        edges: store.getAllEdges(),
+      },
+      boardId,
     }
     setStatus("idle")
 
     const flush = async (): Promise<void> => {
       timer = null
+      const current = lastSavedRef.current
+      // A baseline from a different board is the smoking gun for the
+      // content-swap bug — bail before computing a poisoned diff.
+      if (!current || current.boardId !== boardId) {
+        setStatus("idle")
+        return
+      }
       const next: Snapshot = {
         nodes: store.getAllNodes(),
         edges: store.getAllEdges(),
       }
-      const calls = diffSnapshots(lastSavedRef.current, next)
+      const calls = diffSnapshots(current.snapshot, next)
       if (calls.length === 0) {
         setStatus("idle")
         return
@@ -70,7 +98,11 @@ export const useBoardDebouncedSave = (
       setStatus("saving")
       try {
         await flushApiCalls(calls, boardId)
-        lastSavedRef.current = next
+        // Re-check before committing the new baseline — a board switch
+        // could have happened during the await.
+        if (lastSavedRef.current?.boardId === boardId) {
+          lastSavedRef.current = { snapshot: next, boardId }
+        }
         setStatus("saved")
       } catch (err) {
         console.error("[harness/persist] flush failed", err)
@@ -78,15 +110,18 @@ export const useBoardDebouncedSave = (
       }
     }
 
-    return store.subscribe("change", (batch) => {
+    const unsubscribe = store.subscribe("change", (batch) => {
       // Remote-origin batches (AI/agent applies) are already on the
       // server — folding them into lastSaved prevents the next flush
       // from re-uploading the same data while still keeping the
       // baseline in sync for any later local edits.
       if (batch.origin === "remote") {
         lastSavedRef.current = {
-          nodes: store.getAllNodes(),
-          edges: store.getAllEdges(),
+          snapshot: {
+            nodes: store.getAllNodes(),
+            edges: store.getAllEdges(),
+          },
+          boardId,
         }
         return
       }
@@ -94,6 +129,16 @@ export const useBoardDebouncedSave = (
       else clearTimeout(timer)
       timer = setTimeout(() => { void flush() }, debounceMs)
     })
+
+    return () => {
+      // Clear any pending debounce so a flush queued before a board
+      // switch can't fire after the switch with a stale closure.
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+      unsubscribe()
+    }
   }, [store, boardId, ready, debounceMs])
 
   return status


### PR DESCRIPTION
Three coordinated fixes against a rare-but-catastrophic race where fast board switching could replace one board's content with another's:

- hydrateBoardStore now takes an isCancelled() probe and skips the store mutation if the caller has navigated away while getBoard was in flight. Previously a late-resolving fetch would clobber the current board's store with the previous board's content — and the save loop would then persist that stale content back under the current board's id.

- useBoardDebouncedSave now clears its pending debounce timer on cleanup. Before, a timer queued on board A could fire after the user had navigated to B and the effect had already cleaned up, flushing a poisoned diff against A.

- lastSavedRef is tagged with the boardId it represents; flush() refuses to compute a diff when the tag doesn't match the closure's boardId, and the post-flush baseline write re-checks the tag before committing. Belt-and-suspenders against any future variant of the same shape.

Adds three regression tests in snapshot-load.test.ts covering the happy path, cancel-before-batch, and the two-interleaved-hydrates ordering that produced the symptom in the wild.