### PR TITLE
fix(webui): stamp arrow-drawn edges at create-time to remove double-undo

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "webui",
-  "version": "0.3.44",
+  "version": "0.3.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.44",
+      "version": "0.3.46",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.20",
-        "@canvas-harness/react": "^0.1.20",
-        "@canvas-harness/sync-broadcast": "^0.1.20",
+        "@canvas-harness/core": "^0.1.24",
+        "@canvas-harness/react": "^0.1.24",
+        "@canvas-harness/sync-broadcast": "^0.1.24",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.20.tgz",
-      "integrity": "sha512-CAq4/J+zUpWLcTIk9lrZSpbGNkTpSCSHfDKjlDDuzsx9O8yjMmIJHmVpIKuBIFAK26tv6SPrQJQDLEgcf9DcGw==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.24.tgz",
+      "integrity": "sha512-LRCbawbmWrIT55eq9v26+S+1cVU1a/utBY//LcGXx1LaJUgN7Whw3xvEVcSp9yWT1C6T+2wpoDyW2GYPdQsjpQ==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1939,12 +1939,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.20.tgz",
-      "integrity": "sha512-gswZl3qFg3YUI7WRbKphjTD/eo/M3jkO2g4QNzLZe3XAyrvhxW1pomSWgL6W/Xp+tmwDJvD2G2ke/xCcdewMBQ==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.24.tgz",
+      "integrity": "sha512-YRi1ui0UPGAq6TCioeT9BpKXgHcpd2hwZ6qOBMPB2pJy48dFayvtHZa6lgM8OxUp7aOx/TDVW7ZhRAkeE+bNGQ==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.20"
+        "@canvas-harness/core": "0.1.24"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1952,12 +1952,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.20.tgz",
-      "integrity": "sha512-/vm2zpZH+5GssfNxZp51o9HbnwWZkHMRujTQQLASegEc1PNNQ3P6Oge33jRQai0KAjOArXRAdJ27W2kJrG6ClA==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.24.tgz",
+      "integrity": "sha512-3u5+IUUwouiMmediKOMvx1TplDXnSfWenc4m0bWZxyYSb2AUXT6KgnSiu2zRWu+MHtH5dY6q7YifT6p1ym0xJg==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.20"
+        "@canvas-harness/core": "0.1.24"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.20",
-    "@canvas-harness/react": "^0.1.20",
-    "@canvas-harness/sync-broadcast": "^0.1.20",
+    "@canvas-harness/core": "^0.1.24",
+    "@canvas-harness/react": "^0.1.24",
+    "@canvas-harness/sync-broadcast": "^0.1.24",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -43,6 +43,8 @@ import { hydrateBoardStore } from "../persist/snapshot-load"
 import { ShareButton } from "@/features/sharing/share-button"
 import { useBoardAppStore } from "../store/board-app-store"
 import { createBoardStore } from "../store/create-board-store"
+import { adaptEdgeColors, applyColorsToEdgeStyle } from "../theme/color-adapter"
+import { getBoardThemeMode } from "../theme/theme-mode-ref"
 import { useBoardTheme } from "../theme/use-board-theme"
 import { useThemeColorProjection } from "../theme/use-theme-color-projection"
 import { useBoardKeyboard } from "./use-board-keyboard"
@@ -52,7 +54,7 @@ import { useHarnessDropFiles } from "./use-drop-files"
 import { useHydrateIconNodes } from "./use-hydrate-icon-nodes"
 import { usePresentationMode } from "./use-presentation-mode"
 import { useBlockFolderCopy } from "./use-block-folder-copy"
-import { useStampNewEdges } from "./use-stamp-new-edges"
+import { resolveStoredEdgeColors, useStampNewEdges } from "./use-stamp-new-edges"
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useStyleMemory } from "./use-style-memory"
 import { CUSTOM_NODE_TYPES } from "./custom-node-types"
@@ -134,7 +136,7 @@ export function HarnessCanvas() {
   useViewportPersistence(store, boardId, rootId, ready)
   useCenterFromUrl(store, wrapRef, ready)
   const styleMemory = useStyleMemory(store)
-  useStampNewEdges(store, boardId, rootId, styleMemory.getEdgeStoredColors)
+  useStampNewEdges(store, boardId, rootId)
   useStampNewNodes(store, boardId, rootId)
   useBlockFolderCopy(store)
   useHarnessApplyMindMap(store, boardId, rootId)
@@ -158,9 +160,30 @@ export function HarnessCanvas() {
   // later restyle. The lib reads `arrowDefaults` lazily at edge-draw time
   // (defaultsRef) and keys no effect off it, so a fresh object per render
   // is cheap and is what lets sticky edge styles actually take effect.
+  // Factories run lazily at edge-draw time (canvas-harness 0.1.24+), so
+  // a fresh arrow-drawn edge enters the store already stamped with
+  // scope, version, stored colors, and theme-projected display style.
+  // That lets useStampNewEdges' init branch go away — Cmd+Z on a fresh
+  // edge now reverts the create in one press.
   const arrowDefaults: ArrowToolDefaults = {
     pathStyle: styleMemory.getEdgePathStyle(),
-    style: styleMemory.getEdgeStyle(),
+    style: () => {
+      const base = styleMemory.getEdgeStyle() ?? {}
+      const stored = resolveStoredEdgeColors(styleMemory.getEdgeStoredColors())
+      const mode = getBoardThemeMode()
+      const display = mode === "dark" ? adaptEdgeColors(stored, "dark") : stored
+      return applyColorsToEdgeStyle(base, display)
+    },
+    data: () => {
+      if (!boardId) return undefined
+      return {
+        version: 1,
+        createdAt: new Date().toISOString(),
+        _storedColors: resolveStoredEdgeColors(styleMemory.getEdgeStoredColors()),
+        graphUid: boardId,
+        parentId: rootId ?? undefined,
+      }
+    },
   }
   const { onDragOver, onDrop } = useHarnessDropFiles(wrapRef, store, boardId, rootId, canEdit)
   const navigate = useNavigate()

--- a/webui/src/features/board/harness/canvas/use-stamp-new-edges.test.tsx
+++ b/webui/src/features/board/harness/canvas/use-stamp-new-edges.test.tsx
@@ -1,6 +1,8 @@
-// Tests for the edge-creation stamp, focused on sticky-color inheritance:
-// a freshly-drawn edge must adopt the user's last-picked colors (canonical),
-// projected for the current theme, while paste/scope handling stays intact.
+// Tests for the edge-stamp helpers + paste subscriber. Sticky-color
+// inheritance on a fresh arrow-drawn edge is now produced by the
+// arrowDefaults factory wired in `harness-canvas` (canvas-harness
+// 0.1.24+), so the unit-level behavior worth pinning here is the
+// resolver helper and the subscriber's paste-preservation path.
 import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -10,31 +12,40 @@ import {
   type CanvasStore,
   type EdgeId,
 } from "@canvas-harness/core"
-import { useStampNewEdges } from "./use-stamp-new-edges"
-import { adaptEdgeColors, type StoredEdgeColors } from "../theme/color-adapter"
+import {
+  CANONICAL_EDGE_COLORS,
+  resolveStoredEdgeColors,
+  useStampNewEdges,
+} from "./use-stamp-new-edges"
+import { type StoredEdgeColors } from "../theme/color-adapter"
 import { setBoardThemeMode } from "../theme/theme-mode-ref"
 
 
 const BOARD_ID = "board-1"
-const CANONICAL = { strokeColor: "#292524", textColor: "#000000" }
 
 
-/** Add an edge the way the lib's arrow tool does: a `style`, but no `data`. */
-const drawEdge = (store: CanvasStore, style?: Record<string, unknown>): EdgeId => {
-  const id = asEdgeId(store.generateId())
-  store.addEdge({
-    id,
-    source: { worldPoint: { x: 0, y: 0 } },
-    target: { worldPoint: { x: 100, y: 0 } },
-    pathStyle: "bezier",
-    groups: [],
-    ...(style ? { style } : {}),
+describe("resolveStoredEdgeColors", () => {
+  it("returns the remembered colors verbatim when both fields are set", () => {
+    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
+    expect(resolveStoredEdgeColors(remembered)).toEqual(remembered)
   })
-  return id
-}
 
 
-describe("useStampNewEdges — sticky color inheritance", () => {
+  it("falls back to canonical defaults when nothing is remembered", () => {
+    expect(resolveStoredEdgeColors(undefined)).toEqual(CANONICAL_EDGE_COLORS)
+  })
+
+
+  it("fills only the unpicked field with the canonical default", () => {
+    expect(resolveStoredEdgeColors({ strokeColor: "#00ff00" })).toEqual({
+      strokeColor: "#00ff00",
+      textColor: CANONICAL_EDGE_COLORS.textColor,
+    })
+  })
+})
+
+
+describe("useStampNewEdges — paste preservation", () => {
   let container: HTMLDivElement
   let root: Root
 
@@ -55,13 +66,9 @@ describe("useStampNewEdges — sticky color inheritance", () => {
   })
 
 
-  /** Mount the stamp with a fixed remembered-color getter. */
-  const mountStamp = (
-    store: CanvasStore,
-    remembered: StoredEdgeColors | undefined,
-  ): void => {
+  const mountStamp = (store: CanvasStore): void => {
     const Probe = (): null => {
-      useStampNewEdges(store, BOARD_ID, null, () => remembered)
+      useStampNewEdges(store, BOARD_ID, null)
       return null
     }
     act(() => {
@@ -70,86 +77,11 @@ describe("useStampNewEdges — sticky color inheritance", () => {
   }
 
 
-  it("stamps a freshly-drawn edge with the remembered canonical colors (light mode)", () => {
+  it("preserves a pasted edge's _storedColors when scope + theme already match", () => {
     const store = createCanvasStore()
-    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
-    mountStamp(store, remembered)
+    mountStamp(store)
 
-    let edgeId: EdgeId | undefined
-    act(() => {
-      edgeId = drawEdge(store)
-    })
-    const edge = store.getEdge(edgeId!)
-
-    // Canonical source-of-truth captured...
-    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
-      .toEqual(remembered)
-    // ...and painted as display (light = identity).
-    expect(edge?.style?.strokeColor).toBe("#ef4444")
-    expect(edge?.style?.textColor).toBe("#111111")
-  })
-
-
-  it("projects the remembered colors to dark-mode display while keeping canonical truth", () => {
-    setBoardThemeMode("dark")
-    const store = createCanvasStore()
-    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
-    mountStamp(store, remembered)
-
-    let edgeId: EdgeId | undefined
-    act(() => {
-      edgeId = drawEdge(store)
-    })
-    const edge = store.getEdge(edgeId!)
-    const expectedDisplay = adaptEdgeColors(remembered, "dark")
-
-    // Stored truth stays canonical (light) — this is what hits the DB / collab.
-    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
-      .toEqual(remembered)
-    // Painted style is the dark-adapted projection.
-    expect(edge?.style?.strokeColor).toBe(expectedDisplay.strokeColor)
-    expect(edge?.style?.textColor).toBe(expectedDisplay.textColor)
-  })
-
-
-  it("falls back to canonical defaults when nothing is remembered", () => {
-    const store = createCanvasStore()
-    mountStamp(store, undefined)
-
-    let edgeId: EdgeId | undefined
-    act(() => {
-      edgeId = drawEdge(store)
-    })
-    const edge = store.getEdge(edgeId!)
-
-    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
-      .toEqual(CANONICAL)
-  })
-
-
-  it("merges canonical for the field the user never picked", () => {
-    const store = createCanvasStore()
-    // Only a stroke color was ever picked; label color should stay canonical.
-    mountStamp(store, { strokeColor: "#00ff00" })
-
-    let edgeId: EdgeId | undefined
-    act(() => {
-      edgeId = drawEdge(store)
-    })
-    const edge = store.getEdge(edgeId!)
-
-    expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
-      .toEqual({ strokeColor: "#00ff00", textColor: CANONICAL.textColor })
-  })
-
-
-  it("does not override an edge that already carries its own _storedColors (paste)", () => {
-    const store = createCanvasStore()
-    const remembered = { strokeColor: "#ef4444", textColor: "#111111" }
-    mountStamp(store, remembered)
-
-    // A pasted edge: already initialized + scoped + carrying source colors.
-    const pasted = { strokeColor: "#abcdef", textColor: "#fedcba" }
+    const pasted: StoredEdgeColors = { strokeColor: "#abcdef", textColor: "#fedcba" }
     let edgeId: EdgeId | undefined
     act(() => {
       edgeId = asEdgeId(store.generateId())
@@ -170,7 +102,6 @@ describe("useStampNewEdges — sticky color inheritance", () => {
     })
     const edge = store.getEdge(edgeId!)
 
-    // Source colors preserved — sticky memory must not clobber a paste.
     expect((edge?.data as { _storedColors?: StoredEdgeColors })?._storedColors)
       .toEqual(pasted)
   })

--- a/webui/src/features/board/harness/canvas/use-stamp-new-edges.ts
+++ b/webui/src/features/board/harness/canvas/use-stamp-new-edges.ts
@@ -18,25 +18,39 @@ import { getBoardThemeMode } from "../theme/theme-mode-ref"
  * canonical poisons the cross-theme sync (a light-mode peer would
  * adapt them as identity and see the dark hex).
  */
-const CANONICAL_EDGE_COLORS: StoredEdgeColors = {
+export const CANONICAL_EDGE_COLORS: StoredEdgeColors = {
   strokeColor: "#292524",
   textColor: "#000000",
 }
 
 
 /**
- * Stamp identity, scope, and current-theme display on every local
- * `edge.add`.
+ * Resolve canonical stored colors for a fresh edge: prefer the user's
+ * last picked colors (sticky style memory, light-space), fall back to
+ * the canonical Dim0 defaults. Shared between the arrow-tool init
+ * factory in `harness-canvas` and the paste rewrite below so both
+ * agree on the source-of-truth.
+ */
+export const resolveStoredEdgeColors = (
+  remembered: StoredEdgeColors | undefined,
+): StoredEdgeColors => ({
+  strokeColor: remembered?.strokeColor ?? CANONICAL_EDGE_COLORS.strokeColor,
+  textColor: remembered?.textColor ?? CANONICAL_EDGE_COLORS.textColor,
+})
+
+
+/**
+ * Rewrite pasted local `edge.add`s so they belong to the current
+ * scope and paint in the current theme.
  *
- * Three independent stamps that can each fire on its own:
+ * Fresh arrow-drawn edges are stamped at creation time via
+ * `arrowDefaults.{data,style}` in `harness-canvas` (canvas-harness
+ * 0.1.24+), so they enter the store already initialized — the init
+ * stamp doesn't need a follow-up `updateEdge` here. That removed
+ * a redundant undo batch (Cmd+Z on a fresh edge used to take two
+ * presses).
  *
- *   - **init stamp** (`version === undefined`): a freshly-drawn arrow
- *     from canvas-harness's `useArrowTool` arrives with no `data`.
- *     Set version/createdAt, capture `_storedColors` (from sticky style
- *     memory via `rememberedEdgeColors`, falling back to canonical
- *     defaults), and (in dark mode) project to dark-adapted display
- *     style. Without this, the edge has no source-of-truth for theme
- *     adaptation later, and would ignore the user's last-picked colors.
+ * Two stamps remain, both only relevant to **paste**:
  *
  *   - **rescope stamp** (scope mismatch): a pasted edge carries
  *     `version` + `_storedColors` from the source but its
@@ -57,17 +71,14 @@ const CANONICAL_EDGE_COLORS: StoredEdgeColors = {
  *
  * Invariant for future contributors: any new emitter of a local
  * `edge.add` must either pre-stamp scope + project style for current
- * theme (like the mindmap drain in `use-harness-apply-mindmap`) or
- * accept being rewritten here.
- *
- * Mirrors prod's [line-placement.ts](dim0/.../line-placement.ts)
- * which sets `parentId: rootId` directly at construction time.
+ * theme (like the mindmap drain in `use-harness-apply-mindmap`, or
+ * the arrow-tool factories in `harness-canvas`) or accept being
+ * rewritten here (paying a second undo step).
  */
 export const useStampNewEdges = (
   store: CanvasStore,
   boardId: string | null,
   rootId: string | null,
-  rememberedEdgeColors: () => StoredEdgeColors | undefined,
 ): void => {
   useEffect(() => {
     if (!boardId) return
@@ -78,38 +89,23 @@ export const useStampNewEdges = (
         const data = (op.edge.data ?? {}) as Record<string, unknown>
 
         const wantedParentId = rootId ?? undefined
-        const needsInit = data.version === undefined
         const scopeMismatched =
           data.graphUid !== boardId || data.parentId !== wantedParentId
 
-        // Resolve final stored colors. Priority:
-        //   1. `_storedColors` already on the edge (e.g. a pasted edge
-        //      carrying its source colors) — always wins.
-        //   2. The last color the user picked, from sticky style memory
-        //      (canonical/light-space) — so a freshly-drawn edge inherits
-        //      it, matching how new nodes inherit via `applyStyleMemory`.
-        //      The arrow tool can't carry `_storedColors` through
-        //      `ArrowToolDefaults`, so memory is the trusted channel.
-        //   3. Canonical light defaults.
-        // NEVER read from `style.*` — arrow-tool dark defaults are display
-        // values that masquerade as canonical (see CANONICAL_EDGE_COLORS).
         const existingStored = data._storedColors as StoredEdgeColors | undefined
-        const remembered = rememberedEdgeColors()
-        const storedColors: StoredEdgeColors = existingStored ?? {
-          strokeColor: remembered?.strokeColor ?? CANONICAL_EDGE_COLORS.strokeColor,
-          textColor: remembered?.textColor ?? CANONICAL_EDGE_COLORS.textColor,
+        const currentStyle = op.edge.style ?? {}
+        let displayColors: StoredEdgeColors | undefined
+        let themeStale = false
+        if (existingStored) {
+          const mode = getBoardThemeMode()
+          displayColors =
+            mode === "dark" ? adaptEdgeColors(existingStored, "dark") : existingStored
+          themeStale =
+            currentStyle.strokeColor !== displayColors.strokeColor ||
+            currentStyle.textColor !== displayColors.textColor
         }
 
-        const mode = getBoardThemeMode()
-        const displayColors =
-          mode === "dark" ? adaptEdgeColors(storedColors, "dark") : storedColors
-        const currentStyle = op.edge.style ?? {}
-        const themeStale =
-          existingStored !== undefined &&
-          (currentStyle.strokeColor !== displayColors.strokeColor ||
-            currentStyle.textColor !== displayColors.textColor)
-
-        if (!needsInit && !scopeMismatched && !themeStale) continue
+        if (!scopeMismatched && !themeStale) continue
 
         const nextData: Record<string, unknown> = {
           ...data,
@@ -117,18 +113,12 @@ export const useStampNewEdges = (
           parentId: wantedParentId,
         }
         const patch: Parameters<typeof store.updateEdge>[1] = { data: nextData }
-
-        if (needsInit) {
-          nextData.version = 1
-          nextData.createdAt = new Date().toISOString()
-          nextData._storedColors = storedColors
-          patch.style = applyColorsToEdgeStyle(currentStyle, displayColors)
-        } else if (themeStale) {
+        if (themeStale && displayColors) {
           patch.style = applyColorsToEdgeStyle(currentStyle, displayColors)
         }
 
         store.updateEdge(op.edge.id, patch)
       }
     })
-  }, [store, boardId, rootId, rememberedEdgeColors])
+  }, [store, boardId, rootId])
 }


### PR DESCRIPTION
## Summary
Cmd+Z on a freshly arrow-drawn edge used to take **two presses** — a no-op restyle in light mode, a visible color flip in dark mode, then finally the delete. The root cause was that `useStampNewEdges` reactively `updateEdge`d after every `edge.add`, splitting the create into two local undo batches.

`@canvas-harness/*` 0.1.24 (already published) adds a factory form for `ArrowToolDefaults.{data,style}`. This PR bumps and wires that up so fresh edges enter the store already stamped — the post-create patch goes away.

## Changes
- Bump `@canvas-harness/{core,react,sync-broadcast}` `^0.1.20` → `^0.1.24`.
- [harness-canvas.tsx](webui/src/features/board/harness/canvas/harness-canvas.tsx): `arrowDefaults` now passes `style` and `data` as factories that read live scope + theme + sticky style memory.
- [use-stamp-new-edges.ts](webui/src/features/board/harness/canvas/use-stamp-new-edges.ts): dropped the `needsInit` branch (and the `rememberedEdgeColors` arg). Exported `CANONICAL_EDGE_COLORS` and a new `resolveStoredEdgeColors` helper so the factory and the paste subscriber share one fallback chain. Subscriber is now **paste-only** (scope-mismatch + theme-stale paths kept).
- [use-stamp-new-edges.test.tsx](webui/src/features/board/harness/canvas/use-stamp-new-edges.test.tsx): rewritten — 3 unit tests on `resolveStoredEdgeColors`, 1 paste-preservation test. Obsolete init-stamp tests removed.

## Test plan
- [x] Draw a fresh edge in **light** mode → Cmd+Z once → edge is gone.
- [x] Draw a fresh edge in **dark** mode → Cmd+Z once → edge is gone, no intermediate "color reverts to light" frame.
- [x] Paste an edge from another board → still rewrites scope, two-step undo on paste is unchanged (acceptable trade-off).
- [x] `npm run test:run` passes (314/314 locally).
- [x] `npm run type-check` clean.

## Follow-up
The companion change in canvas-harness is already on npm (0.1.24). If a future emitter of `edge.add` skips the arrow tool, it must either pre-stamp scope + project style itself or accept being rewritten by the paste subscriber (paying a second undo step) — same invariant as before, now restated in the docstring.