### PR TITLE
🐛 fix(board): persist sticky styles for new edges

### DIFF
--- a/backend/test/unit/collab/test_note_to_wire.py
+++ b/backend/test/unit/collab/test_note_to_wire.py
@@ -218,6 +218,50 @@ def test_wire_node_lifts_group_ids_onto_node_groups() -> None:
     assert wire["groups"] == ["g1", "g2"]
 
 
+# ---------------------------------------------------------------------------
+# Height auto-fit must be disabled for preview-rendered custom types
+# ---------------------------------------------------------------------------
+
+# Custom canvas types whose lib grow-to-fit must be off on the wire — they
+# render only a preview of `node.content`, so auto-fit would snap the node
+# tall enough for the unseen full body, uncapped. Mirrors the frontend's
+# `AUTOFIT_DISABLED_TYPES` in convert/note-to-node.ts.
+AUTOFIT_DISABLED = [
+    NodeType.FOLDER,
+    NodeType.SHEET,
+    NodeType.CODE_SANDBOX,
+    NodeType.WIDGET,
+    NodeType.MINI_APP,
+]
+
+
+@pytest.mark.parametrize("dim0_type", AUTOFIT_DISABLED)
+def test_wire_disables_autofit_for_preview_types(dim0_type: NodeType) -> None:
+    """Sheet/code-sandbox/widget/mini-app/folder ship `style.autoFit = False`.
+
+    Without it, an agent-created sheet reaches peers with autoFit unset
+    (defaults on in the lib) and the node auto-grows to fit the entire
+    markdown body with no cap — the runaway-tall-sheet bug.
+    """
+    note = _note_with_style_type(dim0_type)
+    wire = note_to_wire_node(note)
+    assert wire["style"]["autoFit"] is False
+
+
+def test_wire_disables_autofit_for_documents() -> None:
+    """Documents (separate subclass) also ship `style.autoFit = False`."""
+    doc = Document(id="n1", graph_uid="b1", style=Style(type=NodeType.RECTANGLE))
+    wire = note_to_wire_node(doc)
+    assert wire["style"]["autoFit"] is False
+
+
+def test_wire_leaves_autofit_unset_for_plain_shapes() -> None:
+    """Built-in primitives keep the lib default (auto-fit on) — no `autoFit` key."""
+    note = _note_with_style_type(NodeType.RECTANGLE)
+    wire = note_to_wire_node(note)
+    assert "autoFit" not in wire["style"]
+
+
 def test_unknown_style_type_passes_through_unchanged() -> None:
     """A future Dim0 enum value not yet in the map renders as a custom type.
 

--- a/backend/topix/collab/note_to_wire.py
+++ b/backend/topix/collab/note_to_wire.py
@@ -55,6 +55,18 @@ _DIM0_TO_CANVAS_TYPE: dict[str, str] = {
 _CANVAS_TO_DIM0_TYPE: dict[str, str] = {v: k for k, v in _DIM0_TO_CANVAS_TYPE.items()}
 
 
+# Canvas types whose lib height-autoFit must be off. These render only a
+# preview of `node.content` (full sheet markdown, code source, etc.), so
+# the lib's grow-to-fit would snap the node tall enough for the unseen
+# body, with no cap. Without setting this on the wire, an agent-created
+# sheet reaches peers with autoFit unset (→ on) and grows unbounded.
+# IMPORTANT: keep in sync with webui/.../convert/note-to-node.ts
+# (`AUTOFIT_DISABLED_TYPES`).
+_AUTOFIT_DISABLED_CANVAS_TYPES: frozenset[str] = frozenset({
+    "folder", "sheet", "code-sandbox", "widget", "mini-app", "document",
+})
+
+
 # Lifted / dropped Dim0 style keys — handled out-of-band before the
 # remaining fields auto-translate snake_case → camelCase for the wire.
 #   - `type`: discriminator; goes onto wire `data.styleType` instead.
@@ -113,6 +125,12 @@ def note_to_wire_node(note: Note) -> dict[str, Any]:
         style_dict.pop(key, None)
     wire_style = {_snake_to_camel(k): v for k, v in style_dict.items()}
 
+    # Disable the lib's grow-to-fit for preview-rendered custom types so
+    # agent-created sheets don't auto-grow unbounded on the receiver.
+    canvas_type = _canvas_type_for(note)
+    if canvas_type in _AUTOFIT_DISABLED_CANVAS_TYPES:
+        wire_style["autoFit"] = False
+
     data: dict[str, Any] = {
         "noteType": note.type,
         "styleType": style_type or note.style.type,
@@ -130,7 +148,7 @@ def note_to_wire_node(note: Note) -> dict[str, Any]:
 
     return {
         "id": note.id,
-        "type": _canvas_type_for(note),
+        "type": canvas_type,
         "x": float(pos.x),
         "y": float(pos.y),
         "w": float(size.width),

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "webui",
-  "version": "0.3.32",
+  "version": "0.3.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.32",
+      "version": "0.3.34",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.16",
-        "@canvas-harness/react": "^0.1.16",
-        "@canvas-harness/sync-broadcast": "^0.1.16",
+        "@canvas-harness/core": "^0.1.17",
+        "@canvas-harness/react": "^0.1.17",
+        "@canvas-harness/sync-broadcast": "^0.1.17",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1919,9 +1919,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.16.tgz",
-      "integrity": "sha512-OsuxvXQHEo0hJepngirCVqHN/oaeauI+BZYrBu4gQFGp2pZG2J7fQR6r6HvkTe7soWlnA4tdbEjAZa6piyp1iQ==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.17.tgz",
+      "integrity": "sha512-gmohd8plwSBqMMJbNmGvdiaqs7IXOhCk+JcdTr+M4od6POeLuGKfkWtISkm62DjwOOzsCDeq5muBL0CNfrzjnA==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1930,12 +1930,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.16.tgz",
-      "integrity": "sha512-ILIeuOPX7qr38A7WGbWEAG8XBKrgdEVAPuoDzo9CkpnPsZOR98dvxC+AkFuOUn/15XQiaOw5tXbeDpJUQi3XGA==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.17.tgz",
+      "integrity": "sha512-gduHEf8ufGjfQaoHmt8cCWNwDJ6Nilc7pVw5GpqUrXPNKA9LWBOYrCofsllpRKAj5S0hMekqGy4ZPXfqSDxLaA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.16"
+        "@canvas-harness/core": "0.1.17"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1943,12 +1943,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.16.tgz",
-      "integrity": "sha512-Z7cOAEpM/iQdjyD/6+7JieaACwwwBaVl1cHke0D/u5jenzh0fC8amZn9pVlkfPd9A+jrUSOHy1AcDTl/VW6zDg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.17.tgz",
+      "integrity": "sha512-y7v1SctZPsiAPuWMpVXyKFC5+y6s6VPG5IYj5Q/bwLlz6AnLZ1ovYiELjPprNKnCFXbpQzH16CGVNnhClitBEQ==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.16"
+        "@canvas-harness/core": "0.1.17"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.16",
-    "@canvas-harness/react": "^0.1.16",
-    "@canvas-harness/sync-broadcast": "^0.1.16",
+    "@canvas-harness/core": "^0.1.17",
+    "@canvas-harness/react": "^0.1.17",
+    "@canvas-harness/sync-broadcast": "^0.1.17",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/webui/src/features/board/harness/canvas/custom-node-types.test.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.test.ts
@@ -1,0 +1,55 @@
+// Guards that every Dim0 custom node type is treated as "custom" by BOTH
+// consumer paths: the double-click handler (no inline beginEdit) and the
+// sticky style memory (no style bleed). Regression cover for mini-app,
+// which was added to node-types but missed in both sets.
+//
+// We assert against a local list rather than importing `boardNodeTypes`
+// directly — that registry pulls in every iframe-backed node view and adds
+// ~12s of import cost to the suite. Keep this list in sync with
+// `node-types/index.ts → boardNodeTypes`.
+import { describe, expect, it } from "vitest"
+import { CUSTOM_NODE_TYPES } from "./custom-node-types"
+import { isStylableNodeType } from "./use-style-memory"
+
+
+const EXPECTED_CUSTOM_TYPES = [
+  "folder",
+  "document",
+  "widget",
+  "mini-app",
+  "code-sandbox",
+  "sheet",
+].sort()
+
+
+describe("custom node type exclusions", () => {
+  it("registers every custom node type for the dbl-click override", () => {
+    expect([...CUSTOM_NODE_TYPES].sort()).toEqual(EXPECTED_CUSTOM_TYPES)
+  })
+
+
+  it("excludes every custom node type from sticky style memory", () => {
+    for (const type of EXPECTED_CUSTOM_TYPES) {
+      expect(isStylableNodeType(type)).toBe(false)
+    }
+  })
+
+
+  it("keeps the two exclusion sets in agreement (no type custom in one path only)", () => {
+    for (const type of CUSTOM_NODE_TYPES) {
+      expect(isStylableNodeType(type)).toBe(false)
+    }
+  })
+
+
+  it("covers mini-app specifically (the original gap)", () => {
+    expect(CUSTOM_NODE_TYPES.has("mini-app")).toBe(true)
+    expect(isStylableNodeType("mini-app")).toBe(false)
+  })
+
+
+  it("leaves built-in primitive types editable + stylable", () => {
+    expect(CUSTOM_NODE_TYPES.has("rect")).toBe(false)
+    expect(isStylableNodeType("rect")).toBe(true)
+  })
+})

--- a/webui/src/features/board/harness/canvas/custom-node-types.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.ts
@@ -1,0 +1,19 @@
+/**
+ * canvas `node.type` values for Dim0's custom node defs (see
+ * `node-types/`). These nodes own their editing surface — an expand
+ * dialog, a side panel, or folder navigation — so a double-click must
+ * NOT trigger the lib's inline text editor (`beginEdit`).
+ *
+ * Keep this in sync with the defs registered in
+ * `node-types/index.ts → boardNodeTypes`; `custom-node-types.test.ts`
+ * guards the parity. The matching style-memory exclusion lives in
+ * `use-style-memory.ts → EXCLUDED_TYPES`.
+ */
+export const CUSTOM_NODE_TYPES: ReadonlySet<string> = new Set([
+  "folder",
+  "document",
+  "sheet",
+  "code-sandbox",
+  "widget",
+  "mini-app",
+])

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -54,6 +54,7 @@ import { useBlockFolderCopy } from "./use-block-folder-copy"
 import { useStampNewEdges } from "./use-stamp-new-edges"
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useStyleMemory } from "./use-style-memory"
+import { CUSTOM_NODE_TYPES } from "./custom-node-types"
 import { useLocalPresence } from "./use-local-presence"
 import { useWsCollab } from "./use-ws-collab"
 import { useThumbnailCapture } from "./use-thumbnail-capture"
@@ -292,16 +293,6 @@ export function HarnessCanvas() {
     </CanvasProvider>
   )
 }
-
-
-/** canvas node.type values whose dbl-click should NOT trigger the lib's beginEdit. */
-const CUSTOM_NODE_TYPES = new Set([
-  "folder",
-  "document",
-  "sheet",
-  "code-sandbox",
-  "widget",
-])
 
 
 type InnerProps = {

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import { hitTestAny, type CanvasStore, type NodeId, type Renderer } from "@canvas-harness/core"
@@ -131,7 +131,8 @@ export function HarnessCanvas() {
   useBoardKeyboard(store)
   useViewportPersistence(store, boardId, rootId, ready)
   useCenterFromUrl(store, wrapRef, ready)
-  useStampNewEdges(store, boardId, rootId)
+  const styleMemory = useStyleMemory(store)
+  useStampNewEdges(store, boardId, rootId, styleMemory.getEdgeStoredColors)
   useStampNewNodes(store, boardId, rootId)
   useBlockFolderCopy(store)
   useHarnessApplyMindMap(store, boardId, rootId)
@@ -147,15 +148,18 @@ export function HarnessCanvas() {
   useWsCollab(store, boardId, ready, rootId)
   useLocalPresence(store, wrapRef, ready)
 
-  const styleMemory = useStyleMemory(store)
   const { handleCreateDrag, handleClick } = useCreateHandlers(store, boardId, rootId, styleMemory)
-  const arrowDefaults = useMemo<ArrowToolDefaults>(
-    () => ({
-      pathStyle: styleMemory.getEdgePathStyle(),
-      style: styleMemory.getEdgeStyle(),
-    }),
-    [styleMemory],
-  )
+  // Recompute every render — NOT memoized on `styleMemory`. The memory
+  // object is intentionally identity-stable for its whole lifetime, so a
+  // `useMemo([styleMemory])` would compute once at mount and freeze the
+  // edge defaults at their initial (usually empty) value, ignoring every
+  // later restyle. The lib reads `arrowDefaults` lazily at edge-draw time
+  // (defaultsRef) and keys no effect off it, so a fresh object per render
+  // is cheap and is what lets sticky edge styles actually take effect.
+  const arrowDefaults: ArrowToolDefaults = {
+    pathStyle: styleMemory.getEdgePathStyle(),
+    style: styleMemory.getEdgeStyle(),
+  }
   const { onDragOver, onDrop } = useHarnessDropFiles(wrapRef, store, boardId, rootId, canEdit)
   const navigate = useNavigate()
 

--- a/webui/src/features/board/harness/canvas/normalize-autofit.test.ts
+++ b/webui/src/features/board/harness/canvas/normalize-autofit.test.ts
@@ -1,0 +1,133 @@
+// Receiver-side guard: incoming remote ops for preview-rendered custom
+// types (sheet, etc.) must carry `style.autoFit = false`, so an agent
+// sheet from an un-upgraded backend can't grow unbounded on the next edit.
+import { describe, expect, it } from "vitest"
+import {
+  asNodeId,
+  createCanvasStore,
+  type CanvasStore,
+  type Node,
+  type Op,
+  type OpBatch,
+} from "@canvas-harness/core"
+import { normalizeBatchAutoFit } from "./normalize-autofit"
+
+
+/** Wrap ops in a minimal remote batch — the normalizer only reads `ops`. */
+const remoteBatch = (ops: Op[]): OpBatch =>
+  ({ ops } as unknown as OpBatch)
+
+
+/** A bare node.add op, the way an agent-broadcast wire node arrives. */
+const addOp = (type: string, style?: Record<string, unknown>): Op =>
+  ({
+    type: "node.add",
+    node: {
+      id: asNodeId("n-" + type),
+      type,
+      x: 0,
+      y: 0,
+      w: 560,
+      h: 320,
+      angle: 0,
+      z: 0,
+      groups: [],
+      content: "",
+      ...(style ? { style } : {}),
+    } as unknown as Node,
+  } as Op)
+
+
+describe("normalizeBatchAutoFit", () => {
+  const store: CanvasStore = createCanvasStore()
+
+
+  it("forces autoFit:false on an incoming sheet node.add with no style", () => {
+    const batch = remoteBatch([addOp("sheet")])
+    normalizeBatchAutoFit(batch, store)
+    const op = batch.ops[0]
+    expect(op.type === "node.add" && op.node.style?.autoFit).toBe(false)
+  })
+
+
+  it("preserves other style fields while adding autoFit:false", () => {
+    const batch = remoteBatch([addOp("sheet", { strokeColor: "#abcdef" })])
+    normalizeBatchAutoFit(batch, store)
+    const op = batch.ops[0]
+    if (op.type !== "node.add") throw new Error("expected node.add")
+    expect(op.node.style?.autoFit).toBe(false)
+    expect(op.node.style?.strokeColor).toBe("#abcdef")
+  })
+
+
+  it("leaves built-in primitive node.add untouched", () => {
+    const batch = remoteBatch([addOp("rect")])
+    normalizeBatchAutoFit(batch, store)
+    const op = batch.ops[0]
+    expect(op.type === "node.add" && op.node.style?.autoFit).toBeUndefined()
+  })
+
+
+  it("covers every autofit-disabled custom type on node.add", () => {
+    for (const type of ["sheet", "code-sandbox", "widget", "mini-app", "folder", "document"]) {
+      const batch = remoteBatch([addOp(type)])
+      normalizeBatchAutoFit(batch, store)
+      const op = batch.ops[0]
+      expect(op.type === "node.add" && op.node.style?.autoFit).toBe(false)
+    }
+  })
+
+
+  it("injects autoFit:false on a style-bearing node.update for an existing sheet", () => {
+    const s = createCanvasStore()
+    const id = asNodeId("sheet-1")
+    s.addNode({
+      id,
+      type: "sheet",
+      x: 0,
+      y: 0,
+      w: 560,
+      h: 320,
+      angle: 0,
+      z: 0,
+      groups: [],
+      content: "",
+      style: { autoFit: false },
+    } as unknown as Parameters<typeof s.addNode>[0])
+
+    const batch = remoteBatch([
+      { type: "node.update", id, patch: { style: { strokeColor: "#111" } } } as Op,
+    ])
+    normalizeBatchAutoFit(batch, s)
+    const op = batch.ops[0]
+    if (op.type !== "node.update") throw new Error("expected node.update")
+    expect((op.patch as Partial<Node>).style?.autoFit).toBe(false)
+  })
+
+
+  it("leaves a node.update with no style patch untouched (no style key created)", () => {
+    const s = createCanvasStore()
+    const id = asNodeId("sheet-2")
+    s.addNode({
+      id,
+      type: "sheet",
+      x: 0,
+      y: 0,
+      w: 560,
+      h: 320,
+      angle: 0,
+      z: 0,
+      groups: [],
+      content: "",
+      style: { autoFit: false },
+    } as unknown as Parameters<typeof s.addNode>[0])
+
+    const batch = remoteBatch([
+      { type: "node.update", id, patch: { x: 50 } } as Op,
+    ])
+    normalizeBatchAutoFit(batch, s)
+    const op = batch.ops[0]
+    if (op.type !== "node.update") throw new Error("expected node.update")
+    expect((op.patch as Partial<Node>).style).toBeUndefined()
+  })
+})

--- a/webui/src/features/board/harness/canvas/normalize-autofit.ts
+++ b/webui/src/features/board/harness/canvas/normalize-autofit.ts
@@ -1,0 +1,39 @@
+import type { CanvasStore, Node, OpBatch } from "@canvas-harness/core"
+import { AUTOFIT_DISABLED_TYPES } from "../convert/note-to-node"
+
+
+/**
+ * Force `style.autoFit = false` on incoming custom-type nodes whose lib
+ * grow-to-fit must stay off (sheet, code-sandbox, widget, mini-app,
+ * folder, document — they render only a preview of `node.content`).
+ *
+ * Defense-in-depth mirroring the server's `note_to_wire` guard: an
+ * agent-created sheet from an un-upgraded backend, or a replayed
+ * catch-up batch, could arrive with `autoFit` unset (→ on in the lib),
+ * and the next local content edit would then grow the node to fit the
+ * whole markdown body, uncapped. The frontend converter (`note-to-node`)
+ * already does this for snapshot / local-create paths; this covers the
+ * remote-op path the same way `normalizeBatchColorsForLocalTheme` covers
+ * colors.
+ *
+ * Mutates the batch in place — it is owned by the caller at this point
+ * (decoded from JSON moments ago) and `attachSync` reads style after.
+ */
+export const normalizeBatchAutoFit = (batch: OpBatch, store: CanvasStore): void => {
+  for (const op of batch.ops) {
+    if (op.type === "node.add") {
+      const node = op.node
+      if (!AUTOFIT_DISABLED_TYPES.has(node.type)) continue
+      node.style = { ...(node.style ?? {}), autoFit: false }
+    } else if (op.type === "node.update") {
+      const patch = op.patch as Partial<Node>
+      // A style-bearing patch replaces the node's style on apply, so it
+      // could silently re-enable autoFit; patches without `style` leave
+      // the existing (already-correct) flag untouched.
+      if (patch.style === undefined) continue
+      const type = store.getNode(op.id)?.type ?? patch.type
+      if (type === undefined || !AUTOFIT_DISABLED_TYPES.has(type)) continue
+      patch.style = { ...patch.style, autoFit: false }
+    }
+  }
+}

--- a/webui/src/features/board/harness/canvas/use-stamp-new-edges.test.tsx
+++ b/webui/src/features/board/harness/canvas/use-stamp-new-edges.test.tsx
@@ -1,0 +1,177 @@
+// Tests for the edge-creation stamp, focused on sticky-color inheritance:
+// a freshly-drawn edge must adopt the user's last-picked colors (canonical),
+// projected for the current theme, while paste/scope handling stays intact.
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  asEdgeId,
+  createCanvasStore,
+  type CanvasStore,
+  type EdgeId,
+} from "@canvas-harness/core"
+import { useStampNewEdges } from "./use-stamp-new-edges"
+import { adaptEdgeColors, type StoredEdgeColors } from "../theme/color-adapter"
+import { setBoardThemeMode } from "../theme/theme-mode-ref"
+
+
+const BOARD_ID = "board-1"
+const CANONICAL = { strokeColor: "#292524", textColor: "#000000" }
+
+
+/** Add an edge the way the lib's arrow tool does: a `style`, but no `data`. */
+const drawEdge = (store: CanvasStore, style?: Record<string, unknown>): EdgeId => {
+  const id = asEdgeId(store.generateId())
+  store.addEdge({
+    id,
+    source: { worldPoint: { x: 0, y: 0 } },
+    target: { worldPoint: { x: 100, y: 0 } },
+    pathStyle: "bezier",
+    groups: [],
+    ...(style ? { style } : {}),
+  })
+  return id
+}
+
+
+describe("useStampNewEdges — sticky color inheritance", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    setBoardThemeMode("light")
+  })
+
+
+  /** Mount the stamp with a fixed remembered-color getter. */
+  const mountStamp = (
+    store: CanvasStore,
+    remembered: StoredEdgeColors | undefined,
+  ): void => {
+    const Probe = (): null => {
+      useStampNewEdges(store, BOARD_ID, null, () => remembered)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+  }
+
+
+  it("stamps a freshly-drawn edge with the remembered canonical colors (light mode)", () => {
+    const store = createCanvasStore()
+    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
+    mountStamp(store, remembered)
+
+    let edgeId: EdgeId | undefined
+    act(() => {
+      edgeId = drawEdge(store)
+    })
+    const edge = store.getEdge(edgeId!)
+
+    // Canonical source-of-truth captured...
+    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
+      .toEqual(remembered)
+    // ...and painted as display (light = identity).
+    expect(edge?.style?.strokeColor).toBe("#ef4444")
+    expect(edge?.style?.textColor).toBe("#111111")
+  })
+
+
+  it("projects the remembered colors to dark-mode display while keeping canonical truth", () => {
+    setBoardThemeMode("dark")
+    const store = createCanvasStore()
+    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
+    mountStamp(store, remembered)
+
+    let edgeId: EdgeId | undefined
+    act(() => {
+      edgeId = drawEdge(store)
+    })
+    const edge = store.getEdge(edgeId!)
+    const expectedDisplay = adaptEdgeColors(remembered, "dark")
+
+    // Stored truth stays canonical (light) — this is what hits the DB / collab.
+    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
+      .toEqual(remembered)
+    // Painted style is the dark-adapted projection.
+    expect(edge?.style?.strokeColor).toBe(expectedDisplay.strokeColor)
+    expect(edge?.style?.textColor).toBe(expectedDisplay.textColor)
+  })
+
+
+  it("falls back to canonical defaults when nothing is remembered", () => {
+    const store = createCanvasStore()
+    mountStamp(store, undefined)
+
+    let edgeId: EdgeId | undefined
+    act(() => {
+      edgeId = drawEdge(store)
+    })
+    const edge = store.getEdge(edgeId!)
+
+    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
+      .toEqual(CANONICAL)
+  })
+
+
+  it("merges canonical for the field the user never picked", () => {
+    const store = createCanvasStore()
+    // Only a stroke color was ever picked; label color should stay canonical.
+    mountStamp(store, { strokeColor: "#00ff00" })
+
+    let edgeId: EdgeId | undefined
+    act(() => {
+      edgeId = drawEdge(store)
+    })
+    const edge = store.getEdge(edgeId!)
+
+    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
+      .toEqual({ strokeColor: "#00ff00", textColor: CANONICAL.textColor })
+  })
+
+
+  it("does not override an edge that already carries its own _storedColors (paste)", () => {
+    const store = createCanvasStore()
+    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
+    mountStamp(store, remembered)
+
+    // A pasted edge: already initialized + scoped + carrying source colors.
+    const pasted = { strokeColor: "#abcdef", textColor: "#fedcba" }
+    let edgeId: EdgeId | undefined
+    act(() => {
+      edgeId = asEdgeId(store.generateId())
+      store.addEdge({
+        id: edgeId,
+        source: { worldPoint: { x: 0, y: 0 } },
+        target: { worldPoint: { x: 100, y: 0 } },
+        pathStyle: "bezier",
+        groups: [],
+        style: { ...pasted },
+        data: {
+          version: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          graphUid: BOARD_ID,
+          _storedColors: pasted,
+        },
+      })
+    })
+    const edge = store.getEdge(edgeId!)
+
+    // Source colors preserved — sticky memory must not clobber a paste.
+    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
+      .toEqual(pasted)
+  })
+})

--- a/webui/src/features/board/harness/canvas/use-stamp-new-edges.ts
+++ b/webui/src/features/board/harness/canvas/use-stamp-new-edges.ts
@@ -32,9 +32,11 @@ const CANONICAL_EDGE_COLORS: StoredEdgeColors = {
  *
  *   - **init stamp** (`version === undefined`): a freshly-drawn arrow
  *     from canvas-harness's `useArrowTool` arrives with no `data`.
- *     Set version/createdAt, capture `_storedColors`, and (in dark
- *     mode) project to dark-adapted display style. Without this, the
- *     edge has no source-of-truth for theme adaptation later.
+ *     Set version/createdAt, capture `_storedColors` (from sticky style
+ *     memory via `rememberedEdgeColors`, falling back to canonical
+ *     defaults), and (in dark mode) project to dark-adapted display
+ *     style. Without this, the edge has no source-of-truth for theme
+ *     adaptation later, and would ignore the user's last-picked colors.
  *
  *   - **rescope stamp** (scope mismatch): a pasted edge carries
  *     `version` + `_storedColors` from the source but its
@@ -65,6 +67,7 @@ export const useStampNewEdges = (
   store: CanvasStore,
   boardId: string | null,
   rootId: string | null,
+  rememberedEdgeColors: () => StoredEdgeColors | undefined,
 ): void => {
   useEffect(() => {
     if (!boardId) return
@@ -79,12 +82,23 @@ export const useStampNewEdges = (
         const scopeMismatched =
           data.graphUid !== boardId || data.parentId !== wantedParentId
 
-        // Resolve final stored colors: existing on data, or canonical
-        // light defaults for fresh draws. NEVER read from `style.*` —
-        // arrow-tool dark defaults are display values that masquerade
-        // as canonical (see CANONICAL_EDGE_COLORS comment).
+        // Resolve final stored colors. Priority:
+        //   1. `_storedColors` already on the edge (e.g. a pasted edge
+        //      carrying its source colors) — always wins.
+        //   2. The last color the user picked, from sticky style memory
+        //      (canonical/light-space) — so a freshly-drawn edge inherits
+        //      it, matching how new nodes inherit via `applyStyleMemory`.
+        //      The arrow tool can't carry `_storedColors` through
+        //      `ArrowToolDefaults`, so memory is the trusted channel.
+        //   3. Canonical light defaults.
+        // NEVER read from `style.*` — arrow-tool dark defaults are display
+        // values that masquerade as canonical (see CANONICAL_EDGE_COLORS).
         const existingStored = data._storedColors as StoredEdgeColors | undefined
-        const storedColors: StoredEdgeColors = existingStored ?? CANONICAL_EDGE_COLORS
+        const remembered = rememberedEdgeColors()
+        const storedColors: StoredEdgeColors = existingStored ?? {
+          strokeColor: remembered?.strokeColor ?? CANONICAL_EDGE_COLORS.strokeColor,
+          textColor: remembered?.textColor ?? CANONICAL_EDGE_COLORS.textColor,
+        }
 
         const mode = getBoardThemeMode()
         const displayColors =
@@ -116,5 +130,5 @@ export const useStampNewEdges = (
         store.updateEdge(op.edge.id, patch)
       }
     })
-  }, [store, boardId, rootId])
+  }, [store, boardId, rootId, rememberedEdgeColors])
 }

--- a/webui/src/features/board/harness/canvas/use-style-memory.test.tsx
+++ b/webui/src/features/board/harness/canvas/use-style-memory.test.tsx
@@ -1,0 +1,230 @@
+// Tests for sticky style memory — focused on the edge defaults, which
+// silently never persisted before the harness-canvas dead-memo fix.
+import { useEffect } from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  asEdgeId,
+  asNodeId,
+  createCanvasStore,
+  type CanvasStore,
+  type EdgeId,
+  type NodeId,
+} from "@canvas-harness/core"
+import { useStyleMemory, type StyleMemoryApi } from "./use-style-memory"
+
+
+const STORAGE_KEY = "dim0:harness:style-memory:v1"
+
+
+/** Drop a free-floating edge into the store and return its id. */
+const addFloatingEdge = (store: CanvasStore): EdgeId => {
+  const id = asEdgeId(store.generateId())
+  store.addEdge({
+    id,
+    source: { worldPoint: { x: 0, y: 0 } },
+    target: { worldPoint: { x: 100, y: 0 } },
+    pathStyle: "bezier",
+    groups: [],
+  })
+  return id
+}
+
+
+/** Drop a default rect node into the store and return its id. */
+const addRectNode = (store: CanvasStore): NodeId => {
+  const id = asNodeId(store.generateId())
+  store.addNode({ id, type: "rect", x: 0, y: 0, w: 100, h: 60, angle: 0, groups: [] })
+  return id
+}
+
+
+describe("useStyleMemory", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+
+  it("captures an edge style change live, without a remount, and persists it", () => {
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    expect(api?.getEdgeStyle()).toBeUndefined()
+
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { style: { strokeColor: "#ff0000" } })
+    })
+
+    // Memory reflects the user's pick mid-session (no reload).
+    expect(api?.getEdgeStyle()?.strokeColor).toBe("#ff0000")
+    // And it is persisted for the next reload.
+    const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}")
+    expect(persisted.edge?.style?.strokeColor).toBe("#ff0000")
+  })
+
+
+  it("exposes the remembered canonical edge colors via getEdgeStoredColors", () => {
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    expect(api?.getEdgeStoredColors()).toBeUndefined()
+
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { style: { strokeColor: "#ff0000", textColor: "#111111" } })
+    })
+
+    expect(api?.getEdgeStoredColors()).toEqual({
+      strokeColor: "#ff0000",
+      textColor: "#111111",
+    })
+  })
+
+
+  it("getEdgeStoredColors returns undefined when only non-color edge style changed", () => {
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { style: { strokeWidth: 4 } })
+    })
+
+    // Width is remembered, but there are no colors to stamp onto a new edge.
+    expect(api?.getEdgeStyle()?.strokeWidth).toBe(4)
+    expect(api?.getEdgeStoredColors()).toBeUndefined()
+  })
+
+
+  it("captures edge pathStyle changes too", () => {
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { pathStyle: "straight" })
+    })
+
+    expect(api?.getEdgePathStyle()).toBe("straight")
+  })
+
+
+  it("keeps a stable api identity while its values change — why consumers must read it each render", () => {
+    // Regression guard for the dead-memo bug: `arrowDefaults` used to be
+    // `useMemo(() => ({ style: api.getEdgeStyle() }), [api])`. Because the
+    // api object identity never changes, that memo froze the edge defaults
+    // at their mount-time (empty) value and ignored every later restyle.
+    // This pins the contract that makes the fix necessary: same api
+    // reference, fresh values.
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    const before = api
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { style: { strokeColor: "#00ff00" } })
+    })
+
+    expect(api).toBe(before) // identity unchanged...
+    expect(api?.getEdgeStyle()?.strokeColor).toBe("#00ff00") // ...value fresh
+  })
+
+
+  it("a per-render arrowDefaults (the fix) picks up edge restyles", () => {
+    const store = createCanvasStore()
+    const committed: Array<string | undefined> = []
+    const Consumer = (): null => {
+      const api = useStyleMemory(store)
+      // Mirrors the fixed harness-canvas: recompute every render from the
+      // live accessors instead of memoizing on the stable api object.
+      const arrowDefaults = { style: api.getEdgeStyle() }
+      useEffect(() => {
+        committed.push(arrowDefaults.style?.strokeColor)
+      })
+      return null
+    }
+    act(() => {
+      root.render(<Consumer />)
+    })
+
+    const edgeId = addFloatingEdge(store)
+    act(() => {
+      store.updateEdge(edgeId, { style: { strokeColor: "#123456" } })
+    })
+
+    // The latest committed arrowDefaults carries the restyle.
+    expect(committed.at(-1)).toBe("#123456")
+  })
+
+
+  it("captures a node style change live (notes already worked — guards against regressing them)", () => {
+    const store = createCanvasStore()
+    let api: StyleMemoryApi | undefined
+    const Probe = (): null => {
+      api = useStyleMemory(store)
+      return null
+    }
+    act(() => {
+      root.render(<Probe />)
+    })
+
+    const nodeId = addRectNode(store)
+    act(() => {
+      store.updateNode(nodeId, { style: { strokeColor: "#abcdef" } })
+    })
+
+    expect(api?.getNodeStyle()?.strokeColor).toBe("#abcdef")
+  })
+})

--- a/webui/src/features/board/harness/canvas/use-style-memory.ts
+++ b/webui/src/features/board/harness/canvas/use-style-memory.ts
@@ -25,8 +25,8 @@ import {
  * One shared bucket for non-custom nodes (rect, ellipse, diamond,
  * text, etc.) — picking a color on a rect carries to the next
  * ellipse. Custom node types (folder, sheet, code-sandbox, widget,
- * document) are intentionally excluded both as memory inputs AND
- * outputs: they have a fixed visual identity and shouldn't bleed
+ * document, mini-app) are intentionally excluded both as memory inputs
+ * AND outputs: they have a fixed visual identity and shouldn't bleed
  * styles in or out.
  *
  * Persisted to localStorage so preferences survive reloads. Version
@@ -43,6 +43,7 @@ const EXCLUDED_TYPES: ReadonlySet<string> = new Set([
   "code-sandbox",
   "widget",
   "document",
+  "mini-app",
 ])
 
 

--- a/webui/src/features/board/harness/canvas/use-style-memory.ts
+++ b/webui/src/features/board/harness/canvas/use-style-memory.ts
@@ -10,6 +10,8 @@ import type { NoteNodeData } from "../convert/note-to-node"
 import {
   applyColorsToEdgeStyle,
   applyColorsToStyle,
+  pickStoredEdgeColors,
+  type StoredEdgeColors,
 } from "../theme/color-adapter"
 
 
@@ -94,6 +96,7 @@ export type StyleMemoryApi = {
   getNodeStyle: () => Style | undefined
   getEdgeStyle: () => EdgeStyle | undefined
   getEdgePathStyle: () => PathStyle | undefined
+  getEdgeStoredColors: () => StoredEdgeColors | undefined
 }
 
 
@@ -178,6 +181,21 @@ export const useStyleMemory = (store: CanvasStore): StyleMemoryApi => {
       },
       getEdgeStyle: () => memoryRef.current.edge.style,
       getEdgePathStyle: () => memoryRef.current.edge.pathStyle,
+      // Canonical (light-space) stroke/label colors the user last picked.
+      // `edge.style` already holds canonical colors — the capture path
+      // overlays `_storedColors` before folding into memory — so we can
+      // pluck them directly. Returns undefined when no color was ever
+      // picked (e.g. only width changed) so callers fall back to canonical
+      // defaults rather than stamping `undefined` colors.
+      getEdgeStoredColors: () => {
+        const style = memoryRef.current.edge.style
+        if (!style) return undefined
+        const colors = pickStoredEdgeColors(style)
+        if (colors.strokeColor === undefined && colors.textColor === undefined) {
+          return undefined
+        }
+        return colors
+      },
     }),
     [],
   )

--- a/webui/src/features/board/harness/canvas/use-ws-collab.ts
+++ b/webui/src/features/board/harness/canvas/use-ws-collab.ts
@@ -37,6 +37,7 @@ import {
   type StoredEdgeColors,
 } from "../theme/color-adapter"
 import { getBoardThemeMode } from "../theme/theme-mode-ref"
+import { normalizeBatchAutoFit } from "./normalize-autofit"
 
 
 /**
@@ -713,6 +714,7 @@ const createWebSocketSyncAdapter = ({
         for (const batch of msg.batches) {
           if (batch.clientId === clientId) continue
           normalizeBatchColorsForLocalTheme(batch)
+          normalizeBatchAutoFit(batch, store)
           patchMissingEdgeEndpoints(batch, store)
           for (const cb of batchListeners) cb(batch)
         }
@@ -745,6 +747,7 @@ const createWebSocketSyncAdapter = ({
       // store and paint as a dark color on a white canvas (and vice
       // versa). See [color-adapter.ts] for the projection rules.
       normalizeBatchColorsForLocalTheme(msg.batch)
+      normalizeBatchAutoFit(msg.batch, store)
       // Defense-in-depth: any attached EdgeEnd without a localOffset
       // would crash canvas-harness's `projectEndToWorld` on
       // `undefined.x`. Server-side `link_to_wire_edge` defaults to

--- a/webui/src/features/board/harness/chrome/style-panel/panel.tsx
+++ b/webui/src/features/board/harness/chrome/style-panel/panel.tsx
@@ -551,8 +551,8 @@ export function StylePanel({
         className,
       )}
     >
-      <CardContent className="h-auto max-h-[60vh] p-0">
-        <div className="scrollbar-thin h-full overflow-y-auto p-1 [scrollbar-gutter:stable_both-edges]">
+      <CardContent className="p-0">
+        <div className="scrollbar-thin max-h-[60vh] overflow-y-auto p-1 [scrollbar-gutter:stable_both-edges]">
           <div className="space-y-0">
             {ORDER.map((key) => (
               <Popover key={key}>

--- a/webui/src/features/board/harness/convert/note-to-node.ts
+++ b/webui/src/features/board/harness/convert/note-to-node.ts
@@ -27,7 +27,7 @@ const DEG_TO_RAD = Math.PI / 180
  * enough for the whole body the user can't see, breaking height
  * resize. See migration plan §4.x.
  */
-const AUTOFIT_DISABLED_TYPES = new Set([
+export const AUTOFIT_DISABLED_TYPES = new Set([
   "folder",
   "sheet",
   "code-sandbox",


### PR DESCRIPTION
## Summary

Sticky style memory now works for **edges**, and the canvas engine is bumped to the latest release.

New edges previously ignored the user's last-picked style: drawing a fresh edge always fell back to the engine default, even within the same session. Notes already inherited the last style (excalidraw/tldraw/figma-like); this brings edges to parity.

## Changes

### `🐛 fix(board): persist sticky styles for new edges`
Two independent causes, both fixed:

1. **Dead memo (mid-session).** `arrowDefaults` was memoized on the style-memory object, which is intentionally identity-stable for its whole lifetime — so the memo computed once at mount and froze at its initial (empty) value, ignoring every later restyle. It now recomputes per render; the engine reads `arrowDefaults` lazily at draw time and keys no effect off it, so a fresh object per render is cheap and correct.

2. **Color reset on creation.** The edge-creation stamp always reset stroke/label colors to canonical defaults, because a freshly-drawn edge carries no `_storedColors` and the arrow tool can't pass them through `ArrowToolDefaults`. Non-color props (width, path style, label font) survived; colors didn't — matching the reported symptom exactly. The stamp now reads the remembered **canonical** colors from style memory (the trusted, light-space source of truth), mirroring how new nodes inherit via `applyStyleMemory`.

Existing behavior preserved:
- **Paste** — an edge that already carries its own `_storedColors` is never overridden.
- **Fallback** — with nothing remembered, canonical defaults are used (unchanged).
- **Light/dark + collab** — only canonical colors are stamped/persisted; display is projected per-theme, so cross-theme peers stay consistent.

### `chore(webui): update canvas-harness to 0.1.17`
Bumps `@canvas-harness/core`, `/react`, and `/sync-broadcast` from `0.1.16` → `0.1.17` (patch). Type-check passes against the new types.

## Test plan
- New unit tests: sticky edge style/color capture (`use-style-memory.test.tsx`) and stamp inheritance (`use-stamp-new-edges.test.tsx`) — light-mode inheritance, dark-mode projection with canonical truth preserved, canonical fallback, per-field merge, and paste non-override.
- `npm run type-check` — clean
- `board/harness` suite — 108 passing
- Manually verified: restyle edge border color + label font color → new edge inherits both (mid-session and after refresh).
