### PR TITLE
📝 docs: note venv rebuild for backend test import errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ GitHub Actions handle the version check, releases, and Docker publishing.
 - Port already in use? Change `API_PORT` or `APP_PORT`.
 - Env change not picked up? Restart backend and frontend after editing `.env`.
 - Want to see the resolved Compose config? `make config`.
+- Backend tests failing with odd import errors (e.g. `cannot import name 'Docstring' from 'griffe'`)? The local `backend/.venv` is stale or half-installed — a plain `uv sync` won't repair a partially-deleted package. Rebuild it: `rm -rf backend/.venv && uv sync --extra dev`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds a Troubleshooting note for a confusing local-only failure: backend tests blowing up with import errors like `cannot import name 'Docstring' from 'griffe'`.

## Background

`make test-backend` runs against `backend/.venv`. If that venv is stale or half-installed (e.g. a package directory left without its `__init__.py`), importing the openai-agents SDK fails on its `griffe`/`griffelib` dependency, producing a wall of collection errors. A plain `uv sync` does **not** fix it — uv sees the dist-info as present and assumes the package is intact. CI is unaffected because it builds a fresh venv every run.

The note documents the fix: `rm -rf backend/.venv && uv sync --extra dev`.

## Change
- One bullet in the README Troubleshooting section. Docs only.
