### PR TITLE
chore(webui): bump @canvas-harness/* to 0.1.20

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "webui",
-  "version": "0.3.42",
+  "version": "0.3.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.42",
+      "version": "0.3.44",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.18",
-        "@canvas-harness/react": "^0.1.18",
-        "@canvas-harness/sync-broadcast": "^0.1.18",
+        "@canvas-harness/core": "^0.1.20",
+        "@canvas-harness/react": "^0.1.20",
+        "@canvas-harness/sync-broadcast": "^0.1.20",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.18.tgz",
-      "integrity": "sha512-GgnbXC6/aUruJ8V8ZYDq3h6um/CUgYdQGOM5c1ydBJDxsELEIgZl7W+eSQ/M6yl3zDt0BYaCY5l8i9PzpHJObg==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.20.tgz",
+      "integrity": "sha512-CAq4/J+zUpWLcTIk9lrZSpbGNkTpSCSHfDKjlDDuzsx9O8yjMmIJHmVpIKuBIFAK26tv6SPrQJQDLEgcf9DcGw==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1939,12 +1939,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.18.tgz",
-      "integrity": "sha512-wDDPQLnLxypt7UTkuxtWZQgE4nbSadxZVANXjTTFLXuiVyM93077QwXrfL+XzuwMvsW46dvc4CaanI2EQeuVJQ==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.20.tgz",
+      "integrity": "sha512-gswZl3qFg3YUI7WRbKphjTD/eo/M3jkO2g4QNzLZe3XAyrvhxW1pomSWgL6W/Xp+tmwDJvD2G2ke/xCcdewMBQ==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.18"
+        "@canvas-harness/core": "0.1.20"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1952,12 +1952,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.18.tgz",
-      "integrity": "sha512-fQjwlyzdc0rJqAQEibLmMPy1exu6C7/51PD2Gpq97fwc+4h9Po553QXmbMJrThrAXk6TF9n8yymR+sEUQ+7peA==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.20.tgz",
+      "integrity": "sha512-/vm2zpZH+5GssfNxZp51o9HbnwWZkHMRujTQQLASegEc1PNNQ3P6Oge33jRQai0KAjOArXRAdJ27W2kJrG6ClA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.18"
+        "@canvas-harness/core": "0.1.20"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.18",
-    "@canvas-harness/react": "^0.1.18",
-    "@canvas-harness/sync-broadcast": "^0.1.18",
+    "@canvas-harness/core": "^0.1.20",
+    "@canvas-harness/react": "^0.1.20",
+    "@canvas-harness/sync-broadcast": "^0.1.20",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@canvas-harness/{core,react,sync-broadcast}` from `^0.1.18` → `^0.1.20`.
- Pulls in the trackpad gesture fix for the board canvas on macOS:
  - `overscroll-behavior: contain` on the canvas wrapper so two-finger horizontal swipes no longer trigger Safari/Chrome's back/forward history navigation.
  - Safari `gesturestart` / `gesturechange` / `gestureend` listeners with `preventDefault()` so two-finger pinch zooms the canvas instead of the page.

## Test plan
- [ ] On macOS Safari + Chrome with a trackpad, open a board and two-finger horizontal swipe near the canvas edges — pans the canvas, does not trigger browser back/forward.
- [ ] Two-finger pinch — zooms the canvas, does not zoom the page.
- [ ] Regression check: vertical scroll, click-drag select, space-pan, keyboard shortcuts all still behave normally.