### PR TITLE
fix(mini-app): allowlist mini-app.dim0.net in vite preview Host filter

### DIFF
--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -11,8 +11,17 @@ const packageJson = JSON.parse(
 ) as { version?: string }
 const appVersion = packageJson.version ?? "0.0.0"
 const shouldAnalyzeBundle = process.env.ANALYZE === "true"
+// Vite preview Host-header allowlist. Applies to BOTH the host bundle
+// (served at app.dim0.net) AND the mini-app iframe runtime (served at
+// mini-app.dim0.net) — docker-entrypoint.sh runs `vite preview` for
+// each bundle without passing `--config`, so both processes load this
+// single config file and share its `preview.allowedHosts`. Forgetting
+// `mini-app.dim0.net` here makes Caddy → vite reverse-proxy 403 the
+// iframe runtime ("Host not allowed"), while the host bundle keeps
+// working — easy to miss.
 const allowedHosts = [
   "app.dim0.net",
+  "mini-app.dim0.net",
 ]
 
 


### PR DESCRIPTION
## Summary
- The mini-app iframe runtime was 403'ing in prod because `docker-entrypoint.sh` runs `vite preview` for both bundles without `--config`, so both processes share `webui/vite.config.ts` — and the host config's `preview.allowedHosts` only listed `app.dim0.net`, not `mini-app.dim0.net`. Caddy reverse-proxying `mini-app.dim0.net` → :5001 was rejected at vite's Host-header layer.
- Add `mini-app.dim0.net` to the shared allowlist. Comment above the constant explains why both bundles share this list, so the gotcha is documented for the next host added.

The earlier #112 fix in `vite.mini-app.config.ts` didn't take effect because `vite preview` never reads that file — `--config` isn't passed.

## Test plan
- [ ] After deploying the new image, `curl -sI https://mini-app.dim0.net/index.html | head -3` returns `HTTP/2 200` (was 403)
- [ ] Loading a mini-app note in `https://app.dim0.net` paints the iframe widget (handshake completes)
- [ ] Local `make build-up` continues to work — iframe still loads at `http://localhost:5004` in dev

## Follow-up (separate PR)
Architecturally cleaner: pass `--config webui/vite.config.ts` and `--config webui/vite.mini-app.config.ts` per-bundle in the entrypoint so each preview reads its proper config. Today both load the host config — works but conflates concerns. Deferred to avoid mixing infrastructure refactor into a hotfix.