### PR TITLE
⬆️ chore(webui): bump canvas-harness to 0.1.18 + fix edit-mode blank line

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.3.34",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.17",
-        "@canvas-harness/react": "^0.1.17",
-        "@canvas-harness/sync-broadcast": "^0.1.17",
+        "@canvas-harness/core": "^0.1.18",
+        "@canvas-harness/react": "^0.1.18",
+        "@canvas-harness/sync-broadcast": "^0.1.18",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1919,9 +1919,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.17.tgz",
-      "integrity": "sha512-gmohd8plwSBqMMJbNmGvdiaqs7IXOhCk+JcdTr+M4od6POeLuGKfkWtISkm62DjwOOzsCDeq5muBL0CNfrzjnA==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.18.tgz",
+      "integrity": "sha512-GgnbXC6/aUruJ8V8ZYDq3h6um/CUgYdQGOM5c1ydBJDxsELEIgZl7W+eSQ/M6yl3zDt0BYaCY5l8i9PzpHJObg==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1930,12 +1930,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.17.tgz",
-      "integrity": "sha512-gduHEf8ufGjfQaoHmt8cCWNwDJ6Nilc7pVw5GpqUrXPNKA9LWBOYrCofsllpRKAj5S0hMekqGy4ZPXfqSDxLaA==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.18.tgz",
+      "integrity": "sha512-wDDPQLnLxypt7UTkuxtWZQgE4nbSadxZVANXjTTFLXuiVyM93077QwXrfL+XzuwMvsW46dvc4CaanI2EQeuVJQ==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.17"
+        "@canvas-harness/core": "0.1.18"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1943,12 +1943,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.17.tgz",
-      "integrity": "sha512-y7v1SctZPsiAPuWMpVXyKFC5+y6s6VPG5IYj5Q/bwLlz6AnLZ1ovYiELjPprNKnCFXbpQzH16CGVNnhClitBEQ==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.18.tgz",
+      "integrity": "sha512-fQjwlyzdc0rJqAQEibLmMPy1exu6C7/51PD2Gpq97fwc+4h9Po553QXmbMJrThrAXk6TF9n8yymR+sEUQ+7peA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.17"
+        "@canvas-harness/core": "0.1.18"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.17",
-    "@canvas-harness/react": "^0.1.17",
-    "@canvas-harness/sync-broadcast": "^0.1.17",
+    "@canvas-harness/core": "^0.1.18",
+    "@canvas-harness/react": "^0.1.18",
+    "@canvas-harness/sync-broadcast": "^0.1.18",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/webui/src/features/board/harness/canvas/text-editor-adapter.ts
+++ b/webui/src/features/board/harness/canvas/text-editor-adapter.ts
@@ -121,7 +121,12 @@ export const createHarnessTextareaEditor: EditorAdapterFactory = ({
   ta.style.wordBreak = "break-word"
 
   const autosize = (): void => {
-    ta.style.height = "auto"
+    // Collapse to 0 before measuring — a bare <textarea> defaults to
+    // rows=2, so `height: auto` keeps a 2-row floor and `scrollHeight`
+    // over-reports by a blank line for short content (which then sits
+    // high in the vertically-centered wrap). Matches the lib's
+    // createDefaultTextareaEditor.
+    ta.style.height = "0px"
     ta.style.height = `${ta.scrollHeight}px`
   }
 


### PR DESCRIPTION
## Summary

Two changes:

### ⬆️ Bump canvas-harness to 0.1.18
- `@canvas-harness/core`, `@canvas-harness/react`, `@canvas-harness/sync-broadcast`: `0.1.17` → `0.1.18` (patch).

### 🐛 Fix extra blank line in node edit mode
Entering edit mode on a normal (non-custom) node bumped the text upward by a blank line. `autosize()` reset the textarea to `height: auto` before measuring `scrollHeight`, but a bare `<textarea>` defaults to `rows=2` — so short content measured a blank line too tall and, being top-aligned inside the vertically-centered editor wrap, sat high relative to the canvas-rendered text. Collapse to `0px` before measuring (matching the lib's `createDefaultTextareaEditor`) so `scrollHeight` reflects the true content height.

## Test plan
- `npm run type-check` — clean.
- `board/harness` suite — 119 passing.
- Manual: double-click a single-line text node / shape label → text stays vertically centered, no upward jump on entering edit mode.
