### PR TITLE
✅ test(backend): add pytest-timeout safety net for hanging collab tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,10 @@ jobs:
   backend:
     name: backend (ruff + unit tests)
     runs-on: ubuntu-latest
+    # Backstop so a wedged test (e.g. a collab WebSocket frame-ordering
+    # race) can't pin the runner until GitHub's ~6h default. The per-test
+    # pytest-timeout is the primary guard; this caps the whole job.
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 dev = [
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
+    "pytest-timeout>=2.3.1",
     "flake8>=7.3.0",
     "ruff>=0.12.2",
     "black>=25.1.0",
@@ -88,6 +89,17 @@ lines-between-types = 1
 [tool.setuptools.packages.find]
 exclude = ["build", "test"]
 
+[tool.pytest.ini_options]
+# Safety net: no single unit test should run this long. The collab
+# WebSocket tests drive real sessions through Starlette's TestClient
+# with blocking, un-timed `receive_*()` calls; a rare cross-peer
+# frame-ordering race would otherwise wedge a test — and the whole CI
+# job — indefinitely. Turning a hang into a per-test failure surfaces
+# the exact blocked receive instead. `thread` can interrupt a blocked
+# C-level queue.get (the default `signal` method can't, on a worker).
+timeout = 30
+timeout_method = "thread"
+
 [dependency-groups]
 dev = [
     "black>=25.1.0",
@@ -95,5 +107,6 @@ dev = [
     "flake8>=7.3.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
+    "pytest-timeout>=2.3.1",
     "ruff>=0.12.2",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1937,6 +1937,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2418,7 +2430,7 @@ wheels = [
 
 [[package]]
 name = "topix"
-version = "0.3.29"
+version = "0.3.35"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2460,6 +2472,7 @@ dev = [
     { name = "flake8" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -2470,6 +2483,7 @@ dev = [
     { name = "flake8" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -2500,6 +2514,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "qdrant-client", specifier = "==1.17.0" },
@@ -2521,6 +2536,7 @@ dev = [
     { name = "flake8", specifier = ">=7.3.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "ruff", specifier = ">=0.12.2" },
 ]
 


### PR DESCRIPTION
## Summary

Adds a timeout safety net so a hanging unit test can't pin the test run (or a CI job) indefinitely.

**Background:** the collab WebSocket unit tests drive real sessions through Starlette's `TestClient`, whose `receive_*()` calls block with no timeout. Because two endpoint coroutines share one background event loop and frames are relayed cross-socket under a shared `room.lock`, the arrival order of `welcome` / `peer-op` / `presence` / `presence-leave` frames is timing-dependent. In a rare interleaving an awaited frame never arrives and the receive blocks forever. With no per-test timeout and no CI job timeout, that hung the whole run — locally, and on Actions until GitHub's ~6h default.

## Changes
- Add `pytest-timeout` (dev dep) with `timeout = 30`, `timeout_method = "thread"` in `[tool.pytest.ini_options]`. Thread method can interrupt a blocked C-level `queue.get` (the default `signal` method can't on a worker).
- Add `timeout-minutes: 15` to the backend CI job as a whole-job backstop.

## What this does / doesn't do
- **Does:** turn an infinite hang into a per-test failure whose traceback points at the exact blocked `receive_*()`, and bound the CI job.
- **Doesn't:** fix the underlying frame-ordering race. That's a follow-up (bounded receives in tests + de-racing the send-then-connect / "exact next frame" assumptions). This PR makes the next occurrence diagnosable instead of silent.

## Test plan
- `pytest test/unit/api/router/test_collab_router.py` — 26 passed, plugin active.
- Full `test/unit` — no test approaches the 30s ceiling (suite ~14s). (Pre-existing `mini_app/test_compile.py` failures are unrelated: the local env is missing the compiler's `sucrase` npm dep; CI installs it via the mini-app-compiler step.)
