### PR TITLE
fix(mini-app): externalize theme bootstrap so it survives the prod CSP

### DIFF
--- a/webui/mini-app-runtime/index.html
+++ b/webui/mini-app-runtime/index.html
@@ -1,43 +1,35 @@
 <!doctype html>
 <!--
-  Initial theme defaults live on <html> to match where the host writes
-  them (theme-provider.tsx). The inline script below upgrades these
+  Initial theme defaults on <html> match where the host writes them
+  (theme-provider.tsx). `/theme-bootstrap.js` in <head> upgrades these
   from URL query params (`?theme=parchment&mode=dark`) BEFORE any CSS
-  paint, so the iframe boots in the host's active palette without a
-  parchment-light flash. main.tsx then keeps them in sync via the
-  `mini-app:theme` postMessage protocol on live changes.
+  paints, so the iframe boots in the host's active palette without a
+  flash. main.tsx then keeps them in sync via the `mini-app:theme`
+  postMessage protocol on live changes.
+
+  The bootstrap script is external (not inline) so the production CSP
+  `script-src 'self' 'unsafe-eval'` allows it — an inline <script>
+  would be blocked silently and the flash-prevention would regress.
 -->
 <html lang="en" data-theme="parchment" data-mode="light">
-  <script>
-    (function () {
-      try {
-        var p = new URLSearchParams(location.search)
-        var t = p.get("theme")
-        var m = p.get("mode")
-        if (t) document.documentElement.dataset.theme = t
-        if (m === "light" || m === "dark") document.documentElement.dataset.mode = m
-      } catch (_) {
-        // No URL or bad params → fall back to the hardcoded defaults
-        // above. Not worth bailing out of the iframe over.
-      }
-    })()
-  </script>
   <head>
     <meta charset="utf-8" />
     <!--
-      Content Security Policy is intentionally NOT set as a meta-tag.
-      Why: the iframe loads with sandbox="allow-scripts" (no
-      allow-same-origin), giving it an opaque "null" origin. Browsers
-      then refuse to match `'self'` in script-src/style-src against
-      same-host scripts — so a meta-tag CSP with `'self'` blocks
-      everything including main.tsx. The iframe's sandbox attribute is
-      already the load-bearing security boundary; Phase 4 hardening
-      will move CSP to HTTP response headers from the asset host
-      where 'self' isn't ambiguous (production serves from a real
-      origin, not via meta-tag inside a sandboxed document).
+      Content Security Policy is NOT set as a meta-tag — it ships via
+      HTTP response headers from Caddy in production (see
+      mini-app-deploy.md §2). Meta-tag CSPs don't support all
+      directives we need (notably `frame-ancestors`), and the iframe
+      sandbox + cross-origin deploy is what actually fences off the
+      runtime; CSP is the network-layer defense on top of that.
     -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Mini-app runtime</title>
+    <!--
+      Theme bootstrap MUST come before runtime.css so the <html> data
+      attributes are settled before any [data-theme=...] selectors
+      evaluate. Synchronous external script — no async/defer.
+    -->
+    <script src="/theme-bootstrap.js"></script>
     <link rel="stylesheet" href="/runtime.css" />
     <!--
       Runtime config injection — docker-entrypoint.sh generates

--- a/webui/mini-app-runtime/public/theme-bootstrap.js
+++ b/webui/mini-app-runtime/public/theme-bootstrap.js
@@ -1,0 +1,28 @@
+// Theme bootstrap — runs synchronously in <head> before any CSS paints
+// or React mounts. Reads theme + mode from URL query params
+// (`?theme=parchment&mode=dark`) and writes them to <html> dataset
+// attributes so the shared src/index.css theme selectors apply
+// immediately. Without this, the iframe would paint with the
+// hardcoded `<html data-theme="parchment" data-mode="light">` default
+// for a few frames before main.tsx's `mini-app:render` message lands
+// with the host's actual palette — visible flash when the host is in
+// a different theme.
+//
+// Externalized (not inline) because the production CSP from Caddy is
+// `script-src 'self' 'unsafe-eval'` — no `'unsafe-inline'` allowance.
+// An inline <script> would be blocked silently and the flash-prevention
+// silently regresses to the default. Living in /public/ means vite
+// copies this file verbatim to the build output, served from `/self`
+// which the CSP allows.
+(function () {
+  try {
+    var p = new URLSearchParams(location.search)
+    var t = p.get("theme")
+    var m = p.get("mode")
+    if (t) document.documentElement.dataset.theme = t
+    if (m === "light" || m === "dark") document.documentElement.dataset.mode = m
+  } catch (_) {
+    // No URL or bad params → fall back to the hardcoded defaults on
+    // <html>. Not worth bailing out of the iframe over.
+  }
+})()


### PR DESCRIPTION
## Summary
- The URL-param theme bootstrap (set `<html data-theme/data-mode>` from `?theme=…&mode=…` before CSS paints) was inlined into `index.html`. Production CSP from Caddy is `script-src 'self' 'unsafe-eval'` — no `'unsafe-inline'` — so the inline `<script>` was silently blocked, regressing the flash-prevention every time the iframe loaded.
- Move the bootstrap into `mini-app-runtime/public/theme-bootstrap.js`; vite copies the public dir verbatim into `dist-mini-app/`, served from the runtime's own origin which the CSP's `'self'` covers. Reference it from `<head>` with a synchronous external `<script src="/theme-bootstrap.js">` so it still runs before `runtime.css` and before any other module code.

### Drive-by
The previous inline `<script>` sat between `<html>` and `<head>` — invalid HTML; the parser likely moved it to `<body>`, which is too late for theme attributes anyway. Fixed the structure so the bootstrap lives inside `<head>` before the `<link rel="stylesheet">`, where it actually executes before style evaluation.

## Test plan
- [ ] After deploying the new image, open a mini-app in `https://app.dim0.net` — the "Executing inline script violates the following Content Security Policy directive" error in the browser console is gone
- [ ] Theme flash on iframe boot is suppressed when the host is in a non-parchment theme (the URL-param path is active again)
- [ ] CSP header from Caddy is unchanged (still strict, no `'unsafe-inline'` added)
- [ ] `dist-mini-app/theme-bootstrap.js` lands in the build output (confirmed locally — see commit description)