### PR TITLE
✅ test(mini-app): skip compile-bridge tests when node deps absent + add local setup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,19 @@ test-ui: ## Webui vitest suite (one-shot)
 lint-backend: ## Backend ruff check (runs before backend tests in CI)
 	cd backend && uv run ruff check topix test/unit
 
+.PHONY: setup-mini-app-compiler
+setup-mini-app-compiler: ## Install mini-app compiler node deps (sucrase) for the compile-bridge tests
+	@if [ ! -d backend/scripts/mini-app-compiler/node_modules ]; then \
+		if command -v npm >/dev/null 2>&1; then \
+			echo "Installing mini-app compiler deps (sucrase)…"; \
+			cd backend/scripts/mini-app-compiler && npm ci --omit=dev; \
+		else \
+			echo "npm not found — skipping mini-app compiler deps; compile-bridge tests will skip"; \
+		fi; \
+	fi
+
 .PHONY: test-backend
-test-backend: ## Backend unit tests (integration deferred — they need DBs)
+test-backend: setup-mini-app-compiler ## Backend unit tests (integration deferred — they need DBs)
 	cd backend && uv run pytest test/unit
 
 .PHONY: test-ci

--- a/backend/test/unit/mini_app/test_compile.py
+++ b/backend/test/unit/mini_app/test_compile.py
@@ -3,9 +3,10 @@
 These run the real Node subprocess against
 ``backend/scripts/mini-app-compiler/compile.mjs`` — they're effectively
 integration tests for the Python↔Node bridge. The script's
-``node_modules`` must be installed (``npm install`` in that dir);
-both CI and the Dockerfile do this. Tests are skipped with a helpful
-message when ``node`` isn't on PATH.
+``node_modules`` must be installed (``npm ci`` in that dir, or
+``make setup-mini-app-compiler``); both CI and the Dockerfile do this.
+Tests skip with a helpful message when ``node`` isn't on PATH **or** the
+compiler's ``node_modules`` is absent.
 """
 
 from __future__ import annotations
@@ -14,15 +15,22 @@ import shutil
 
 import pytest
 
-from topix.mini_app.compile import compile_mini_app_source
+from topix.mini_app.compile import _COMPILER_SCRIPT, compile_mini_app_source
 
-# All tests in this module need a real Node binary + an installed
-# node_modules. Skip cleanly when either is missing so a contributor
-# without the local setup gets a green-by-skip rather than a confusing
-# failure.
+# All tests in this module need a real Node binary AND the compiler's
+# installed node_modules (sucrase). Skip cleanly when either is missing
+# so a contributor without the local setup gets a green-by-skip rather
+# than a confusing `subprocess_failure` from an ERR_MODULE_NOT_FOUND.
+# CI / the Dockerfile install the deps; locally run `make
+# setup-mini-app-compiler` (or `npm ci` in that dir).
+_NODE_MISSING = shutil.which("node") is None
+_DEPS_MISSING = not (_COMPILER_SCRIPT.parent / "node_modules").is_dir()
 pytestmark = pytest.mark.skipif(
-    shutil.which("node") is None,
-    reason="`node` not on PATH — mini-app compile bridge cannot run",
+    _NODE_MISSING or _DEPS_MISSING,
+    reason=(
+        "mini-app compile bridge unavailable — needs `node` on PATH and the "
+        "compiler's node_modules (run `make setup-mini-app-compiler`)"
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

Fixes the local-only test failures in `mini_app/test_compile.py` (CI was always green). Two parts: an honest skip guard, and a Makefile target so local runs match CI.

## Background

The compile-bridge tests shell out to `node backend/scripts/mini-app-compiler/compile.mjs`, which needs the compiler's `node_modules` (`sucrase`). CI installs them in a dedicated step (`npm ci --omit=dev`) and the Dockerfile does too — but there was **no local equivalent**, and the Makefile didn't install them. On a machine with `node` but without the install, the subprocess hit `ERR_MODULE_NOT_FOUND: sucrase` → `kind="subprocess_failure"` → 13 red tests.

The skip guard was *supposed* to cover this — its docstring says "skip when either [node or node_modules] is missing" — but it only checked `shutil.which("node")`, so a machine with node (but no deps) ran the tests and failed instead of skipping.

## Changes
- **Honest skip guard** ([test_compile.py](backend/test/unit/mini_app/test_compile.py)): also require the compiler's `node_modules` to exist (derived from `_COMPILER_SCRIPT`), so an un-set-up machine gets a clean green-by-skip with a message pointing at the fix.
- **Local parity** ([Makefile](Makefile)): new `make setup-mini-app-compiler` (runs `npm ci --omit=dev` in that dir; idempotent — no-ops when `node_modules` is present; degrades gracefully with a message when `npm` is absent). `test-backend` now depends on it, so `make test-backend` / `make check` install what CI installs and actually exercise the bridge.

## Test plan
- Without deps: compile tests **skip** cleanly (10 skipped) with the new message.
- `make setup-mini-app-compiler` installs sucrase; re-run is a no-op.
- With deps: compile tests **pass** (10 passed).
- `node_modules` confirmed gitignored. ruff clean on the changed test.
