### PR TITLE
🎨 chore(webui): default color theme to noir

### DIFF
--- a/webui/src/components/theme-provider.tsx
+++ b/webui/src/components/theme-provider.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/theme-constants"
 
 
-const DEFAULT_THEME_ID: ThemeId = "matcha"
+const DEFAULT_THEME_ID: ThemeId = "noir"
 
 const DEFAULT_MODE: Mode = "system"
 


### PR DESCRIPTION
## Summary

Set the default color theme to **Noir** (was Matcha).

Single-line change to `DEFAULT_THEME_ID` in `theme-provider.tsx` — it feeds the initial state, the SSR fallback, and the no-stored-prefs path, so the default switches consistently everywhere.

## Notes
- **Affects new users / fresh browsers only.** Anyone with an existing theme saved in `localStorage` (`topix-ui-theme`) keeps their choice — stored prefs take precedence over the default. To preview, clear that key or use an incognito window.
- **Mode (light/dark) is unchanged** — still `system`. Noir has both light and dark variants, so new users get Noir in whatever their OS prefers.

## Test plan
- `npm run type-check` — clean.
- eslint — clean.
