### PR TITLE
fix(collab): only emit dimensions actually in the wire patch

### DIFF
--- a/backend/test/unit/collab/test_apply_ops.py
+++ b/backend/test/unit/collab/test_apply_ops.py
@@ -121,6 +121,69 @@ async def test_node_update_resize_emits_node_size():
     }
 
 
+async def test_node_update_height_only_does_not_zero_width():
+    """A `node.update` with only `h` (no `w`) emits height alone.
+
+    Regression: canvas-harness's `commitEdit` runs autofit and emits
+    `{ content, h }` with the recomputed height — `w` stays unchanged
+    so the patch doesn't include it. The translator used to default
+    the missing dimension to 0, producing `node_size.size = {width: 0,
+    height: <correct>}`, which then deep-merged over the existing
+    note and wiped its width on the DB. On refresh the node came back
+    with width=0 and collapsed to invisible.
+    """
+    store = _RecordingGraphStore()
+    op = {"type": "node.update", "id": "n1", "patch": {"content": "abc", "h": 250}, "prev": {}}
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    data = store.patch_calls[0]["data"]
+    # Only `height` is in the size patch — width is absent so deep-merge
+    # leaves the existing width alone.
+    assert data["properties"]["node_size"] == {
+        "type": "size",
+        "size": {"height": 250.0},
+    }
+    assert "width" not in data["properties"]["node_size"]["size"]
+
+
+async def test_node_update_width_only_does_not_zero_height():
+    """Symmetric to the height-only case.
+
+    A `w`-only patch must not write `height: 0` and clobber the
+    existing height on the DB.
+    """
+    store = _RecordingGraphStore()
+    op = {"type": "node.update", "id": "n1", "patch": {"w": 400}, "prev": {}}
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    data = store.patch_calls[0]["data"]
+    assert data["properties"]["node_size"] == {
+        "type": "size",
+        "size": {"width": 400.0},
+    }
+    assert "height" not in data["properties"]["node_size"]["size"]
+
+
+async def test_node_update_x_only_does_not_zero_y():
+    """Position patch with only `x` (no `y`) emits `x` alone.
+
+    Defends against the same partial-dimension class of bug as size.
+    """
+    store = _RecordingGraphStore()
+    op = {"type": "node.update", "id": "n1", "patch": {"x": 200}, "prev": {}}
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    data = store.patch_calls[0]["data"]
+    assert data["properties"]["node_position"] == {
+        "type": "position",
+        "position": {"x": 200.0},
+    }
+    assert "y" not in data["properties"]["node_position"]["position"]
+
+
 async def test_node_update_z_index():
     """Node update z index."""
     store = _RecordingGraphStore()

--- a/backend/topix/collab/apply_ops.py
+++ b/backend/topix/collab/apply_ops.py
@@ -246,21 +246,31 @@ def _node_patch_to_note_data(patch: dict[str, Any]) -> dict[str, Any]:  # noqa: 
         refresh shows the old value.
     """
     properties: dict[str, Any] = {}
+    # Only emit the dimension fields actually in the patch. Defaulting
+    # the missing one to 0 corrupts the DB on partial updates — e.g.
+    # `commitEdit` ships `{ content, h }` after autofit, and
+    # `patch_notes`'s deep-merge would replace `width=<correct>` with
+    # `width=0` because the patched `node_size.size` carried both
+    # fields with `w` defaulted.
     if "x" in patch or "y" in patch:
+        position: dict[str, float] = {}
+        if "x" in patch:
+            position["x"] = float(patch["x"])
+        if "y" in patch:
+            position["y"] = float(patch["y"])
         properties["node_position"] = {
             "type": "position",
-            "position": {
-                "x": float(patch.get("x", 0)),
-                "y": float(patch.get("y", 0)),
-            },
+            "position": position,
         }
     if "w" in patch or "h" in patch:
+        size: dict[str, float] = {}
+        if "w" in patch:
+            size["width"] = float(patch["w"])
+        if "h" in patch:
+            size["height"] = float(patch["h"])
         properties["node_size"] = {
             "type": "size",
-            "size": {
-                "width": float(patch.get("w", 0)),
-                "height": float(patch.get("h", 0)),
-            },
+            "size": size,
         }
     if "z" in patch:
         properties["node_z_index"] = {


### PR DESCRIPTION
`_node_patch_to_note_data` defaulted missing dimensions to 0 when emitting `node_size` / `node_position`. The translator used to write both `width` and `height` (and `x` and `y`) whenever EITHER was in the patch, so:

- `commitEdit` fires `updateNode(id, { content })`.
- Canvas-harness's autofit branch rewrites to `{ content, h: <new> }` — no `w` in the patch because width didn't change.
- Server saw `"h" in patch`, built `node_size.size = {width: 0, height: <correct>}`. `patch_notes`' deep-merge overwrote the note's existing width with 0.
- On refresh, REST returned width=0 and the node collapsed.

Manifested loudly on AI mindmap generation because the post-create content layout autofit-resizes every leaf rectangle, but the bug fires on any height-only or width-only node.update.

Only emit the dimension fields actually present in the wire patch. Same fix applied to position for symmetry (defensive, not user- visible today since drag commits both x and y together).

Adds three regression tests covering height-only, width-only, and x-only patches.