### PR TITLE
👷 ci(release): default manual bump to patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       bump:
         description: Semantic version bump to apply
         required: true
-        default: minor
+        default: patch
         type: choice
         options:
           - patch


### PR DESCRIPTION
## Summary

Change the manual release workflow's default version bump from `minor` to `patch`.

The `workflow_dispatch` `bump` input now defaults to `patch`, so a no-thought "Run workflow" cuts a patch release; `minor`/`major` stay available in the dropdown. Matches the cadence of most releases (small fixes).
