### PR TITLE
fix(webui): disable macos trackpad swipe-back via overscroll-behavior

### DIFF
--- a/webui/src/index.css
+++ b/webui/src/index.css
@@ -1037,6 +1037,15 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html,
+  body {
+    /* Disable macOS trackpad swipe-back/forward and pinch-page-zoom
+       app-wide. `overscroll-behavior` only takes effect on scroll
+       containers, so it must live on the document root — setting it
+       on the canvas wrapper alone is ignored by Chrome for the
+       history-navigation decision. */
+    overscroll-behavior: none;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- Sets `overscroll-behavior: none` on `html, body` in [webui/src/index.css](webui/src/index.css) so two-finger trackpad swipes inside the board no longer trigger Chrome's history navigation on macOS.
- Follow-up to #128 (canvas-harness 0.1.20 bump). That release added `overscroll-behavior: contain` to the canvas wrapper, but the wrapper has `overflow: hidden` and is not a scroll container — so Chrome ignores it and falls back to the document root when deciding to start the back/forward gesture. Setting it at the document root fixes that.

## Test plan
- [x] macOS Chrome with a trackpad: two-finger horizontal swipe across the board canvas — pans the canvas, does not navigate back/forward.
- [x] Regression: vertical scroll on chat/sidebar, dropdowns, all other pages behave normally.
- [x] No visual changes; CSS is invisible behavior.

## Follow-up (out of scope here)
If two-finger pinch still occasionally triggers page zoom while a text node is in edit mode, that's caused by the `isEditing()` early-return in `@canvas-harness/react`'s wheel handler bypassing `preventDefault()`. Would need a fix upstream in canvas-harness.