### PR TITLE
chore(webui): bump @canvas-harness packages to 0.1.16

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "webui",
-  "version": "0.3.28",
+  "version": "0.3.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.28",
+      "version": "0.3.31",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.15",
-        "@canvas-harness/react": "^0.1.15",
-        "@canvas-harness/sync-broadcast": "^0.1.15",
+        "@canvas-harness/core": "^0.1.16",
+        "@canvas-harness/react": "^0.1.16",
+        "@canvas-harness/sync-broadcast": "^0.1.16",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1917,9 +1917,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.15.tgz",
-      "integrity": "sha512-1uJdF7jXwkf0bbAu1okdTIrSxUXSyZk2RTIZhlJhIbhXAN2plZ33g2/ShC+i+6LdveNN7m4W4un6VJV5Mr53Hw==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.16.tgz",
+      "integrity": "sha512-OsuxvXQHEo0hJepngirCVqHN/oaeauI+BZYrBu4gQFGp2pZG2J7fQR6r6HvkTe7soWlnA4tdbEjAZa6piyp1iQ==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1928,12 +1928,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.15.tgz",
-      "integrity": "sha512-su4Zzm5B7rNQbHF0zO8cveyj97jgqlEyuqhFS1raJ69p8oo6r09YsKIyX4wMeSLnBde1fu7QZT9X0SbzBiV42A==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.16.tgz",
+      "integrity": "sha512-ILIeuOPX7qr38A7WGbWEAG8XBKrgdEVAPuoDzo9CkpnPsZOR98dvxC+AkFuOUn/15XQiaOw5tXbeDpJUQi3XGA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.15"
+        "@canvas-harness/core": "0.1.16"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1941,12 +1941,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.15.tgz",
-      "integrity": "sha512-+/MeastnAogeZtBPA5OJQRynZTg1if1xmHNX5+4OtedW7DhRssAGscbeCyu2F/Yvmur7IV73U4r2X9BPu+5e/w==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.16.tgz",
+      "integrity": "sha512-Z7cOAEpM/iQdjyD/6+7JieaACwwwBaVl1cHke0D/u5jenzh0fC8amZn9pVlkfPd9A+jrUSOHy1AcDTl/VW6zDg==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.15"
+        "@canvas-harness/core": "0.1.16"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.15",
-    "@canvas-harness/react": "^0.1.15",
-    "@canvas-harness/sync-broadcast": "^0.1.15",
+    "@canvas-harness/core": "^0.1.16",
+    "@canvas-harness/react": "^0.1.16",
+    "@canvas-harness/sync-broadcast": "^0.1.16",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
Picks up the renderer's marqueeing-inclusive isMoving gate (mouse-pan / marquee-transit now drops custom-node React overlays to the canvas placeholder during motion).