### PR TITLE
feat: decorative textures for empty board, canvas, and auth

### DIFF
--- a/webui/src/features/board/components/flow/floating-assistant/floating-island.tsx
+++ b/webui/src/features/board/components/flow/floating-assistant/floating-island.tsx
@@ -58,7 +58,7 @@ export const FloatingIsland = ({ boardId, onOpenFullSheet }: FloatingIslandProps
   }
 
   return (
-    <div className='absolute bottom-1 left-1/2 -translate-x-1/2 z-[60] w-[min(580px,calc(100vw-4rem))] pointer-events-auto hidden md:flex flex-col gap-1.5'>
+    <div data-coachmark='ai-island' className='absolute bottom-1 left-1/2 -translate-x-1/2 z-[60] w-[min(580px,calc(100vw-4rem))] pointer-events-auto hidden md:flex flex-col gap-1.5'>
       <div className={cn(
         "bg-sidebar/80 backdrop-blur-md backdrop-saturate-150",
         "border rounded-2xl flex flex-col",

--- a/webui/src/features/board/components/folder-breadcrumb.tsx
+++ b/webui/src/features/board/components/folder-breadcrumb.tsx
@@ -58,6 +58,7 @@ export function FolderBreadcrumb({
             variant="ghost"
             size="sm"
             className="h-auto max-w-[200px] truncate px-0 text-sm font-normal hover:underline"
+            data-coachmark="title"
             title={boardLabel}
             onClick={() =>
               navigate({

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -345,6 +345,13 @@ function HarnessCanvasInner({
             onDoubleClick={onDoubleClick}
             onRenderer={onRenderer}
           />
+          {/*
+            Paper grain over the canvas surface: sits above the drawn
+            scene (z-index 1) but below all chrome (z-50+), pointer-events
+            none so it never intercepts interaction. Hidden while
+            presenting for clean slides.
+          */}
+          {!presenting && <div className="board-paper-grain" aria-hidden="true" />}
           {!presenting && (
             <Minimap
               width={200}

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/sheet"
 import {
   CanvasContextMenu,
+  EmptyBoardCoachmarks,
   HarnessCollabStatus,
   HarnessPeerChip,
   HarnessReadonlyChip,
@@ -278,6 +279,7 @@ export function HarnessCanvas() {
           <HarnessCanvasInner
             theme={theme}
             tool={tool}
+            ready={ready}
             viewMode={viewMode}
             arrowDefaults={arrowDefaults}
             onCreateDrag={handleCreateDrag}
@@ -298,6 +300,7 @@ export function HarnessCanvas() {
 type InnerProps = {
   theme: ReturnType<typeof useBoardTheme>
   tool: string
+  ready: boolean
   viewMode: "board" | "files" | "list"
   arrowDefaults: ArrowToolDefaults
   onCreateDrag: ReturnType<typeof useCreateHandlers>["handleCreateDrag"]
@@ -310,6 +313,7 @@ type InnerProps = {
 function HarnessCanvasInner({
   theme,
   tool,
+  ready,
   viewMode,
   arrowDefaults,
   onCreateDrag,
@@ -362,6 +366,7 @@ function HarnessCanvasInner({
           {!presenting && <HarnessViewportControls />}
           <StyleSidebar />
           <RemoteCursors />
+          <EmptyBoardCoachmarks ready={ready} />
         </>
       ) : viewMode === "files" ? (
         <LinearView />

--- a/webui/src/features/board/harness/chrome/empty-board-coachmarks.css
+++ b/webui/src/features/board/harness/chrome/empty-board-coachmarks.css
@@ -1,0 +1,61 @@
+/*
+ * Empty-board coachmark overlay. A purely decorative onboarding layer
+ * shown only while the canvas has no nodes/edges. Mirrors the dim0
+ * landing-page graph aesthetic (sticky notes, dashed idea bubbles,
+ * mono chips, dots) with a gentle drift and curved connectors that
+ * point at the real board chrome.
+ */
+
+.coachmark-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  overflow: hidden;
+  /* Fade the whole layer in once mounted; it unmounts the instant the
+     board stops being empty (first node/edge created). */
+  animation: coachmark-fade-in 600ms ease both;
+}
+
+.coachmark-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  will-change: transform;
+  user-select: none;
+}
+
+/* Each node drifts on its own slow loop; per-node delay/duration are
+   set inline so the field never pulses in unison. */
+.coachmark-float {
+  animation-name: coachmark-float;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+}
+
+@keyframes coachmark-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes coachmark-float {
+  from {
+    transform: translate(-50%, -50%) translateY(-5px);
+  }
+  to {
+    transform: translate(-50%, -50%) translateY(5px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .coachmark-layer {
+    animation: none;
+  }
+  .coachmark-float {
+    animation: none;
+  }
+}

--- a/webui/src/features/board/harness/chrome/empty-board-coachmarks.test.tsx
+++ b/webui/src/features/board/harness/chrome/empty-board-coachmarks.test.tsx
@@ -1,0 +1,159 @@
+// Tests for the empty-board coachmark overlay.
+//
+// The harness has no @testing-library/react dependency; we mount with
+// vanilla `react-dom/client` against jsdom, wrapped in `act` so effects
+// (anchor measurement) flush before assertions.
+//
+// `useNodes`/`useEdges` and the board-app-store are mocked via hoisted
+// mutable state so each test can dial the gate inputs (empty? editable?
+// presenting?) and the set of chrome anchors present in the DOM.
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+
+const hooks = vi.hoisted(() => ({
+  nodes: [] as unknown[],
+  edges: [] as unknown[],
+}))
+
+const store = vi.hoisted(() => ({
+  canEdit: true,
+  presentationMode: false,
+}))
+
+vi.mock("@canvas-harness/react", () => ({
+  useNodes: () => hooks.nodes,
+  useEdges: () => hooks.edges,
+}))
+
+vi.mock("../store/board-app-store", () => ({
+  useBoardAppStore: (selector: (s: typeof store) => unknown) => selector(store),
+}))
+
+
+import { EmptyBoardCoachmarks } from "./empty-board-coachmarks"
+
+
+const ANCHOR_KEYS = ["title", "toolbar", "share", "ai-island"] as const
+
+
+/** Drop a tagged stand-in for each named piece of chrome so the overlay
+ *  can find anchors via `[data-coachmark="..."]`. */
+function mountAnchors(keys: readonly string[]): HTMLElement[] {
+  return keys.map((key) => {
+    const el = document.createElement("div")
+    el.setAttribute("data-coachmark", key)
+    document.body.appendChild(el)
+    return el
+  })
+}
+
+
+describe("EmptyBoardCoachmarks", () => {
+  let container: HTMLDivElement
+  let root: Root
+  let originalWidth: number
+
+
+  beforeEach(() => {
+    hooks.nodes = []
+    hooks.edges = []
+    store.canEdit = true
+    store.presentationMode = false
+    originalWidth = window.innerWidth
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    document.querySelectorAll("[data-coachmark]").forEach((el) => el.remove())
+    window.innerWidth = originalWidth
+  })
+
+
+  function render(ready: boolean) {
+    act(() => {
+      root.render(<EmptyBoardCoachmarks ready={ready} />)
+    })
+  }
+
+
+  it("shows the layer on a ready, empty, editable board", () => {
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).not.toBeNull()
+  })
+
+
+  it("stays hidden until hydration is ready", () => {
+    mountAnchors(ANCHOR_KEYS)
+    render(false)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("stays hidden once the board has any node", () => {
+    hooks.nodes = [{ id: "n1" }]
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("stays hidden once the board has any edge", () => {
+    hooks.edges = [{ id: "e1" }]
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("stays hidden for a read-only viewer", () => {
+    store.canEdit = false
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("stays hidden in presentation mode", () => {
+    store.presentationMode = true
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("stays hidden on narrow (mobile) viewports", () => {
+    window.innerWidth = 500
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    expect(container.querySelector(".coachmark-layer")).toBeNull()
+  })
+
+
+  it("draws one connector per chrome anchor present in the DOM", () => {
+    mountAnchors(ANCHOR_KEYS)
+    render(true)
+    // Each Connector renders a single <g> (line + arrowhead); ambient
+    // edges render bare <path>s, so <g> count == resolved callouts.
+    const connectors = container.querySelectorAll(".coachmark-layer svg g")
+    expect(connectors.length).toBe(ANCHOR_KEYS.length)
+  })
+
+
+  it("skips callouts whose anchor is absent (e.g. Share hidden for non-owners)", () => {
+    mountAnchors(["title", "toolbar", "ai-island"])
+    render(true)
+    const connectors = container.querySelectorAll(".coachmark-layer svg g")
+    expect(connectors.length).toBe(3)
+  })
+})

--- a/webui/src/features/board/harness/chrome/empty-board-coachmarks.tsx
+++ b/webui/src/features/board/harness/chrome/empty-board-coachmarks.tsx
@@ -1,0 +1,391 @@
+import { type CSSProperties, useEffect, useMemo, useState } from "react"
+import { useEdges, useNodes } from "@canvas-harness/react"
+
+import { useBoardAppStore } from "../store/board-app-store"
+import "./empty-board-coachmarks.css"
+
+
+type AnchorKey = "title" | "toolbar" | "share" | "ai-island"
+
+type NodeKind = "note" | "idea" | "chip" | "dot"
+
+type Point = { x: number; y: number }
+
+
+/** The four chrome targets a callout can point at, keyed by their
+ *  `data-coachmark` attribute. */
+const ANCHOR_KEYS: AnchorKey[] = ["title", "toolbar", "share", "ai-island"]
+
+const SIDEBAR_COLORS = [
+  "var(--sidebar-icon-1)",
+  "var(--sidebar-icon-2)",
+  "var(--sidebar-icon-3)",
+  "var(--sidebar-icon-4)",
+]
+
+
+type Callout = {
+  anchor: AnchorKey
+  label: string
+  color: string
+  // Which side of the anchor the bubble floats on, so the connector
+  // curves away from the chrome instead of across it.
+  side: "below" | "above"
+  // Bubble offset from the anchor's connect edge, in px.
+  dx: number
+  dy: number
+}
+
+
+const CALLOUTS: Callout[] = [
+  { anchor: "title", label: "name your\ncanvas", color: SIDEBAR_COLORS[1], side: "below", dx: 18, dy: 70 },
+  { anchor: "toolbar", label: "tools to\nbuild", color: SIDEBAR_COLORS[0], side: "below", dx: 6, dy: 84 },
+  { anchor: "share", label: "share &\ninvite", color: SIDEBAR_COLORS[2], side: "below", dx: -14, dy: 70 },
+  { anchor: "ai-island", label: "or ask the\nAI agent", color: SIDEBAR_COLORS[3], side: "above", dx: 0, dy: -96 },
+]
+
+
+type Ambient = {
+  kind: NodeKind
+  color: string
+  label: string
+  // Fractional position inside the safe canvas region (0..1).
+  fx: number
+  fy: number
+}
+
+
+const AMBIENT: Ambient[] = [
+  { kind: "note", color: SIDEBAR_COLORS[0], label: "ideas", fx: 0.15, fy: 0.34 },
+  { kind: "chip", color: SIDEBAR_COLORS[2], label: "#topic", fx: 0.28, fy: 0.66 },
+  { kind: "dot", color: SIDEBAR_COLORS[1], label: "", fx: 0.21, fy: 0.5 },
+  { kind: "idea", color: SIDEBAR_COLORS[0], label: "a hunch", fx: 0.8, fy: 0.36 },
+  { kind: "note", color: SIDEBAR_COLORS[3], label: "notes", fx: 0.86, fy: 0.62 },
+  { kind: "dot", color: SIDEBAR_COLORS[2], label: "", fx: 0.72, fy: 0.52 },
+  { kind: "chip", color: SIDEBAR_COLORS[1], label: "#link", fx: 0.52, fy: 0.82 },
+  { kind: "note", color: SIDEBAR_COLORS[1], label: "to-do", fx: 0.62, fy: 0.2 },
+  { kind: "dot", color: SIDEBAR_COLORS[0], label: "", fx: 0.4, fy: 0.18 },
+]
+
+
+// Sparse links between ambient nodes, by index — just enough to read as
+// a graph rather than scattered confetti.
+const AMBIENT_EDGES: [number, number][] = [
+  [0, 2],
+  [2, 1],
+  [3, 5],
+  [5, 4],
+  [8, 0],
+  [7, 6],
+]
+
+const MOBILE_BREAKPOINT = 768
+
+
+/**
+ * Decorative onboarding overlay for an empty board. Renders the dim0
+ * landing-page graph aesthetic (sticky notes, dashed idea bubbles, mono
+ * chips, dots) with a gentle drift, plus four labelled callouts whose
+ * connectors point at the real board chrome (title, toolbar, share, AI
+ * island). Mounts only while the canvas is empty and editable; the first
+ * node or edge created unmounts it.
+ */
+export function EmptyBoardCoachmarks({ ready }: { ready: boolean }) {
+  const canEdit = useBoardAppStore((s) => s.canEdit)
+  const presentationMode = useBoardAppStore((s) => s.presentationMode)
+  const nodes = useNodes()
+  const edges = useEdges()
+  const isEmpty = nodes.length === 0 && edges.length === 0
+  const show = ready && canEdit && !presentationMode && isEmpty
+
+  const [vp, setVp] = useState<{ w: number; h: number }>(() => ({
+    w: typeof window === "undefined" ? 1280 : window.innerWidth,
+    h: typeof window === "undefined" ? 800 : window.innerHeight,
+  }))
+  const [anchors, setAnchors] = useState<Partial<Record<AnchorKey, DOMRect>>>({})
+
+  // Measure the viewport + chrome anchors. Chrome can mount a frame
+  // after us, so we re-measure on a couple of animation frames as well
+  // as on resize.
+  useEffect(() => {
+    if (!show) return
+    const measure = () => {
+      setVp({ w: window.innerWidth, h: window.innerHeight })
+      const next: Partial<Record<AnchorKey, DOMRect>> = {}
+      for (const key of ANCHOR_KEYS) {
+        const el = document.querySelector(`[data-coachmark="${key}"]`)
+        if (el) next[key] = el.getBoundingClientRect()
+      }
+      setAnchors(next)
+    }
+    measure()
+    const r1 = requestAnimationFrame(measure)
+    const r2 = requestAnimationFrame(() => requestAnimationFrame(measure))
+    window.addEventListener("resize", measure)
+    return () => {
+      cancelAnimationFrame(r1)
+      cancelAnimationFrame(r2)
+      window.removeEventListener("resize", measure)
+    }
+  }, [show])
+
+  // Safe region for ambient nodes: inset from edges, clear of the top
+  // chrome row and the bottom AI island.
+  const region = useMemo(() => {
+    const left = 28
+    const right = vp.w - 28
+    const top = 84
+    const bottom = vp.h - 128
+    return { left, right, top, bottom }
+  }, [vp])
+
+  const ambientPoints = useMemo(
+    () =>
+      AMBIENT.map((a) => ({
+        ...a,
+        x: region.left + a.fx * (region.right - region.left),
+        y: region.top + a.fy * (region.bottom - region.top),
+      })),
+    [region],
+  )
+
+  if (!show) return null
+  if (vp.w < MOBILE_BREAKPOINT) return null
+
+  const connectors = CALLOUTS.map((c) => {
+    const rect = anchors[c.anchor]
+    if (!rect) return null
+    const cx = rect.left + rect.width / 2
+    const connect: Point =
+      c.side === "below"
+        ? { x: cx, y: rect.bottom + 4 }
+        : { x: cx, y: rect.top - 4 }
+    const bubble: Point =
+      c.side === "below"
+        ? { x: cx + c.dx, y: rect.bottom + c.dy }
+        : { x: cx + c.dx, y: rect.top + c.dy }
+    return { callout: c, connect, bubble }
+  }).filter((v): v is { callout: Callout; connect: Point; bubble: Point } => v !== null)
+
+  return (
+    <div className="coachmark-layer" aria-hidden="true">
+      <svg
+        width={vp.w}
+        height={vp.h}
+        style={{ position: "absolute", inset: 0 }}
+      >
+        {AMBIENT_EDGES.map(([a, b], i) => {
+          const p1 = ambientPoints[a]
+          const p2 = ambientPoints[b]
+          if (!p1 || !p2) return null
+          return (
+            <path
+              key={`ae-${i}`}
+              d={wobblePath(p1, p2, (a + b) * 1.3)}
+              stroke="var(--muted-foreground)"
+              strokeOpacity={0.28}
+              strokeWidth={1}
+              fill="none"
+              strokeLinecap="round"
+            />
+          )
+        })}
+
+        {connectors.map(({ callout, connect, bubble }) => (
+          <Connector key={`cn-${callout.anchor}`} from={bubble} to={connect} color={callout.color} />
+        ))}
+      </svg>
+
+      {ambientPoints.map((p, i) => (
+        <CoachmarkNode
+          key={`an-${i}`}
+          kind={p.kind}
+          color={p.color}
+          label={p.label}
+          x={p.x}
+          y={p.y}
+          floatSeed={i}
+        />
+      ))}
+
+      {connectors.map(({ callout, bubble }, i) => (
+        <CoachmarkNode
+          key={`cl-${callout.anchor}`}
+          kind="idea"
+          color={callout.color}
+          label={callout.label}
+          x={bubble.x}
+          y={bubble.y}
+          floatSeed={i + 0.5}
+        />
+      ))}
+    </div>
+  )
+}
+
+
+/** Quadratic path between two points with a perpendicular wobble, so
+ *  connectors read as hand-drawn rather than ruler-straight. */
+function wobblePath(p1: Point, p2: Point, phase: number): string {
+  const mx = (p1.x + p2.x) / 2
+  const my = (p1.y + p2.y) / 2
+  const dx = p2.x - p1.x
+  const dy = p2.y - p1.y
+  const len = Math.hypot(dx, dy) || 1
+  const nx = -dy / len
+  const ny = dx / len
+  const wobble = Math.sin(phase) * 12
+  const cpx = mx + nx * wobble
+  const cpy = my + ny * wobble
+  return `M ${p1.x} ${p1.y} Q ${cpx} ${cpy} ${p2.x} ${p2.y}`
+}
+
+
+/** A curved connector from a callout bubble to a chrome anchor, capped
+ *  with a small arrowhead at the anchor end. */
+function Connector({ from, to, color }: { from: Point; to: Point; color: string }) {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const len = Math.hypot(dx, dy) || 1
+  const ux = dx / len
+  const uy = dy / len
+  const size = 7
+  // Two barbs rotated ~30° off the incoming direction.
+  const left = {
+    x: to.x - ux * size - uy * size * 0.6,
+    y: to.y - uy * size + ux * size * 0.6,
+  }
+  const right = {
+    x: to.x - ux * size + uy * size * 0.6,
+    y: to.y - uy * size - ux * size * 0.6,
+  }
+  return (
+    <g>
+      <path
+        d={wobblePath(from, to, (from.x + to.y) * 0.01)}
+        stroke={color}
+        strokeOpacity={0.5}
+        strokeWidth={1.5}
+        fill="none"
+        strokeLinecap="round"
+      />
+      <path
+        d={`M ${left.x} ${left.y} L ${to.x} ${to.y} L ${right.x} ${right.y}`}
+        stroke={color}
+        strokeOpacity={0.6}
+        strokeWidth={1.5}
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  )
+}
+
+
+type CoachmarkNodeProps = {
+  kind: NodeKind
+  color: string
+  label: string
+  x: number
+  y: number
+  floatSeed: number
+}
+
+
+/** One decorative node. Visual archetypes mirror the landing-page graph;
+ *  each drifts on its own slow, staggered loop. */
+function CoachmarkNode({ kind, color, label, x, y, floatSeed }: CoachmarkNodeProps) {
+  const floatStyle: CSSProperties = {
+    left: x,
+    top: y,
+    animationDuration: `${5 + (floatSeed % 4)}s`,
+    animationDelay: `${(floatSeed % 5) * -0.7}s`,
+  }
+
+  if (kind === "dot") {
+    return (
+      <div
+        className="coachmark-node coachmark-float"
+        style={{
+          ...floatStyle,
+          width: 9,
+          height: 9,
+          borderRadius: "50%",
+          background: color,
+          opacity: 0.62,
+        }}
+      />
+    )
+  }
+
+  if (kind === "chip") {
+    return (
+      <div
+        className="coachmark-node coachmark-float"
+        style={{
+          ...floatStyle,
+          padding: "4px 10px",
+          borderRadius: 999,
+          background: `color-mix(in oklab, ${color} 18%, var(--card))`,
+          color,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          border: `1px solid color-mix(in oklab, ${color} 44%, var(--border))`,
+          opacity: 0.8,
+        }}
+      >
+        {label}
+      </div>
+    )
+  }
+
+  if (kind === "idea") {
+    return (
+      <div
+        className="coachmark-node coachmark-float"
+        style={{
+          ...floatStyle,
+          padding: "9px 15px",
+          borderRadius: 999,
+          background: "var(--card)",
+          border: `1.5px dashed ${color}`,
+          boxShadow: "var(--shadow-sm)",
+          fontFamily: "var(--font-handwriting)",
+          fontSize: 14,
+          lineHeight: 1.15,
+          textAlign: "center",
+          whiteSpace: "pre-line",
+          color,
+          opacity: 0.92,
+        }}
+      >
+        {label}
+      </div>
+    )
+  }
+
+  // note (sticky paper)
+  return (
+    <div
+      className="coachmark-node coachmark-float"
+      style={{
+        ...floatStyle,
+        minWidth: 78,
+        borderRadius: 6,
+        background: `color-mix(in oklab, ${color} 24%, var(--card))`,
+        border: `1px solid color-mix(in oklab, ${color} 50%, transparent)`,
+        boxShadow: "0 4px 10px -4px hsl(32 28% 30% / 0.18)",
+        padding: "8px 10px",
+        fontFamily: "var(--font-handwriting)",
+        fontSize: 12,
+        lineHeight: 1.25,
+        whiteSpace: "pre-line",
+        color,
+        opacity: 0.85,
+      }}
+    >
+      {label}
+    </div>
+  )
+}

--- a/webui/src/features/board/harness/chrome/index.ts
+++ b/webui/src/features/board/harness/chrome/index.ts
@@ -1,5 +1,6 @@
 export { CanvasContextMenu } from "./canvas-context-menu"
 export { HarnessCollabStatus } from "./collab-status"
+export { EmptyBoardCoachmarks } from "./empty-board-coachmarks"
 export { HarnessPeerChip } from "./peer-chip"
 export { HarnessReadonlyChip } from "./readonly-chip"
 export { NodeSurfaceHost } from "./node-surface-host"

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -126,6 +126,7 @@ export function HarnessToolbar() {
       )}
       role="toolbar"
       aria-label="Board toolbar"
+      data-coachmark="toolbar"
     >
       <DropdownMenu>
         <Tooltip>

--- a/webui/src/features/sharing/share-button.tsx
+++ b/webui/src/features/sharing/share-button.tsx
@@ -32,6 +32,7 @@ export function ShareButton() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label="Share this board"
+        data-coachmark="share"
         className={
           "flex items-center gap-1.5 rounded-md px-1.5 py-1 " +
           "text-xs font-medium text-card-foreground " +

--- a/webui/src/features/signin/components/auth-graph-texture.css
+++ b/webui/src/features/signin/components/auth-graph-texture.css
@@ -1,0 +1,56 @@
+/*
+ * Decorative graph texture for the auth screens. Purely ambient — a
+ * sparse scatter of notes / idea-bubbles / chips / dots with wobbly
+ * connectors and a gentle drift, layered over the dot grid. Mirrors the
+ * dim0 landing-page / board aesthetic. Non-interactive; never competes
+ * with the sign-in card.
+ */
+
+.auth-graph {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  animation: auth-graph-fade-in 800ms ease both;
+}
+
+.auth-graph-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  will-change: transform;
+  user-select: none;
+}
+
+.auth-graph-float {
+  animation-name: auth-graph-float;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+}
+
+@keyframes auth-graph-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes auth-graph-float {
+  from {
+    transform: translate(-50%, -50%) translateY(-5px);
+  }
+  to {
+    transform: translate(-50%, -50%) translateY(5px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .auth-graph {
+    animation: none;
+  }
+  .auth-graph-float {
+    animation: none;
+  }
+}

--- a/webui/src/features/signin/components/auth-graph-texture.tsx
+++ b/webui/src/features/signin/components/auth-graph-texture.tsx
@@ -1,0 +1,246 @@
+import { type CSSProperties, useEffect, useMemo, useState } from "react"
+
+import "./auth-graph-texture.css"
+
+
+type NodeKind = "note" | "idea" | "chip" | "dot"
+
+type Point = { x: number; y: number }
+
+
+const COLORS = [
+  "var(--sidebar-icon-1)",
+  "var(--sidebar-icon-2)",
+  "var(--sidebar-icon-3)",
+  "var(--sidebar-icon-4)",
+]
+
+
+type AmbientNode = {
+  kind: NodeKind
+  color: string
+  label: string
+  // Fractional position across the viewport (0..1). Positions hug the
+  // edges and leave the centre clear for the auth card.
+  fx: number
+  fy: number
+}
+
+
+const NODES: AmbientNode[] = [
+  { kind: "note", color: COLORS[0], label: "ideas", fx: 0.12, fy: 0.22 },
+  { kind: "dot", color: COLORS[1], label: "", fx: 0.07, fy: 0.48 },
+  { kind: "chip", color: COLORS[2], label: "#focus", fx: 0.19, fy: 0.72 },
+  { kind: "note", color: COLORS[1], label: "to-do", fx: 0.15, fy: 0.88 },
+  { kind: "idea", color: COLORS[0], label: "a spark", fx: 0.85, fy: 0.26 },
+  { kind: "dot", color: COLORS[2], label: "", fx: 0.74, fy: 0.5 },
+  { kind: "note", color: COLORS[3], label: "notes", fx: 0.9, fy: 0.64 },
+  { kind: "chip", color: COLORS[1], label: "#flow", fx: 0.82, fy: 0.86 },
+  { kind: "dot", color: COLORS[0], label: "", fx: 0.5, fy: 0.1 },
+  { kind: "idea", color: COLORS[2], label: "connect", fx: 0.52, fy: 0.9 },
+]
+
+
+// Sparse links between nearby nodes, by index.
+const EDGES: [number, number][] = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [4, 5],
+  [5, 6],
+  [6, 7],
+]
+
+const MOBILE_BREAKPOINT = 768
+
+
+/**
+ * Ambient decorative graph for the auth screens. Renders a sparse field
+ * of drifting nodes + wobbly connectors over the dot grid. No state
+ * coupling and no anchoring — pure texture. Hidden on narrow viewports
+ * where the card dominates.
+ */
+export function AuthGraphTexture() {
+  const [vp, setVp] = useState<{ w: number; h: number }>(() => ({
+    w: typeof window === "undefined" ? 1280 : window.innerWidth,
+    h: typeof window === "undefined" ? 800 : window.innerHeight,
+  }))
+
+  useEffect(() => {
+    const measure = () => setVp({ w: window.innerWidth, h: window.innerHeight })
+    measure()
+    window.addEventListener("resize", measure)
+    return () => window.removeEventListener("resize", measure)
+  }, [])
+
+  // Inset the field slightly from the viewport edges so nothing clips.
+  const points = useMemo<(AmbientNode & Point)[]>(() => {
+    const pad = 36
+    const left = pad
+    const right = vp.w - pad
+    const top = pad
+    const bottom = vp.h - pad
+    return NODES.map((n) => ({
+      ...n,
+      x: left + n.fx * (right - left),
+      y: top + n.fy * (bottom - top),
+    }))
+  }, [vp])
+
+  if (vp.w < MOBILE_BREAKPOINT) return null
+
+  return (
+    <div className="auth-graph" aria-hidden="true">
+      <svg width={vp.w} height={vp.h} style={{ position: "absolute", inset: 0 }}>
+        {EDGES.map(([a, b], i) => {
+          const p1 = points[a]
+          const p2 = points[b]
+          if (!p1 || !p2) return null
+          return (
+            <path
+              key={`e-${i}`}
+              d={wobblePath(p1, p2, (a + b) * 1.3)}
+              stroke="var(--muted-foreground)"
+              strokeOpacity={0.26}
+              strokeWidth={1}
+              fill="none"
+              strokeLinecap="round"
+            />
+          )
+        })}
+      </svg>
+
+      {points.map((p, i) => (
+        <AuthGraphNode
+          key={`n-${i}`}
+          kind={p.kind}
+          color={p.color}
+          label={p.label}
+          x={p.x}
+          y={p.y}
+          floatSeed={i}
+        />
+      ))}
+    </div>
+  )
+}
+
+
+/** Quadratic path between two points with a perpendicular wobble, so
+ *  connectors read as hand-drawn rather than ruler-straight. */
+function wobblePath(p1: Point, p2: Point, phase: number): string {
+  const mx = (p1.x + p2.x) / 2
+  const my = (p1.y + p2.y) / 2
+  const dx = p2.x - p1.x
+  const dy = p2.y - p1.y
+  const len = Math.hypot(dx, dy) || 1
+  const nx = -dy / len
+  const ny = dx / len
+  const wobble = Math.sin(phase) * 12
+  const cpx = mx + nx * wobble
+  const cpy = my + ny * wobble
+  return `M ${p1.x} ${p1.y} Q ${cpx} ${cpy} ${p2.x} ${p2.y}`
+}
+
+
+type AuthGraphNodeProps = {
+  kind: NodeKind
+  color: string
+  label: string
+  x: number
+  y: number
+  floatSeed: number
+}
+
+
+/** One decorative node. Archetypes mirror the landing-page graph; each
+ *  drifts on its own slow, staggered loop. */
+function AuthGraphNode({ kind, color, label, x, y, floatSeed }: AuthGraphNodeProps) {
+  const floatStyle: CSSProperties = {
+    left: x,
+    top: y,
+    animationDuration: `${6 + (floatSeed % 4)}s`,
+    animationDelay: `${(floatSeed % 5) * -0.7}s`,
+  }
+
+  if (kind === "dot") {
+    return (
+      <div
+        className="auth-graph-node auth-graph-float"
+        style={{
+          ...floatStyle,
+          width: 9,
+          height: 9,
+          borderRadius: "50%",
+          background: color,
+          opacity: 0.5,
+        }}
+      />
+    )
+  }
+
+  if (kind === "chip") {
+    return (
+      <div
+        className="auth-graph-node auth-graph-float"
+        style={{
+          ...floatStyle,
+          padding: "4px 10px",
+          borderRadius: 999,
+          background: `color-mix(in oklab, ${color} 16%, var(--card))`,
+          color,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          border: `1px solid color-mix(in oklab, ${color} 40%, var(--border))`,
+          opacity: 0.7,
+        }}
+      >
+        {label}
+      </div>
+    )
+  }
+
+  if (kind === "idea") {
+    return (
+      <div
+        className="auth-graph-node auth-graph-float"
+        style={{
+          ...floatStyle,
+          padding: "9px 15px",
+          borderRadius: 999,
+          background: "var(--card)",
+          border: `1.5px dashed ${color}`,
+          boxShadow: "var(--shadow-sm)",
+          fontFamily: "var(--font-handwriting)",
+          fontSize: 14,
+          color,
+          opacity: 0.82,
+        }}
+      >
+        {label}
+      </div>
+    )
+  }
+
+  // note (sticky paper)
+  return (
+    <div
+      className="auth-graph-node auth-graph-float"
+      style={{
+        ...floatStyle,
+        minWidth: 70,
+        borderRadius: 6,
+        background: `color-mix(in oklab, ${color} 22%, var(--card))`,
+        border: `1px solid color-mix(in oklab, ${color} 46%, transparent)`,
+        boxShadow: "0 4px 10px -4px hsl(32 28% 30% / 0.18)",
+        padding: "8px 10px",
+        fontFamily: "var(--font-handwriting)",
+        fontSize: 12,
+        color,
+        opacity: 0.75,
+      }}
+    >
+      {label}
+    </div>
+  )
+}

--- a/webui/src/index.css
+++ b/webui/src/index.css
@@ -1162,6 +1162,13 @@
     opacity: 0.10;
     filter: invert(1);
   }
+  /* Auth screens use the same grain, dialed up a touch. */
+  .auth-paper-grain {
+    opacity: 0.3;
+  }
+  [data-mode="dark"] .auth-paper-grain {
+    opacity: 0.14;
+  }
 
   /* ── paper note texture ─────────────────────────────────── */
   .paper-note-texture {

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -137,6 +137,7 @@ export function RootLayout() {
  * Full-screen auth background:
  * - subtle dot grid overlay (matches the dim0.net landing-page graph paper)
  * - decorative graph texture layered on top
+ * - fractal-noise paper grain (shared with the board) for a tactile finish
  */
 export function AuthBackground() {
   return (
@@ -153,6 +154,9 @@ export function AuthBackground() {
 
       {/* decorative graph layered on top of the dot grid */}
       <AuthGraphTexture />
+
+      {/* fractal-noise paper grain (same substrate the board uses) */}
+      <div className="board-paper-grain auth-paper-grain" />
     </div>
   )
 }

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -14,6 +14,7 @@ import { useBoardAppStore } from '@/features/board/harness/store/board-app-store
 import { useAuth } from '@/features/signin/hooks/auth'
 import { initConnectionState } from '@/features/connection/connection-state'
 import { OfflineOverlay } from '@/features/connection/offline-overlay'
+import { AuthGraphTexture } from '@/features/signin/components/auth-graph-texture'
 
 export function RootLayout() {
   // only hydrates store from token; does not navigate
@@ -134,17 +135,12 @@ export function RootLayout() {
 
 /**
  * Full-screen auth background:
- * - soft "secondary" blobs
  * - subtle dot grid overlay (matches the dim0.net landing-page graph paper)
+ * - decorative graph texture layered on top
  */
 export function AuthBackground() {
   return (
     <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      {/* soft secondary blobs */}
-      <div className="absolute -top-24 left-1/2 -translate-x-1/2 h-[40vh] w-[70vw] rounded-full bg-secondary-foreground/20 blur-3xl" />
-      <div className="absolute -bottom-24 -left-24 h-[45vh] w-[55vw] rounded-full bg-secondary-foreground/15 blur-3xl" />
-      <div className="absolute -bottom-40 -right-40 h-[35vh] w-[45vw] rounded-full bg-secondary-foreground/10 blur-3xl" />
-
       {/* dot grid overlay */}
       <div
         className="absolute inset-0 opacity-50"
@@ -154,6 +150,9 @@ export function AuthBackground() {
           backgroundSize: "22px 22px",
         }}
       />
+
+      {/* decorative graph layered on top of the dot grid */}
+      <AuthGraphTexture />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adds the dim0 landing-page visual language (graph paper + ambient graph + fractal-noise grain) across three surfaces, all purely decorative and non-interactive.

### 1. Empty-board onboarding coachmarks (`feat(board)`)
A decorative graph shown **only while a board is empty and editable**: drifting notes / idea-bubbles / chips / dots with curved arrows pointing at real chrome (title, toolbar, share, AI island). Anchors are tagged via `data-coachmark` and measured from the live DOM; missing anchors (e.g. owner-only Share) are skipped. Unmounts the instant the first node/edge is created. `pointer-events: none`, hidden on mobile + in presentation mode, respects `prefers-reduced-motion`. Includes a behaviour test suite (gating + anchor wiring).

### 2. Auth background graph texture (`feat(signin)`)
The same ambient graph layered over the auth dot grid (shared across sign-in / sign-up / verify / reset). Standalone — no canvas-harness coupling. Also drops the old soft blur blobs so the graph reads cleanly.

### 3. Paper grain (`feat(signin)` + `feat(board)`)
hex.tech-style fractal-noise (`feTurbulence`) grain, reusing the existing `.board-paper-grain` substrate:
- **Auth**: layered over the dot grid + graph, opacity nudged up slightly via `.auth-paper-grain`.
- **Canvas**: mounted above the drawn scene (z-index 1) but below all chrome, `pointer-events: none`. Hidden in presentation mode.

`multiply` blend in light mode / `screen` + invert in dark mode, so the grain stays visible in both themes.

## Performance
Grain is a one-time-rasterized cached tile (no per-frame `feTurbulence`). Idle cost is zero; only re-blends while the canvas backdrop repaints during pan/zoom — verified no noticeable impact.

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `eslint` clean on all touched files
- [x] coachmark gating + anchor-wiring tests pass (`vitest run`)
- [x] manually eyeballed canvas grain + pan performance