### PR TITLE
fix(board): stop space-pan from re-firing focused buttons

### DIFF
--- a/webui/src/features/board/harness/canvas/use-board-keyboard.ts
+++ b/webui/src/features/board/harness/canvas/use-board-keyboard.ts
@@ -16,6 +16,19 @@ const isTypingTarget = (target: EventTarget | null): boolean => {
 }
 
 
+/**
+ * Whether the event originated from a focused button-like control.
+ * Space "clicks" a focused button by default, which collides with
+ * hold-Space-to-pan: after clicking e.g. the sidebar trigger, every
+ * Space press meant for panning would re-fire that button. We suppress
+ * Space's default activation only for these targets.
+ */
+const isButtonTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false
+  return target.closest("button, [role='button']") !== null
+}
+
+
 /** Single-key shortcuts that map straight to a tool-mode swap. */
 const TOOL_SHORTCUTS: Record<string, string> = {
   p: "pan",
@@ -56,6 +69,16 @@ export const useBoardKeyboard = (store: CanvasStore): void => {
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (isTypingTarget(e.target)) return
+
+      // Reserve Space for hold-to-pan: stop a focused button from
+      // re-firing its click on each Space press (e.g. the sidebar
+      // trigger after it's been clicked). The lib's pan handler reads
+      // its own keydown listener, so this doesn't affect panning.
+      if (e.code === "Space" && isButtonTarget(e.target)) {
+        e.preventDefault()
+        return
+      }
+
       const meta = e.metaKey || e.ctrlKey
 
       if (meta && (e.key === "z" || e.key === "Z")) {


### PR DESCRIPTION
## Problem

Hold-**Space**-to-pan works without switching tools, but a focused `<button>` gets "clicked" by Space (native button activation). So after clicking e.g. the sidebar trigger, every Space press meant for panning re-fires that button — the sidebar toggles repeatedly while you try to pan. This affects any focused button (toolbar, share, viewport controls), not just the sidebar.

## Cause

The space-pan handler lives in the published `@canvas-harness/react` lib (`use-pan-zoom.ts`), listens on `window`, sets a `panActivatedBySpace` flag, and never calls `preventDefault()` — so the browser's default button activation still runs alongside the pan. Fixing it in the lib isn't an option (the in-repo source is stale; the app runs the published package), and a blanket `preventDefault` on Space would break Space in text inputs.

## Fix

In the existing board keydown handler (`use-board-keyboard.ts`), swallow Space's default action only when focus sits on a button-like element:

- Text inputs/textarea/contenteditable already bail via `isTypingTarget`.
- Checkboxes/radios/links keep native Space behavior.
- Panning is unaffected — the lib's pan handler has its own keydown listener that just sets a flag; `preventDefault()` cancels the browser's button activation, not delivery to other listeners.

## Test

Click the sidebar toggle, then hold Space and drag — the canvas pans without the sidebar flickering.