### PR TITLE
fix(mini-app): allow vite preview to accept Caddy-forwarded Host header

### DIFF
--- a/webui/vite.mini-app.config.ts
+++ b/webui/vite.mini-app.config.ts
@@ -61,6 +61,15 @@ export default defineConfig({
     port: Number(process.env.MINI_APP_PORT) || 5174,
     strictPort: true,
     cors: { origin: "*" },
+    // Accept any Host header. Vite preview defaults to rejecting
+    // unknown Host headers as a defense against DNS rebinding, but the
+    // mini-app runtime sits behind Caddy in prod (mini-app.dim0.net →
+    // 127.0.0.1:5004) — Caddy's reverse_proxy forwards the public
+    // Host header, and the iframe-sandbox + cross-origin + CSP +
+    // frame-ancestors stack is what actually fences off this runtime.
+    // Vite's Host filter adds no security on top of that; without
+    // disabling it, every prod request gets 403'd at this layer.
+    allowedHosts: true,
   },
   build: {
     outDir: path.resolve(__dirname, "dist-mini-app"),


### PR DESCRIPTION
## Summary
- In prod the iframe runtime sits behind Caddy reverse-proxying `mini-app.dim0.net` → `127.0.0.1:5004`. Caddy forwards the public Host header; `vite preview` defaults to rejecting unknown Host values as DNS-rebinding defense, so every prod request was 403'd at the vite layer before reaching the bundle.
- Set `allowedHosts: true` on `vite preview` so Vite accepts whatever Host Caddy forwards. Security stays intact: cross-origin deploy + iframe sandbox + CSP (`connect-src 'none'`, `frame-ancestors https://app.dim0.net`) is what actually fences off this runtime; Vite's Host filter adds nothing on top of that, and anything reaching `:5004` has already passed Caddy.

## Test plan
- [ ] After deploying the new image with `MINI_APP_PORT=5004` and the Caddy block for `mini-app.dim0.net`, `curl -sI https://mini-app.dim0.net/index.html | head -5` returns `HTTP/2 200` (was 403)
- [ ] CSP / CORS / `X-Frame-Options` headers still appear in the response
- [ ] Loading a mini-app note in the host app at `https://app.dim0.net` paints the iframe widget (handshake completes)
- [ ] Local `make build-up` continues to work — iframe still loads at `http://localhost:5004` in dev