### PR TITLE
fix(collab): persist note label through apply_ops

### DIFF
--- a/backend/test/unit/collab/test_apply_ops.py
+++ b/backend/test/unit/collab/test_apply_ops.py
@@ -744,6 +744,95 @@ async def test_node_update_lifts_phosphor_icon_data_with_color():
     }
 
 
+async def test_node_update_lifts_label_to_patch_dict():
+    """A `node.update` carrying `data.label` lifts to the merged patch.
+
+    Title renames done via the local-store path (sheet-panel.persistTitle
+    and NodeTitleCaption.commitTitle) write to `data.label`. Without
+    this lift the wire op reaches the server but the title never lands
+    in the DB — refresh reverts the rename.
+    """
+    store = _RecordingGraphStore()
+    op = {
+        "type": "node.update",
+        "id": "n1",
+        "patch": {"data": {"label": {"markdown": "Daily standup"}}},
+        "prev": {},
+    }
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    assert store.patch_calls[0]["data"]["label"] == {"markdown": "Daily standup"}
+
+
+async def test_node_update_label_cleared_with_explicit_null():
+    """An explicit `data.label: null` clears the title via deep-merge."""
+    store = _RecordingGraphStore()
+    op = {
+        "type": "node.update",
+        "id": "n1",
+        "patch": {"data": {"label": None}},
+        "prev": {},
+    }
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    assert store.patch_calls[0]["data"]["label"] is None
+
+
+async def test_node_update_label_ignored_when_markdown_missing():
+    """A malformed `data.label` (no markdown string) is silently skipped.
+
+    Defensive: a malformed peer could ship `data.label: {}` and we'd
+    rather keep the existing title than wipe it with a bad payload.
+    The op carries an unrelated field (`x`) so the patch still fires
+    and we can assert the absence of `label` in the resulting dict.
+    """
+    store = _RecordingGraphStore()
+    op = {
+        "type": "node.update",
+        "id": "n1",
+        "patch": {"x": 100, "data": {"label": {"foo": "bar"}}},
+        "prev": {},
+    }
+
+    await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    assert "label" not in store.patch_calls[0]["data"]
+
+
+async def test_node_add_persists_label_from_data():
+    """A `node.add` op with `data.label` keeps the title on the new Note.
+
+    Mirror of the icon-name lift on the add path: without this, a newly
+    created sheet's title isn't surfaced to the server and reload shows
+    "Untitled".
+    """
+    store = _RecordingGraphStore()
+    op = {
+        "type": "node.add",
+        "node": {
+            "id": "n1",
+            "x": 0, "y": 0, "w": 320, "h": 200, "z": 0,
+            "angle": 0,
+            "type": "sheet",
+            "data": {
+                "noteType": "note",
+                "styleType": "sheet",
+                "version": 1,
+                "label": {"markdown": "Welcome"},
+            },
+        },
+    }
+
+    results = await apply_batch(graph_store=store, board_id="b1", user_id="u1", ops=[op])
+
+    assert results[0].applied is True
+    [note] = store.add_notes_calls[0]
+    assert note.label is not None
+    assert note.label.markdown == "Welcome"
+
+
 async def test_node_update_phosphor_icon_with_css_var_color():
     """The CSS-var color form (`var(--color-foreground)`) round-trips as-is.
 

--- a/backend/topix/collab/apply_ops.py
+++ b/backend/topix/collab/apply_ops.py
@@ -338,6 +338,21 @@ def _node_patch_to_note_data(patch: dict[str, Any]) -> dict[str, Any]:  # noqa: 
             data["parent_id"] = wire_data["parentId"]
         if "graphUid" in wire_data:
             data["graph_uid"] = wire_data["graphUid"]
+        # `data.label = {markdown: "..."}` carries title renames done via
+        # the local-store path (sheet-panel `persistTitle` and the canvas
+        # `NodeTitleCaption` both write `data.label`). Without this lift
+        # the wire op reaches the server but `patch_notes`'s deep-merge
+        # never sees the field — DB title stays at the old value and
+        # refresh reverts the rename. Explicit `None` clears the title
+        # so a "clear name" op works symmetrically.
+        if "label" in wire_data:
+            label_value = wire_data["label"]
+            if isinstance(label_value, dict):
+                markdown = label_value.get("markdown")
+                if isinstance(markdown, str):
+                    data["label"] = {"markdown": markdown}
+            elif label_value is None:
+                data["label"] = None
 
     return data
 
@@ -395,6 +410,15 @@ def _wire_node_to_note(node: dict[str, Any], *, board_id: str) -> Note | None:  
     }
     if "content" in node:
         note_dict["content"] = {"markdown": str(node["content"] or "")}
+
+    # `data.label` carries the title for newly-created notes. Same lift
+    # as `_node_patch_to_note_data` (which handles renames); without it
+    # an add op never persists the title and refresh shows "Untitled".
+    label_value = data_field.get("label")
+    if isinstance(label_value, dict):
+        markdown = label_value.get("markdown")
+        if isinstance(markdown, str):
+            note_dict["label"] = {"markdown": markdown}
 
     # Prefer `data.styleType` (the Dim0 enum value the client embeds for
     # round-trip fidelity). Fall back to translating the wire `type`


### PR DESCRIPTION
## Summary

- `_node_patch_to_note_data` was lifting `data.properties`, `data.parentId`, and `data.graphUid` from the wire patch but **never `data.label`**. Title renames done via the local-store path (sheet-panel `persistTitle` + canvas `NodeTitleCaption.commitTitle`) reached the server, but the field was silently dropped — `patch_notes`'s deep-merge never saw it, so the DB row kept the old title and refresh reverted the rename.
- Mirror lift on the `node.add` path (`_wire_node_to_note`) so newly created sheets also persist their initial title.
- Explicit `None` clears the title via deep-merge; malformed `label` payloads (no markdown string) are silently skipped to avoid a bad peer wiping an existing title.

## Why the sidebar wasn't auto-updating either

The optimistic `setQueriesData` patches for `boardContents` (in `persistTitle` and `commitTitle`) already wrote the new label into cache the moment a rename committed. But any subsequent refetch — tab focus, navigation, or a `staleTime` expiry — returned the stale label from the server (because of the bug above) and overwrote the optimistic value. With the backend lift in place, refetches return the new title and the sidebar's optimistic value stops being clobbered.

## Test plan

- [x] `pytest test/unit/collab/test_apply_ops.py` — 4 new tests:
  - `test_node_update_lifts_label_to_patch_dict` — happy-path rename via WS
  - `test_node_update_label_cleared_with_explicit_null` — explicit `None` clears
  - `test_node_update_label_ignored_when_markdown_missing` — malformed label is silently skipped (other fields in the same patch still apply)
  - `test_node_add_persists_label_from_data` — new sheets keep their initial title
- [x] `pytest test/unit/collab test/unit/api/router/test_boards_contents_router.py test/unit/datatypes/test_property.py` — 71 passed, no regressions in adjacent suites
- [ ] Manual smoke: rename a sheet via the editor modal, refresh → title sticks; rename via the canvas title caption, refresh → title sticks; sidebar shows the new title without a flicker-revert