### PR TITLE
🐛 test(collab): run all WS sessions on one event loop (fix intermittent hang)

### DIFF
--- a/backend/test/unit/api/router/test_collab_router.py
+++ b/backend/test/unit/api/router/test_collab_router.py
@@ -1,5 +1,9 @@
 """Router tests for the collab ticket mint endpoint and the WS relay."""
 
+import contextlib
+
+import pytest
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -7,6 +11,30 @@ from topix.api.router.collab import router
 from topix.api.utils.security import get_current_user_uid
 from topix.collab.room import RoomRegistry
 from topix.collab.tickets import mint_ticket
+
+# Every TestClient built in a test must run all its WebSocket sessions on
+# ONE event loop. Starlette's TestClient only shares a single portal
+# (loop + thread) across `websocket_connect` calls when it's entered as a
+# context manager; an un-entered client spins up a fresh portal per
+# connect. Two peers in the same room would then run on different loops
+# and share the room's `asyncio.Lock` across them — and a cross-loop lock
+# wakeup is lost (not thread-safe), intermittently hanging multi-peer
+# tests. This autouse stack enters every client so they share one loop,
+# and tears them down cleanly afterwards. (Production is single-loop, so
+# this only affects the test harness.)
+_active_stack: contextlib.ExitStack | None = None
+
+
+@pytest.fixture(autouse=True)
+def _shared_client_portal():
+    """Scope an ExitStack that `_build_app` enters each TestClient into."""
+    global _active_stack
+    with contextlib.ExitStack() as stack:
+        _active_stack = stack
+        try:
+            yield
+        finally:
+            _active_stack = None
 
 
 class _FakeRedis:
@@ -130,7 +158,11 @@ def _build_app(
         return user_uid
 
     app.dependency_overrides[get_current_user_uid] = _fake_current_user_uid
-    return TestClient(app), app
+    # Enter the client (context-manager mode) so all its WebSocket
+    # sessions share one portal/event loop — see `_shared_client_portal`.
+    assert _active_stack is not None, "_build_app called outside a test"
+    client = _active_stack.enter_context(TestClient(app))
+    return client, app
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the intermittent hang in the collab WebSocket router tests (e.g. `test_ws_malformed_presence_is_rejected_not_relayed`) at the root, rather than just bounding it with a timeout.

## Root cause

The tests built `TestClient(app)` but never entered it as a context manager. Starlette only shares a single portal (one thread + event loop) across `websocket_connect` calls when the client is entered (`with TestClient(app) as client:`); otherwise **each `websocket_connect` spins up its own portal — a separate thread and event loop**.

So two peers in the same room ran their `collab_ws` handlers on **different event loops**, while sharing the same in-memory `Room` and its `asyncio.Lock` (and the registry lock). `asyncio.Lock` is not safe across loops: when the two loops contend for it, the holder (on loop A) wakes the waiter's future (on loop B) with a plain, non-thread-safe `call_soon`, and the wakeup is occasionally lost — so `async with room.lock` never returns, the peer's frame is never relayed, and the test's `receive_*()` waits forever. Intermittent because it only triggers when both loops want the lock at the same instant, which is why only the multi-peer tests were affected.

**Production is unaffected** — the server runs on a single uvicorn event loop, so the room locks are only ever touched from one loop. This was purely a test-harness artifact.

## Fix

An autouse `ExitStack` fixture enters every `TestClient` (`_build_app` registers it), so all sockets in a test share one portal/loop. No cross-loop lock sharing → no lost wakeup → no hang. Minimal touch: the 27 `_build_app` call sites are unchanged.

## Test plan
- Collab suite run 5× consecutively: 26 passed each time (was intermittently hanging).
- Full `test/unit`: 443 passed.
- ruff clean.

## Relation to #108
`pytest-timeout` (#108) converts a residual hang into a 30s failure so CI can't wedge. This PR removes the race itself. Keep both.
