### PR TITLE
feat: content-fit board visuals, mindmap hubs, border edges, and higher agent turn ceiling

### DIFF
--- a/backend/test/unit/agents/assistant/test_note_tools.py
+++ b/backend/test/unit/agents/assistant/test_note_tools.py
@@ -52,8 +52,8 @@ class DummyGraphStore:
 
 
 @pytest.mark.asyncio
-async def test_build_note_uses_frontend_aligned_defaults() -> None:
-    """New note helpers should mirror the frontend size defaults."""
+async def test_build_note_sheet_keeps_reading_width_and_fits_height() -> None:
+    """Sheets keep their fixed reading width; height fits the content."""
     graph_store = DummyGraphStore()
 
     note = await build_note(
@@ -67,8 +67,11 @@ async def test_build_note_uses_frontend_aligned_defaults() -> None:
 
     assert note.graph_uid == "graph-1"
     assert note.style.type == NodeType.SHEET
+    # Sheet is a fixed-width (document) type: width stays at the reading default.
     assert note.properties.node_size.size.width == 560
-    assert note.properties.node_size.size.height == 320
+    # Height now fits the content, so a one-line sheet is far shorter than the
+    # old fixed 320 default.
+    assert 0 < note.properties.node_size.size.height < 320
     assert note.properties.node_position.position.x == 0
     assert note.properties.node_position.position.y == 0
 
@@ -93,8 +96,8 @@ async def test_build_widget_note_uses_widget_defaults() -> None:
 
 
 @pytest.mark.asyncio
-async def test_build_inscribed_shapes_use_larger_square_defaults() -> None:
-    """Ellipse and diamond families should start from roomier square defaults."""
+async def test_build_inscribed_shapes_stay_square() -> None:
+    """Ellipse and diamond families fit content but keep a square-ish aspect."""
     graph_store = DummyGraphStore()
 
     ellipse_note = await build_note(
@@ -114,10 +117,15 @@ async def test_build_inscribed_shapes_use_larger_square_defaults() -> None:
         parent_id=None,
     )
 
-    assert ellipse_note.properties.node_size.size.width == 320
-    assert ellipse_note.properties.node_size.size.height == 320
-    assert diamond_note.properties.node_size.size.width == 340
-    assert diamond_note.properties.node_size.size.height == 340
+    ellipse_size = ellipse_note.properties.node_size.size
+    diamond_size = diamond_note.properties.node_size.size
+    # Content-fit shrinks them, but the min-aspect floor keeps height >= width
+    # so a short label doesn't collapse into a sliver.
+    assert ellipse_size.height >= ellipse_size.width
+    assert diamond_size.height >= diamond_size.width
+    # And never grow past the type's default footprint.
+    assert ellipse_size.width <= 320
+    assert diamond_size.width <= 340
 
 
 @pytest.mark.asyncio
@@ -142,7 +150,8 @@ async def test_write_note_tool_creates_note_in_root_scope_by_default() -> None:
     assert created_note.parent_id == "folder-1"
     assert created_note.content is not None
     assert created_note.content.markdown == "New note content"
-    assert created_note.properties.node_size.size.width == get_default_note_size(NodeType.RECTANGLE)[0]
+    # Width is content-fit, never wider than the type's default footprint.
+    assert 0 < created_note.properties.node_size.size.width <= get_default_note_size(NodeType.RECTANGLE)[0]
 
 
 @pytest.mark.asyncio

--- a/backend/test/unit/agents/notes/test_layout.py
+++ b/backend/test/unit/agents/notes/test_layout.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass, field
 import pytest
 
 from topix.agents.notes.layout import (
+    EDGE_ANCHOR_INSET,
     TILE_GAP_X,
     _connected_components,
+    _edge_anchor_offset,
     rearrange_created_notes,
 )
 from topix.datatypes.note.link import Link
 from topix.datatypes.note.note import Note
+from topix.datatypes.note.style import NodeType
 from topix.datatypes.property import PositionProperty, SizeProperty
 
 
@@ -47,9 +50,13 @@ class _FakeGraphStore:
     notes: dict[str, Note] = field(default_factory=dict)
     links: list[Link] = field(default_factory=list)
     patches: list[tuple[str, dict]] = field(default_factory=list)
+    link_updates: list[tuple[str, dict]] = field(default_factory=list)
 
     async def get_nodes(self, note_ids: list[str]) -> list[Note]:
         return [self.notes[nid] for nid in note_ids if nid in self.notes]
+
+    async def update_links(self, updates: list[tuple[str, dict]]) -> None:
+        self.link_updates.extend(updates)
 
     async def get_links(self, link_ids: list[str]) -> list[Link]:
         requested = set(link_ids)
@@ -510,3 +517,100 @@ async def test_rearrange_does_not_move_anchor_node() -> None:
     # Anchor's persisted position stays put.
     assert old_anchor.properties.node_position.position.x == 2000.0
     assert old_anchor.properties.node_position.position.y == 1000.0
+
+
+# -----------------------------
+# Edge endpoint anchoring
+# -----------------------------
+
+def test_edge_anchor_rectangle_picks_facing_border_midpoint() -> None:
+    """A rectangle anchors at the midpoint of the border facing the peer."""
+    w, h = 300.0, 100.0
+    inset = EDGE_ANCHOR_INSET
+    # Peer to the right → right-border midpoint.
+    assert _edge_anchor_offset(NodeType.RECTANGLE, w, h, 500.0, 10.0) == (w - inset, h / 2)
+    # Peer to the left → left-border midpoint.
+    assert _edge_anchor_offset(NodeType.RECTANGLE, w, h, -500.0, 10.0) == (inset, h / 2)
+    # Peer below (vertical dominates) → bottom-border midpoint.
+    assert _edge_anchor_offset(NodeType.RECTANGLE, w, h, 10.0, 500.0) == (w / 2, h - inset)
+    # Peer above → top-border midpoint.
+    assert _edge_anchor_offset(NodeType.RECTANGLE, w, h, 10.0, -500.0) == (w / 2, inset)
+
+
+def test_edge_anchor_round_and_diamond_stay_centered() -> None:
+    """Circles/diamonds keep the center anchor (renderer clips to a radial point)."""
+    w, h = 200.0, 200.0
+    for node_type in (NodeType.LAYERED_CIRCLE, NodeType.ELLIPSE, NodeType.DIAMOND,
+                      NodeType.SOFT_DIAMOND, NodeType.LAYERED_DIAMOND):
+        assert _edge_anchor_offset(node_type, w, h, 500.0, 0.0) == (w / 2, h / 2)
+
+
+def test_edge_anchor_inset_clamps_for_tiny_nodes() -> None:
+    """The inset never exceeds half the node, so it can't invert a tiny box."""
+    assert _edge_anchor_offset(NodeType.RECTANGLE, 2.0, 100.0, 5.0, 0.0) == (1.0, 50.0)
+
+
+@pytest.mark.asyncio
+async def test_rearrange_anchors_link_endpoints_to_borders() -> None:
+    """A parent→child link is persisted with border-to-border local offsets."""
+    parent = _make_note("p", x=0.0, y=0.0)
+    child = _make_note("c", x=0.0, y=400.0)
+    link = Link(id="l1", source="p", target="c", graph_uid="graph-1")
+    store = _FakeGraphStore(
+        notes={"p": parent, "c": child},
+        links=[link],
+    )
+
+    await rearrange_created_notes(
+        graph_store=store,
+        graph_uid="graph-1",
+        created_ids=["p", "c"],
+        created_link_ids=["l1"],
+    )
+
+    assert len(store.link_updates) == 1
+    _, data = store.link_updates[0]
+    start = data["properties"]["start_point"]
+    end = data["properties"]["end_point"]
+    # Both endpoints are node-local offsets.
+    assert start["is_local_offset"] is True
+    assert end["is_local_offset"] is True
+    # LR layout puts the child to the right: source exits its right border,
+    # target enters its left border (both at vertical mid-height = 50).
+    assert start["position"] == {"x": 300.0 - EDGE_ANCHOR_INSET, "y": 50.0}
+    assert end["position"] == {"x": EDGE_ANCHOR_INSET, "y": 50.0}
+
+
+@pytest.mark.asyncio
+async def test_rearrange_keeps_hub_centered_and_anchors_rect_children() -> None:
+    """A layered-circle hub stays center-anchored; rectangle children border-anchor."""
+    hub = _make_note("hub", x=0.0, y=0.0, width=200.0, height=200.0)
+    hub.style.type = NodeType.LAYERED_CIRCLE
+    a = _make_note("a", x=0.0, y=0.0)
+    b = _make_note("b", x=0.0, y=0.0)
+    links = [
+        Link(id="la", source="hub", target="a", graph_uid="graph-1"),
+        Link(id="lb", source="hub", target="b", graph_uid="graph-1"),
+    ]
+    store = _FakeGraphStore(
+        notes={"hub": hub, "a": a, "b": b},
+        links=links,
+    )
+
+    await rearrange_created_notes(
+        graph_store=store,
+        graph_uid="graph-1",
+        created_ids=["hub", "a", "b"],
+        created_link_ids=["la", "lb"],
+    )
+
+    updates = dict(store.link_updates)
+    assert set(updates) == {"la", "lb"}
+    for lid in ("la", "lb"):
+        start = updates[lid]["properties"]["start_point"]["position"]
+        end = updates[lid]["properties"]["end_point"]["position"]
+        # Hub (source) is a layered-circle → center anchor (200/2).
+        assert start == {"x": 100.0, "y": 100.0}
+        # Child (rect 300x100) enters on a vertical border at mid-height.
+        assert end["y"] == 50.0
+        assert end["x"] in (EDGE_ANCHOR_INSET, 300.0 - EDGE_ANCHOR_INSET)

--- a/backend/test/unit/agents/notes/test_service.py
+++ b/backend/test/unit/agents/notes/test_service.py
@@ -1,0 +1,152 @@
+"""Tests for default note style construction (webui createDefaultStyle parity)."""
+
+from __future__ import annotations
+
+import pytest
+
+from topix.agents.notes.service import build_default_note_style, build_note, get_default_note_size
+from topix.datatypes.note.style import NodeType, Style
+from topix.utils.colors import BLUE_200, TAILWIND_200_ADAPTED
+from topix.utils.graph.text_measure import estimate_node_size
+
+_TRANSPARENT = "#00000000"
+
+# Built-in shapes that should be sharp-cornered and filled from the adapted
+# Tailwind-200 palette, matching the frontend.
+_SHARP_SHAPES = [
+    NodeType.RECTANGLE,
+    NodeType.LAYERED_RECTANGLE,
+    NodeType.ELLIPSE,
+    NodeType.LAYERED_CIRCLE,
+    NodeType.DIAMOND,
+    NodeType.SOFT_DIAMOND,
+    NodeType.LAYERED_DIAMOND,
+    NodeType.CAPSULE,
+    NodeType.TAG,
+    NodeType.THOUGHT_CLOUD,
+]
+
+
+def test_style_class_defaults_match_frontend_rectangle():
+    """The bare Style default is the frontend rectangle: sharp + adapted blue."""
+    style = Style()
+    assert style.roundness == 0.0
+    assert style.background_color == BLUE_200
+
+
+@pytest.mark.parametrize("note_type", _SHARP_SHAPES)
+def test_builtin_shapes_are_sharp_and_palette_filled(note_type):
+    """Built-in shapes get roundness 0 and a fill from the adapted palette."""
+    style = build_default_note_style(note_type)
+    assert style.roundness == 0
+    assert style.background_color in TAILWIND_200_ADAPTED
+
+
+def test_text_is_transparent_and_sharp():
+    """Text notes are transparent with no rounding."""
+    style = build_default_note_style(NodeType.TEXT)
+    assert style.background_color == _TRANSPARENT
+    assert style.roundness == 0
+
+
+def test_sheet_is_sharp_and_flat():
+    """Sheets are sharp-cornered and flat (roughness 0)."""
+    style = build_default_note_style(NodeType.SHEET)
+    assert style.roundness == 0
+    assert style.roughness == 0
+
+
+@pytest.mark.parametrize(
+    ("note_type", "expected_roundness"),
+    [
+        (NodeType.SLIDE, 2),
+        (NodeType.CODE_SANDBOX, 1),
+        (NodeType.WIDGET, 1),
+    ],
+)
+def test_custom_nodes_keep_their_roundness(note_type, expected_roundness):
+    """Custom nodes override the shape default with their own roundness."""
+    assert build_default_note_style(note_type).roundness == expected_roundness
+
+
+def test_code_sandbox_and_widget_use_rose_pine_fill():
+    """Code/widget cards keep their bespoke rose-pine background, not the palette."""
+    for note_type in (NodeType.CODE_SANDBOX, NodeType.WIDGET):
+        assert build_default_note_style(note_type).background_color == "#faf4ed"
+
+
+# --- build_note content-fit sizing ------------------------------------------
+
+
+class _EmptyGraphStore:
+    """Minimal GraphStore stand-in: an empty board (no siblings)."""
+
+    async def get_graph(self, *_args, **_kwargs):
+        return None
+
+
+async def _build(content: str, note_type: NodeType = NodeType.RECTANGLE):
+    return await build_note(
+        graph_store=_EmptyGraphStore(),
+        graph_uid="g1",
+        label=None,
+        content=content,
+        note_type=note_type,
+        parent_id=None,
+    )
+
+
+async def test_build_note_fits_box_to_content():
+    """A rectangle's box matches the shape-aware content estimate, not the default."""
+    content = "The quick brown fox jumps over the lazy dog and keeps running past the meadow"
+    note = await _build(content)
+    default_w, default_h = get_default_note_size(NodeType.RECTANGLE)
+    exp_w, exp_h = estimate_node_size(NodeType.RECTANGLE, default_w, content, note.style.font_size)
+    size = note.properties.node_size.size
+    assert (size.width, size.height) == (exp_w, exp_h)
+    assert exp_h != default_h  # actually content-driven, not the stub default
+
+
+async def test_build_note_short_label_shrinks_width_and_height():
+    """Fit-exact: a one-word rectangle shrinks in both dimensions below the default."""
+    note = await _build("Hi")
+    default_w, default_h = get_default_note_size(NodeType.RECTANGLE)
+    size = note.properties.node_size.size
+    assert size.width < default_w
+    assert size.height < default_h
+
+
+async def test_build_note_long_single_line_clamps_width_to_default():
+    """A long unbroken line can't grow past the type's default (max) width."""
+    note = await _build("word " * 200)
+    default_w, _ = get_default_note_size(NodeType.RECTANGLE)
+    assert note.properties.node_size.size.width == default_w
+
+
+async def test_build_note_diamond_stays_squareish():
+    """A short-label diamond keeps a square-ish aspect, not a flat sliver."""
+    note = await _build("Decision point", NodeType.DIAMOND)
+    size = note.properties.node_size.size
+    assert size.height >= size.width  # min-aspect floor (square)
+
+
+async def test_build_note_sheet_keeps_reading_width():
+    """Sheets keep their fixed reading width; only height fits content."""
+    default_w, _ = get_default_note_size(NodeType.SHEET)
+    note = await _build("a short heading", NodeType.SHEET)
+    assert note.properties.node_size.size.width == default_w
+
+
+async def test_build_note_empty_content_keeps_default_size():
+    """Empty content has nothing to measure, so the default size is kept."""
+    note = await _build("")
+    width, height = get_default_note_size(NodeType.RECTANGLE)
+    assert note.properties.node_size.size.width == width
+    assert note.properties.node_size.size.height == height
+
+
+async def test_build_note_non_content_type_keeps_default_size():
+    """Preview types (e.g. slide) are not content-sized; default height stands."""
+    note = await _build("lots of text " * 50, NodeType.SLIDE)
+    width, height = get_default_note_size(NodeType.SLIDE)
+    assert note.properties.node_size.size.height == height

--- a/backend/test/unit/agents/test_widget_learn.py
+++ b/backend/test/unit/agents/test_widget_learn.py
@@ -103,11 +103,14 @@ async def test_learn_generate_diagram_returns_skill_prompt() -> None:
     # Brevity rule.
     assert "paragraph" in prompt.lower()
     assert "label" in prompt.lower()
-    # Shape vocabulary — narrow on purpose (no capsule / tag / thought-cloud / layered-*).
+    # Shape vocabulary — narrow on purpose (no capsule / tag / thought-cloud).
     assert "rectangle" in prompt
     assert "ellipse" in prompt
     assert "diamond" in prompt
-    # Stay-with-rectangles rule for pure taxonomies — drift would
+    # Mindmap/taxonomy hub: the root is a layered-circle, branches rectangles.
+    # Drift here would let the agent flatten the center back into a rectangle.
+    assert "layered-circle" in prompt
+    # Hub-plus-rectangles rule for pure taxonomies — drift would
     # let the agent over-decorate hierarchies.
     assert "taxonomy" in prompt.lower() or "hierarchy" in prompt.lower()
 

--- a/backend/test/unit/utils/test_colors.py
+++ b/backend/test/unit/utils/test_colors.py
@@ -1,0 +1,73 @@
+"""Tests for the paper-adapted Tailwind palette (webui parity)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from topix.utils.colors import (
+    BLUE_200,
+    TAILWIND_200_ADAPTED,
+    TAILWIND_200_RAW,
+    adapt_tailwind_color,
+    hex_to_rgb,
+    rgb_to_hsl,
+)
+
+_HEX_RE = re.compile(r"^#[0-9a-f]{6}$")
+
+# Expected outputs computed by running the webui math (tailwind.ts
+# adaptTailwindColor + color.ts helpers) on the raw shade-200 inputs. These pin
+# byte-for-byte parity with the frontend; if the warming constants change there,
+# update them here too.
+_FRONTEND_ADAPTED_200 = {
+    "blue": "#cbeaf3",
+    "orange": "#f5d9b5",
+    "teal": "#a7eccb",
+    "stone": "#e9e6e3",
+    "red": "#f8d4d0",
+    "slate": "#e5eaec",
+}
+
+
+@pytest.mark.parametrize(("family", "expected"), _FRONTEND_ADAPTED_200.items())
+def test_adapt_matches_frontend(family, expected):
+    """Adapted shade-200 values are byte-identical to the webui output."""
+    assert adapt_tailwind_color(TAILWIND_200_RAW[family], 200) == expected
+
+
+def test_palette_has_one_entry_per_family():
+    """The adapted palette covers every raw family, in order."""
+    assert len(TAILWIND_200_ADAPTED) == len(TAILWIND_200_RAW) == 23
+
+
+def test_palette_entries_are_valid_hex():
+    """Every adapted swatch is a normalized #rrggbb string."""
+    assert all(_HEX_RE.match(c) for c in TAILWIND_200_ADAPTED)
+
+
+def test_adaptation_warms_away_from_raw():
+    """Warming actually changes the color (not a passthrough)."""
+    assert adapt_tailwind_color("#bfdbfe", 200) != "#bfdbfe"
+
+
+def test_blue_200_is_adapted_blue():
+    """The exported BLUE_200 default is the adapted blue swatch."""
+    assert BLUE_200 == adapt_tailwind_color(TAILWIND_200_RAW["blue"], 200)
+    assert BLUE_200 == "#cbeaf3"
+
+
+def test_hex_to_rgb_handles_short_and_long_form():
+    """Both #abc and #aabbcc parse to the same RGB triple."""
+    assert hex_to_rgb("#fff") == (255, 255, 255)
+    assert hex_to_rgb("#000000") == (0, 0, 0)
+    assert hex_to_rgb("#bfdbfe") == (191, 219, 254)
+
+
+def test_rgb_to_hsl_known_values():
+    """RGB→HSL returns hue in degrees and s/l as 0-100 integers."""
+    assert rgb_to_hsl(255, 255, 255) == (0, 0, 100)
+    assert rgb_to_hsl(0, 0, 0) == (0, 0, 0)
+    h, s, _ = rgb_to_hsl(255, 0, 0)
+    assert h == 0 and s == 100

--- a/backend/test/unit/utils/test_text_measure.py
+++ b/backend/test/unit/utils/test_text_measure.py
@@ -1,0 +1,118 @@
+"""Tests for markdown height estimation used by post-turn auto-layout."""
+
+from __future__ import annotations
+
+import pytest
+
+from topix.datatypes.note.style import FontSize, NodeType
+from topix.utils.graph.text_measure import (
+    CONTENT_HEIGHT_BUFFER,
+    CONTENT_SIZED_TYPES,
+    MAX_ESTIMATED_HEIGHT,
+    estimate_markdown_height,
+    estimate_node_height,
+)
+
+# One short line at the default font size: a single 24px line plus the buffer.
+_ONE_LINE_M = 24 + CONTENT_HEIGHT_BUFFER
+_LONG_LINE = "The quick brown fox jumps over the lazy dog and keeps running past the meadow"
+
+
+@pytest.mark.parametrize("content", ["", "   ", "\n\t\n", None])
+def test_empty_content_is_zero(content):
+    """Blank or missing content contributes no height."""
+    assert estimate_markdown_height(content, 300) == 0.0
+
+
+def test_single_short_line_is_one_line_plus_buffer():
+    """A line that fits the width is exactly one line height plus the buffer."""
+    assert estimate_markdown_height("hello world", 300) == _ONE_LINE_M
+
+
+def test_wrapping_grows_height_as_width_shrinks():
+    """The same text wraps to more lines (taller) at a narrower width."""
+    wide = estimate_markdown_height(_LONG_LINE, 600)
+    narrow = estimate_markdown_height(_LONG_LINE, 200)
+    assert narrow > wide > _ONE_LINE_M
+
+
+def test_hard_line_breaks_count_as_lines():
+    """Each newline forces a new line even when each fits the width."""
+    three = estimate_markdown_height("line one\nline two\nline three", 300)
+    assert three == 3 * 24 + CONTENT_HEIGHT_BUFFER
+
+
+def test_code_block_adds_vertical_margin():
+    """A fenced block carries top+bottom margin beyond its prose lines."""
+    plain = estimate_markdown_height("def f(x):\n    return x * x", 300)
+    fenced = estimate_markdown_height("```python\ndef f(x):\n    return x * x\n```", 300)
+    assert fenced > plain
+
+
+def test_larger_font_is_taller():
+    """A larger font size yields a taller single line."""
+    small = estimate_markdown_height("hello", 300, FontSize.S)
+    large = estimate_markdown_height("hello", 300, FontSize.XL)
+    assert large > small
+
+
+def test_inline_markers_do_not_inflate_height():
+    """Emphasis markers are stripped before measuring, so they don't add lines."""
+    plain = estimate_markdown_height("bold and code and link", 300)
+    marked = estimate_markdown_height("**bold** and `code` and [link](http://x)", 300)
+    assert marked == plain
+
+
+def test_oversize_content_is_clamped():
+    """Pathologically large content is capped, not unbounded."""
+    assert estimate_markdown_height("word " * 200_000, 300) == MAX_ESTIMATED_HEIGHT
+
+
+def test_long_unbroken_word_char_wraps():
+    """A word longer than the width wraps by character into multiple lines."""
+    assert estimate_markdown_height("x" * 400, 300) > 5 * 24
+
+
+def test_font_size_accepts_string_alias():
+    """The font size may be passed as its string value, not only the enum."""
+    assert estimate_markdown_height("hello", 300, "M") == estimate_markdown_height(
+        "hello", 300, FontSize.M
+    )
+
+
+# --- estimate_node_height (shape-aware) -------------------------------------
+
+
+def test_excluded_types_return_zero():
+    """Preview / non-text node types are not content-sized."""
+    for node_type in (NodeType.SLIDE, NodeType.WIDGET, NodeType.MINI_APP, NodeType.FOLDER,
+                       NodeType.IMAGE, NodeType.ICON):
+        assert node_type not in CONTENT_SIZED_TYPES
+        assert estimate_node_height(node_type, 400, _LONG_LINE) == 0.0
+
+
+def test_included_types_are_positive():
+    """Content-sized types produce a positive height for non-empty content."""
+    for node_type in (NodeType.RECTANGLE, NodeType.TEXT, NodeType.SHEET,
+                      NodeType.CODE_SANDBOX, NodeType.DIAMOND, NodeType.ELLIPSE):
+        assert estimate_node_height(node_type, 400, _LONG_LINE) > 0.0
+
+
+def test_node_height_zero_for_empty_or_no_width():
+    """No content or a non-positive width yields no height."""
+    assert estimate_node_height(NodeType.RECTANGLE, 400, "") == 0.0
+    assert estimate_node_height(NodeType.RECTANGLE, 0, _LONG_LINE) == 0.0
+
+
+def test_diamond_and_ellipse_taller_than_rectangle():
+    """Inscribed-area shapes need a taller bounding box than a plain rect."""
+    rect = estimate_node_height(NodeType.RECTANGLE, 300, _LONG_LINE)
+    diamond = estimate_node_height(NodeType.DIAMOND, 300, _LONG_LINE)
+    ellipse = estimate_node_height(NodeType.ELLIPSE, 300, _LONG_LINE)
+    assert diamond > rect
+    assert ellipse > rect
+
+
+def test_node_height_is_clamped():
+    """Even after the shape height-factor divide, output stays within the cap."""
+    assert estimate_node_height(NodeType.DIAMOND, 300, "word " * 200_000) == MAX_ESTIMATED_HEIGHT

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -37,6 +37,13 @@ logger = logging.getLogger(__name__)
 AUTO_MODEL_BASE_PLAN = "openrouter/z-ai/glm-4.7:nitro"
 AUTO_MODEL_COMPLEX_PLAN = ModelEnum.OpenAI.GPT_5_4
 
+# Hard ceiling on plan-agent turns (one turn = one LLM invocation, which may
+# fire several parallel tool calls). This is a runaway-loop backstop, not a
+# working target: normal answers finish in a handful of turns. Sized generously
+# so research-heavy turns (memory + several searches + writes + links + a
+# re-read) complete rather than getting cut off mid-build.
+ASSISTANT_MAX_TURNS = 30
+
 
 class AssistantManager:
     """Orchestrates the full flow: query rewrite, planning, searching ..."""
@@ -265,7 +272,7 @@ class AssistantManager:
         query: str,
         session: AssistantSession | None = None,
         message_id: str | None = None,
-        max_turns: int = 5,
+        max_turns: int = ASSISTANT_MAX_TURNS,
         message_context: str | None = None
     ) -> str:
         """Run the assistant agent with the provided context and query."""
@@ -314,7 +321,7 @@ class AssistantManager:
         query: str,
         session: AssistantSession | None = None,
         message_id: str | None = None,
-        max_turns: int = 8,
+        max_turns: int = ASSISTANT_MAX_TURNS,
         message_context: str | None = None
     ) -> AsyncGenerator[AgentStreamMessage | ToolCall, str]:
         """Run the assistant agent with the provided context and query.

--- a/backend/topix/agents/notes/layout.py
+++ b/backend/topix/agents/notes/layout.py
@@ -24,9 +24,11 @@ from typing import TYPE_CHECKING
 from topix.agents.notes.service import DEFAULT_NOTE_GAP
 from topix.datatypes.note.link import Link
 from topix.datatypes.note.note import Note
+from topix.datatypes.note.style import NodeType
 from topix.datatypes.property import PositionProperty
 from topix.store.graph import GraphStore
 from topix.utils.graph.layout import LayoutDirection, layout_directed
+from topix.utils.graph.text_measure import estimate_node_height
 
 if TYPE_CHECKING:
     from topix.collab.agent_bridge import AgentBoardBridge
@@ -45,6 +47,41 @@ RANK_PAD = 150.0
 TILE_GAP_X = 80.0
 TILE_GAP_Y = 120.0
 MAX_ROW_WIDTH = 3500.0
+
+# Edge endpoint anchoring: pull the attach point this many px inside the border
+# so it sits just inside the shape (clean arrowhead, no sub-pixel gap).
+EDGE_ANCHOR_INSET = 1.5
+
+# Shapes whose edges stay centre-anchored — the renderer clips a center→center
+# line to a clean radial point on the curve/tip. A fixed side-midpoint would
+# bunch every spoke at one point (e.g. all branches leaving a hub's rightmost
+# pixel). Rectangles instead anchor at the border midpoint facing the peer.
+_CENTER_ANCHOR_TYPES = {
+    NodeType.ELLIPSE,
+    NodeType.LAYERED_CIRCLE,
+    NodeType.DIAMOND,
+    NodeType.LAYERED_DIAMOND,
+    NodeType.SOFT_DIAMOND,
+}
+
+
+def _edge_anchor_offset(
+    node_type: NodeType, width: float, height: float, dx: float, dy: float,
+) -> tuple[float, float]:
+    """Node-local edge anchor (relative to top-left), facing the peer node.
+
+    `(dx, dy)` points from this node's center toward the other endpoint's
+    center. Round/diamond shapes anchor at the center (the renderer clips to a
+    clean radial point); rectangles anchor at the midpoint of the border facing
+    the peer, inset slightly so the point sits just inside the border. The
+    dominant axis picks the side: horizontal → left/right, vertical → top/bottom.
+    """
+    if node_type in _CENTER_ANCHOR_TYPES or width <= 0 or height <= 0:
+        return width / 2.0, height / 2.0
+    inset = min(EDGE_ANCHOR_INSET, width / 2.0, height / 2.0)
+    if abs(dx) >= abs(dy):
+        return (width - inset if dx >= 0 else inset), height / 2.0
+    return width / 2.0, (height - inset if dy >= 0 else inset)
 
 
 def _classify_tree(
@@ -176,11 +213,25 @@ def _connected_components(
 
 
 def _size_of(note: Note) -> tuple[float, float]:
-    """Return the note's persisted (width, height), defaulting to (0, 0) if unset."""
+    """Return the note's (width, height) for layout, defaulting to (0, 0) if unset.
+
+    For content-sized node types the persisted height is only a stub (text notes
+    default to 20px), so we grow it to the height the markdown will actually
+    render at — this is what keeps Sugiyama's sibling spacing from collapsing.
+    Width is kept as-is and height never shrinks below the persisted value.
+    """
     size = note.properties.node_size.size
     if size is None:
         return 0.0, 0.0
-    return size.width, size.height
+    width, height = size.width, size.height
+    if width > 0:
+        text = note.content.markdown if note.content else None
+        if not text and note.label:
+            text = note.label.markdown
+        if text:
+            estimated = estimate_node_height(note.style.type, width, text, note.style.font_size)
+            height = max(height, estimated)
+    return width, height
 
 
 def _real_position(note: Note) -> tuple[float, float]:
@@ -512,4 +563,72 @@ async def rearrange_created_notes(  # noqa: C901
             updated = await graph_store.patch_note(nid, patch)
         if updated is not None:
             moved.append(nid)
+
+    await _anchor_link_endpoints(
+        graph_store=graph_store,
+        links=relevant_links,
+        final_positions=final_positions,
+        anchors_by_id=anchors_by_id,
+        notes_by_id={**movable_by_id, **anchors_by_id},
+        sizes=sizes,
+    )
     return moved
+
+
+async def _anchor_link_endpoints(
+    graph_store: GraphStore,
+    links: list[Link],
+    final_positions: dict[str, tuple[float, float]],
+    anchors_by_id: dict[str, Note],
+    notes_by_id: dict[str, Note],
+    sizes: dict[str, tuple[float, float]],
+) -> None:
+    """Persist border-to-border edge anchors for the laid-out links.
+
+    For each link, set `start_point` / `end_point` to a node-local offset
+    (`is_local_offset=True`) on the border facing the peer node, so edges run
+    border-to-border instead of center-to-center. Endpoints whose node was not
+    laid out this turn are skipped. Persisted (not broadcast): the initiating
+    client re-fetches canonical link state, and live peers re-anchor on reload.
+    """
+    def center(nid: str) -> tuple[float, float] | None:
+        if nid in final_positions:
+            x, y = final_positions[nid]
+        elif nid in anchors_by_id:
+            x, y = _real_position(anchors_by_id[nid])
+        else:
+            return None
+        w, h = sizes.get(nid, (0.0, 0.0))
+        return x + w / 2.0, y + h / 2.0
+
+    updates: list[tuple[str, dict]] = []
+    for link in links:
+        src_c = center(link.source)
+        tgt_c = center(link.target)
+        src_note = notes_by_id.get(link.source)
+        tgt_note = notes_by_id.get(link.target)
+        if src_c is None or tgt_c is None or src_note is None or tgt_note is None:
+            continue
+        sw, sh = sizes.get(link.source, (0.0, 0.0))
+        tw, th = sizes.get(link.target, (0.0, 0.0))
+        dx, dy = tgt_c[0] - src_c[0], tgt_c[1] - src_c[1]
+        sox, soy = _edge_anchor_offset(src_note.style.type, sw, sh, dx, dy)
+        tox, toy = _edge_anchor_offset(tgt_note.style.type, tw, th, -dx, -dy)
+        updates.append((
+            link.id,
+            {
+                "properties": {
+                    "start_point": PositionProperty(
+                        position=PositionProperty.Position(x=sox, y=soy),
+                        is_local_offset=True,
+                    ).model_dump(),
+                    "end_point": PositionProperty(
+                        position=PositionProperty.Position(x=tox, y=toy),
+                        is_local_offset=True,
+                    ).model_dump(),
+                }
+            },
+        ))
+
+    if updates:
+        await graph_store.update_links(updates)

--- a/backend/topix/agents/notes/service.py
+++ b/backend/topix/agents/notes/service.py
@@ -9,33 +9,32 @@ from topix.datatypes.note.style import FontFamily, NodeType, StrokeStyle, Style,
 from topix.datatypes.property import PositionProperty, SizeProperty
 from topix.datatypes.resource import RichText
 from topix.store.graph import GraphStore
+from topix.utils.colors import TAILWIND_200_ADAPTED
+from topix.utils.graph.text_measure import estimate_node_size
 
 DEFAULT_NOTE_GAP = 80
 DEFAULT_CHILD_OFFSET_X = 40
 DEFAULT_CHILD_OFFSET_Y = 80
 SHEET_MIN_WIDTH = 200
 SHEET_MIN_HEIGHT = 120
-DEFAULT_NOTE_COLORS_HEX = [
-    "#d2bfb4",
-    "#f1bd85",
-    "#eed25d",
-    "#f2b2cb",
-    "#95e4a1",
-    "#71deb2",
-    "#f1b8ec",
-    "#f5afb1",
-    "#a4def0",
-]
 
 
 def build_default_note_style(note_type: NodeType) -> Style:
-    """Return the backend default style for a given note type."""
+    """Return the backend default style for a given note type.
+
+    Mirrors webui `createDefaultStyle`: built-in shapes are sharp-cornered
+    (roundness 0) and filled with a random paper-adapted Tailwind-200 swatch —
+    the same palette the canvas renders (see :mod:`topix.utils.colors`). Custom
+    nodes (sheet / code-sandbox / widget / slide) keep their bespoke styling.
+    """
     style = Style(type=note_type)
-    style.background_color = random.choice(DEFAULT_NOTE_COLORS_HEX)
+    style.background_color = random.choice(TAILWIND_200_ADAPTED)
+    # Built-in shapes default to sharp corners; the Style class default (3.0)
+    # is for legacy rows. Custom nodes override below.
+    style.roundness = 0
 
     if note_type == NodeType.SHEET:
         style.roughness = 0
-        style.roundness = 0
         style.text_align = TextAlign.LEFT
     elif note_type == NodeType.TEXT:
         style.background_color = "#00000000"
@@ -44,6 +43,7 @@ def build_default_note_style(note_type: NodeType) -> Style:
         style.background_color = "#00000000"
         style.stroke_style = StrokeStyle.DASHED
         style.font_family = FontFamily.SANS_SERIF
+        style.roundness = 2
     elif note_type == NodeType.CODE_SANDBOX:
         style.background_color = "#faf4ed"
         style.text_color = "#575279"
@@ -160,6 +160,13 @@ async def build_note(
         content=RichText(markdown=content),
     )
     note.properties.node_position = PositionProperty(position=position)
+    # Fit the box to the rendered markdown (shape-aware) so agent-created notes
+    # aren't stuck at the stub default: shapes/text labels shrink toward their
+    # content width, document types keep their reading width and fit height.
+    # Empty content / non-content-sized types fall back to the default size.
+    fitted = estimate_node_size(note_type, width, content or label, note.style.font_size)
+    if fitted is not None:
+        width, height = fitted
     note.properties.node_size = SizeProperty(
         size=SizeProperty.Size(width=width, height=height)
     )

--- a/backend/topix/datatypes/note/style.py
+++ b/backend/topix/datatypes/note/style.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from topix.utils.colors import BLUE_200
+
 
 class NodeType(StrEnum):
     """Enumeration for node types."""
@@ -99,16 +101,17 @@ class Style(BaseModel):
 
     """
 
-    # Defaults aligned with frontend createDefaultStyle() for rectangle nodes
+    # Defaults aligned with frontend createDefaultStyle() for rectangle nodes:
+    # sharp corners (roundness 0) and the paper-adapted blue-200 fill.
     type: NodeType = NodeType.RECTANGLE
     angle: float = 0.0
     stroke_color: str = "#00000000"
     stroke_width: float = 2
     stroke_style: StrokeStyle = StrokeStyle.SOLID
-    background_color: str = "#dbeafe"
+    background_color: str = BLUE_200
     fill_style: FillStyle = FillStyle.SOLID
     roughness: float = 0.5
-    roundness: float = 3.0
+    roundness: float = 0.0
     opacity: float = 100
     group_ids: list[str] = []
     font_size: FontSize = FontSize.M

--- a/backend/topix/nlp/pipeline/parsing.py
+++ b/backend/topix/nlp/pipeline/parsing.py
@@ -26,41 +26,20 @@ from topix.datatypes.resource import RichText
 from topix.nlp.chunking import Chunker
 from topix.nlp.parser import MistralParser
 from topix.store.qdrant.store import ContentStore
+from topix.utils.colors import TAILWIND_200_ADAPTED
 from topix.utils.graph.layout import LayoutDirection, displace_nodes, layout_directed
 
 logger = logging.getLogger(__name__)
 
-TAILWIND_200_HEX = [
-    "#e2e8f0",  # slate
-    "#e5e7eb",  # gray
-    "#e7e5e4",  # stone
-    "#e5e5e5",  # neutral
-    "#e4e4e7",  # zinc
-    "#eaddd7",  # brown
-    "#fecaca",  # red
-    "#fecdd3",  # rose
-    "#fbcfe8",  # pink
-    "#f5d0fe",  # fuchsia
-    "#ddd6fe",  # violet
-    "#e9d5ff",  # purple
-    "#c7d2fe",  # indigo
-    "#bfdbfe",  # blue
-    "#bae6fd",  # sky
-    "#a5f3fc",  # cyan
-    "#99f6e4",  # teal
-    "#a7f3d0",  # emerald
-    "#bbf7d0",  # green
-    "#d9f99d",  # lime
-    "#fef08a",  # yellow
-    "#fde68a",  # amber
-    "#fed7aa",  # orange
-]
-
 
 def color_notes_random_200(notes: list[Note]) -> None:
-    """Assign a random Tailwind 200 background color to each note."""
+    """Assign each note a random paper-adapted Tailwind-200 background color.
+
+    Uses the same palette the canvas renders (see :mod:`topix.utils.colors`) so
+    document-derived notes match the frontend swatches.
+    """
     for note in notes:
-        note.style.background_color = random.choice(TAILWIND_200_HEX)
+        note.style.background_color = random.choice(TAILWIND_200_ADAPTED)
         note.style.text_color = "#000000"
 
 

--- a/backend/topix/prompts/plan.system.jinja
+++ b/backend/topix/prompts/plan.system.jinja
@@ -122,11 +122,11 @@ Citations: inline Markdown only, placed immediately after the claim they support
 - If a widget call succeeded, briefly confirm; if it failed, briefly say so — do not go into detail.
 
 ## BUDGETS AND FAILURES
-- Max 8 actions total
+- Be efficient in tool calling: every call costs time and tokens, so reach for the answer in as few as the task genuinely needs. Prefer one decisive call over several exploratory ones, and batch independent calls into a single parallel step rather than spreading them across turns.
 - Max 4 `web_search`
 - Max 2 `code_interpreter`
 - Max 25 notes created per turn, regardless of structure.
-- If nearing a budget, spend remaining calls only on facts that could materially change the answer.
+- Spend tool calls only on facts that could materially change the answer; if you already know enough to answer well, stop calling tools and answer.
 - If sources conflict, note the disagreement briefly and rely on the strongest or most relevant evidence.
 
 ## SECURITY

--- a/backend/topix/prompts/widget/learn_generate_diagram.jinja
+++ b/backend/topix/prompts/widget/learn_generate_diagram.jinja
@@ -17,32 +17,33 @@ If you find yourself writing more than ~20 words in `content`, stop and split it
 
 ---
 
-## Mix three shapes when the diagram is a flow or schema
+## Use shapes to carry meaning
 
-For pure taxonomies (parent → child → grandchild hierarchies — "kingdoms of life", "parts of an atom"), use `rectangle` everywhere. The tree shape carries the meaning; shape variety would only add noise.
-
-For **flows** (a sequence with branches/decisions — sign-up flow, request lifecycle) and **schemas** (different kinds of things linked together — entity relationships, system architecture), reach for the right shape so the reader sees structure at a glance:
+Shapes are semantic, not decoration. The whole vocabulary:
 
 | Shape | When the node represents |
 |---|---|
-| `rectangle` | Generic concept, fact, branch (default — when in doubt, this) |
+| `rectangle` | Generic concept, fact, branch, or step (default — when in doubt, this) |
+| `layered-circle` | The hub of a mindmap / taxonomy — the single root the tree radiates from |
 | `ellipse` | Terminal point in a flow — a start, an end, a final outcome |
-| `diamond` / `soft-diamond` | A decision or fork — any branching point in the flow |
+| `diamond` / `soft-diamond` | A decision or fork — any branching point in a flow |
 
 That's the entire vocabulary for now. Other shapes exist but are not part of this skill — don't reach for them.
 
-**Aim for ~3 shapes per flow, not 8.** Use the minimum variety needed to make the structure legible.
+For pure taxonomies / mindmaps (parent → child → grandchild — "kingdoms of life", "parts of an atom"), make the **root a `layered-circle`** and every child and grandchild a `rectangle`. The circle anchors the eye on the center; the tree shape carries the rest — don't vary the branch shapes further.
+
+For **flows** (a sequence with branches/decisions — sign-up flow, request lifecycle) and **schemas** (different kinds of things linked together — entity relationships, system architecture), reach for `ellipse` and `diamond` so the reader sees structure at a glance. **Aim for ~3 shapes per flow, not 8** — the minimum variety needed to be legible.
 
 ---
 
 ## Worked examples
 
-### Pure taxonomy — rectangles only
+### Pure taxonomy — layered-circle hub, rectangle branches
 
 > "Explain the kingdoms of life."
 
 ```
-write_note label="Living things"   type="rectangle"  content="The six kingdoms across three domains."
+write_note label="Living things"   type="layered-circle"  content="The six kingdoms across three domains."
 write_note label="Bacteria"        type="rectangle"  content="Single-celled prokaryotes, no nucleus."
 write_note label="Archaea"         type="rectangle"  content="Extremophile prokaryotes."
 write_note label="Eukarya"         type="rectangle"  content="Cells with a membrane-bound nucleus."
@@ -84,7 +85,7 @@ Three shapes, each one carries meaning: ellipse for entry/exit points, rectangle
 Walk through these before issuing the `write_note`s:
 
 1. Every node's `content` is a short phrase or one short sentence — no paragraphs.
-2. For a taxonomy: all rectangles; hierarchy is the message.
+2. For a taxonomy / mindmap: the root is a `layered-circle`, every other node is a `rectangle`; hierarchy is the message.
 3. For a flow or schema: at least one ellipse (terminal) AND at least one diamond (decision), used where they actually fit. If you don't have those, you're probably building a taxonomy after all — drop the variety.
 4. Total notes between 5 and 15. Never exceed 25.
 

--- a/backend/topix/utils/colors.py
+++ b/backend/topix/utils/colors.py
@@ -1,0 +1,164 @@
+"""Paper-adapted Tailwind palette — backend mirror of the webui color pipeline.
+
+Faithful port of `webui/src/features/board/lib/colors/tailwind.ts` (and the HSL
+helpers in `webui/src/features/board/utils/color.ts`). The canvas does NOT render
+raw Tailwind: every shade is warmed toward a paper anchor (#f7f1e8) by
+`adapt_tailwind_color`. Shapes the agent creates on the backend must draw from
+the SAME adapted palette, otherwise their colors don't exist in the frontend's
+swatches. Keep this in sync with tailwind.ts; the warming constants and the
+ORIGINAL_TAILWIND_HEX ramp are the source of truth there.
+"""
+
+from __future__ import annotations
+
+# Raw Tailwind shade-200, one entry per family (23), copied from
+# ORIGINAL_TAILWIND_HEX in tailwind.ts. Only shade 200 is kept: it is the only
+# shade the backend fills shapes with, and the warming math needs just the
+# single source hex. If another shade is ever needed, copy its row from
+# tailwind.ts and call adapt_tailwind_color with that shade.
+TAILWIND_200_RAW: dict[str, str] = {
+    "slate": "#e2e8f0",
+    "gray": "#e5e7eb",
+    "stone": "#e7e5e4",
+    "neutral": "#e5e5e5",
+    "zinc": "#e4e4e7",
+    "brown": "#eaddd7",
+    "red": "#fecaca",
+    "rose": "#fecdd3",
+    "pink": "#fbcfe8",
+    "fuchsia": "#f5d0fe",
+    "violet": "#ddd6fe",
+    "purple": "#e9d5ff",
+    "indigo": "#c7d2fe",
+    "blue": "#bfdbfe",
+    "sky": "#bae6fd",
+    "cyan": "#a5f3fc",
+    "teal": "#99f6e4",
+    "emerald": "#a7f3d0",
+    "green": "#bbf7d0",
+    "lime": "#d9f99d",
+    "yellow": "#fef08a",
+    "amber": "#fde68a",
+    "orange": "#fed7aa",
+}
+
+TAILWIND_SHADES = (50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950)
+_SHADE_INDEX = {shade: index for index, shade in enumerate(TAILWIND_SHADES)}
+
+# Warming anchor — mirrors PAPER_REFERENCE_HEX in tailwind.ts.
+_PAPER_REFERENCE_HEX = "#f7f1e8"
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    """Clamp `value` into the inclusive [low, high] range."""
+    return max(low, min(high, value))
+
+
+def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Parse a #rgb or #rrggbb string into an (r, g, b) tuple of 0-255 ints."""
+    clean = hex_color.lstrip("#")
+    if len(clean) == 3:
+        clean = "".join(ch * 2 for ch in clean)
+    num = int(clean[:6], 16)
+    return (num >> 16) & 255, (num >> 8) & 255, num & 255
+
+
+def rgb_to_hsl(r: int, g: int, b: int) -> tuple[int, int, int]:
+    """Convert RGB (0-255) to HSL with hue in degrees and s/l as 0-100 ints."""
+    rf, gf, bf = r / 255, g / 255, b / 255
+    mx, mn = max(rf, gf, bf), min(rf, gf, bf)
+    h = 0.0
+    s = 0.0
+    light = (mx + mn) / 2
+    delta = mx - mn
+    if delta != 0:
+        s = delta / (2 - mx - mn) if light > 0.5 else delta / (mx + mn)
+        if mx == rf:
+            h = (gf - bf) / delta + (6 if gf < bf else 0)
+        elif mx == gf:
+            h = (bf - rf) / delta + 2
+        else:
+            h = (rf - gf) / delta + 4
+        h /= 6
+    return round(h * 360), round(s * 100), round(light * 100)
+
+
+def _hsl_to_hex(h: float, s: float, lightness: float) -> str:
+    """Convert HSL (hue degrees, s/l as 0-100) back to a #rrggbb string."""
+    hue = ((h % 360) + 360) % 360
+    sat = _clamp(s, 0, 100) / 100
+    light = _clamp(lightness, 0, 100) / 100
+    c = (1 - abs(2 * light - 1)) * sat
+    x = c * (1 - abs(((hue / 60) % 2) - 1))
+    m = light - c / 2
+    if hue < 60:
+        r, g, b = c, x, 0.0
+    elif hue < 120:
+        r, g, b = x, c, 0.0
+    elif hue < 180:
+        r, g, b = 0.0, c, x
+    elif hue < 240:
+        r, g, b = 0.0, x, c
+    elif hue < 300:
+        r, g, b = x, 0.0, c
+    else:
+        r, g, b = c, 0.0, x
+
+    def channel(value: float) -> str:
+        return format(round((value + m) * 255), "02x")
+
+    return f"#{channel(r)}{channel(g)}{channel(b)}"
+
+
+def _mix_hex(a: str, b: str, amount: float) -> str:
+    """Linearly blend two hex colors; `amount` is the weight toward `b`."""
+    ar, ag, ab = hex_to_rgb(a)
+    br, bg, bb = hex_to_rgb(b)
+    t = _clamp(amount, 0, 1)
+
+    def channel(x: float, y: float) -> str:
+        return format(round(x * (1 - t) + y * t), "02x")
+
+    return f"#{channel(ar, br)}{channel(ag, bg)}{channel(ab, bb)}"
+
+
+def _lerp_angle(frm: float, to: float, amount: float) -> float:
+    """Interpolate between two hue angles along the shortest arc."""
+    delta = ((((to - frm) % 360) + 540) % 360) - 180
+    return (frm + delta * amount + 360) % 360
+
+
+_PAPER_REFERENCE_HSL = rgb_to_hsl(*hex_to_rgb(_PAPER_REFERENCE_HEX))
+
+
+def adapt_tailwind_color(hex_color: str, shade: int) -> str:
+    """Warm a Tailwind color toward the paper anchor, preserving family identity.
+
+    Direct port of `adaptTailwindColor` in tailwind.ts — same blend/hue/sat/light
+    constants — so the output matches the swatches the canvas renders.
+    """
+    shade_index = _SHADE_INDEX.get(shade, 0)
+    shade_progress = shade_index / (len(TAILWIND_SHADES) - 1)
+    paper_blend = 0.28 - shade_progress * 0.14
+    hue_pull = 0.06 + (1 - shade_progress) * 0.06
+    saturation_scale = 0.9 - (1 - shade_progress) * 0.08
+
+    mixed = _mix_hex(hex_color, _PAPER_REFERENCE_HEX, paper_blend)
+    mixed_h, mixed_s, mixed_l = rgb_to_hsl(*hex_to_rgb(mixed))
+    _, _, base_l = rgb_to_hsl(*hex_to_rgb(hex_color))
+
+    return _hsl_to_hex(
+        _lerp_angle(mixed_h, _PAPER_REFERENCE_HSL[0], hue_pull),
+        _clamp(mixed_s * saturation_scale, 6, 92),
+        _clamp(base_l + (mixed_l - base_l) * 0.18, 18, 96),
+    )
+
+
+# Pre-built adapted shade-200 palette — the swatch set the canvas uses for
+# random shape fills (matches webui `pickRandomColorOfShade(200)`).
+TAILWIND_200_ADAPTED: list[str] = [
+    adapt_tailwind_color(raw, 200) for raw in TAILWIND_200_RAW.values()
+]
+
+# Default rectangle fill — mirrors webui `BLUE_200` (resolveFamilyShade("blue", 200)).
+BLUE_200: str = adapt_tailwind_color(TAILWIND_200_RAW["blue"], 200)

--- a/backend/topix/utils/graph/text_measure.py
+++ b/backend/topix/utils/graph/text_measure.py
@@ -1,0 +1,337 @@
+"""Estimate the rendered height of a note's markdown at a given width.
+
+Python port of the canvas engine's height probe
+(`canvas-harness/packages/core/src/text/estimate-height.ts`, itself ported
+from `canvas-lite-markdown.tsx`). The canvas wraps text with the browser's
+`canvas.measureText`; here we have no canvas, so we mirror its SSR fallback —
+a character-count heuristic (`len * fontSizePx * CHAR_WIDTH_FACTOR`).
+
+Used by the post-turn auto-layout so Sugiyama spacing reflects how tall a
+note will actually render, instead of the stub default heights (e.g. a TEXT
+note defaults to 20px tall but renders much taller once content wraps).
+
+Because the width heuristic is linear in character count, wrapping is pure
+arithmetic — no per-character re-measuring — so this stays O(content length).
+Keep the constants below in sync with `text/defaults.ts`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from math import ceil
+
+from topix.datatypes.note.style import FontSize, NodeType
+
+# Mirror text/defaults.ts. Font size and line height in CSS px per FontSize.
+_FONT_SIZE_PX: dict[str, int] = {"S": 14, "M": 16, "L": 24, "XL": 36}
+_LINE_HEIGHT_PX: dict[str, int] = {"S": 20, "M": 24, "L": 32, "XL": 40}
+
+# Average glyph advance as a fraction of font size. Matches the canvas's own
+# SSR / no-context fallback in `text/measure.ts` (`length * fontSize * 0.55`).
+# It is deliberately rough: we only need realistic *line counts*, not pixels.
+CHAR_WIDTH_FACTOR = 0.55
+
+# Layout constants from text/defaults.ts.
+CODE_BLOCK_PADDING_X = 6
+CODE_BLOCK_MARGIN_Y = 4
+CONTENT_HEIGHT_BUFFER = 4
+MIN_WIDTH = 40
+MIN_CODE_WIDTH = 20
+
+# Guards against pathological content: a 100KB note tells us nothing more
+# about spacing than a 5KB one does — both just mean "give it lots of room".
+MAX_MEASURE_CHARS = 16_000
+MAX_ESTIMATED_HEIGHT = 4_000.0
+
+# Width-fitting: horizontal text padding (2 × canvas CONTENT_PADDING) and the
+# floor a shrunk node width may not drop below.
+HORIZONTAL_PADDING = 12
+MIN_NODE_WIDTH = 120.0
+
+_HR_RE = re.compile(r"^[ \t]*---[ \t]*$")
+_HR_DOUBLE_RE = re.compile(r"^[ \t]*===[ \t]*$")
+
+# Collapses inline markdown emphasis to its display text so marker characters
+# (`**`, `` ` ``, `[…](…)`, `$$…$$`, …) don't inflate the measured width.
+# Mirrors INLINE_PATTERN in text/tokens.ts; the captured group is the text
+# that actually renders (link label, code body, math source, etc.).
+_INLINE_SUB = re.compile(
+    r"\$\$([^\n]+?)\$\$"
+    r"|\*\*([^*]+)\*\*"
+    r"|==([^=\s](?:[^=]*?[^=\s])?)=="
+    r"|`([^`]+)`"
+    r"|\*([^*]+)\*"
+    r"|__([^_]+)__"
+    r"|~~([^~]+)~~"
+    r"|_([^_]+)_"
+    r"|\[([^\]]+)\]\([^)]+\)"
+)
+
+_WS_SPLIT = re.compile(r"(\s+)")
+
+
+def _display_text(line: str) -> str:
+    """Strip inline emphasis markers, keeping the text that renders."""
+
+    def repl(match: re.Match[str]) -> str:
+        for group in match.groups():
+            if group is not None:
+                return group
+        return match.group(0)
+
+    return _INLINE_SUB.sub(repl, line)
+
+
+def _wrap_line_count(line: str, max_width: float, char_w: float) -> int:
+    """Count the visual lines one prose source line wraps into at `max_width`.
+
+    Word-wraps by whitespace, falling back to character wrapping for words
+    longer than the width — same policy as the canvas wrap engine.
+    """
+    chunks = [c for c in _WS_SPLIT.split(_display_text(line)) if c]
+    if not chunks:
+        return 1
+
+    cursor = 0.0
+    count = 1
+    for chunk in chunks:
+        width = len(chunk) * char_w
+        if chunk.isspace():
+            # Leading whitespace on a fresh line is dropped (cursor == 0).
+            if cursor > 0.0:
+                cursor += width
+            continue
+        if cursor > 0.0 and cursor + width > max_width:
+            count += 1
+            cursor = 0.0
+        if width > max_width and len(chunk) > 1:
+            # Word longer than the line: char-wrap. Linear because width is
+            # proportional to length — no need to re-measure per character.
+            per_line = max(1, int(max_width // char_w))
+            lines_needed = ceil(len(chunk) / per_line)
+            count += lines_needed - 1
+            last_chars = len(chunk) - (lines_needed - 1) * per_line
+            cursor = last_chars * char_w
+            continue
+        cursor += width
+    return count
+
+
+def _prose_height(block: str, max_width: float, char_w: float, line_height: int) -> float:
+    """Height of a non-code text segment (handles hard breaks and hr lines)."""
+    if not block.strip():
+        return 0.0
+    visual = 0
+    for line in block.split("\n"):
+        if _HR_RE.match(line) or _HR_DOUBLE_RE.match(line):
+            visual += 1
+            continue
+        visual += _wrap_line_count(line, max_width, char_w)
+    return visual * line_height
+
+
+def _code_block_height(code: str, max_width: float, char_w: float, line_height: int) -> float:
+    """Height of a fenced code block: char-wrapped lines plus top/bottom margin."""
+    code_max_width = max(MIN_CODE_WIDTH, max_width - CODE_BLOCK_PADDING_X * 2)
+    per_line = max(1, int(code_max_width // char_w))
+
+    visual = 0
+    for raw in code.split("\n"):
+        normalized = raw.replace("\t", "  ")
+        if not normalized:
+            visual += 1
+        else:
+            visual += max(1, ceil(len(normalized) / per_line))
+    visual = max(1, visual)
+    # First and last visual line each carry a vertical margin.
+    return visual * line_height + 2 * CODE_BLOCK_MARGIN_Y
+
+
+def _iter_segments(text: str):
+    """Yield (is_code, segment_text) splitting on ``` fences, like tokenize()."""
+    cursor = 0
+    length = len(text)
+    while cursor < length:
+        start = text.find("```", cursor)
+        if start == -1:
+            yield False, text[cursor:]
+            return
+        if start > cursor:
+            yield False, text[cursor:start]
+        end = text.find("```", start + 3)
+        if end == -1:
+            # Unterminated fence: treat the remainder as prose (matches tokenize).
+            yield False, text[start:]
+            return
+        fence_content = text[start + 3 : end]
+        # Drop the optional language line after the opening fence.
+        newline = re.search(r"[\r\n]", fence_content)
+        code = fence_content
+        if newline:
+            code = re.sub(r"^\r?\n", "", fence_content[newline.start() :])
+        yield True, code.replace("\r\n", "\n")
+        cursor = end + 3
+
+
+def estimate_markdown_height(
+    content: str | None,
+    width: float,
+    font_size: FontSize | str = FontSize.M,
+) -> float:
+    """Estimate the px height `content` renders to when wrapped at `width`.
+
+    Mirrors the canvas `estimateMarkdownContentHeight`. Returns 0.0 for empty
+    content; otherwise at least one line height plus a small buffer, clamped to
+    a sane maximum so a giant note can't blow up downstream layout math.
+    """
+    text = (content or "").strip()
+    if not text:
+        return 0.0
+    if len(text) > MAX_MEASURE_CHARS:
+        text = text[:MAX_MEASURE_CHARS]
+
+    key = font_size.value if isinstance(font_size, FontSize) else str(font_size)
+    line_height = _LINE_HEIGHT_PX.get(key, _LINE_HEIGHT_PX["M"])
+    char_w = _FONT_SIZE_PX.get(key, _FONT_SIZE_PX["M"]) * CHAR_WIDTH_FACTOR
+    max_width = max(MIN_WIDTH, ceil(width))
+
+    total = 0.0
+    for is_code, segment in _iter_segments(text):
+        if is_code:
+            total += _code_block_height(segment, max_width, char_w, line_height)
+        else:
+            total += _prose_height(segment, max_width, char_w, line_height)
+
+    total = max(line_height, total) + CONTENT_HEIGHT_BUFFER
+    return min(total, MAX_ESTIMATED_HEIGHT)
+
+
+# Per-shape (text_width_factor, content_height_factor), mirroring the canvas
+# `contentBounds` insets (render/shapes/content-bounds.ts). text_width_factor
+# shrinks the wrap width — a narrower interior makes the same text wrap taller;
+# content_height_factor is the fraction of the bounding box usable for text, so
+# the box height needed is `content_height / content_height_factor`. Capsule /
+# tag / thought-cloud use approximate constants in place of the canvas's
+# size-dependent (and self-referential) absolute insets — close enough for
+# layout spacing.
+_SQRT2_INV = 0.7071067811865476
+_SHAPE_FACTORS: dict[NodeType, tuple[float, float]] = {
+    NodeType.DIAMOND: (_SQRT2_INV, _SQRT2_INV),
+    NodeType.LAYERED_DIAMOND: (_SQRT2_INV, _SQRT2_INV),
+    NodeType.SOFT_DIAMOND: (_SQRT2_INV, _SQRT2_INV),
+    NodeType.ELLIPSE: (0.7, 0.7),
+    NodeType.LAYERED_CIRCLE: (0.7, 0.7),
+    NodeType.CAPSULE: (0.8, 1.0),
+    NodeType.TAG: (0.75, 1.0),
+    NodeType.THOUGHT_CLOUD: (1.0, 0.75),
+}
+
+# Node types whose layout height is derived from rendered content instead of the
+# stub default. Built-in shapes auto-fit to text on the canvas; among the custom
+# / preview nodes only sheet and code-sandbox are treated as content-sized.
+# Everything else (folder, image, icon, slide, widget, mini-app) keeps its fixed
+# default size.
+CONTENT_SIZED_TYPES: frozenset[NodeType] = frozenset(
+    {
+        NodeType.RECTANGLE,
+        NodeType.LAYERED_RECTANGLE,
+        NodeType.TEXT,
+        NodeType.ELLIPSE,
+        NodeType.LAYERED_CIRCLE,
+        NodeType.DIAMOND,
+        NodeType.LAYERED_DIAMOND,
+        NodeType.SOFT_DIAMOND,
+        NodeType.CAPSULE,
+        NodeType.TAG,
+        NodeType.THOUGHT_CLOUD,
+        NodeType.SHEET,
+        NodeType.CODE_SANDBOX,
+    }
+)
+
+
+def estimate_node_height(
+    node_type: NodeType,
+    width: float,
+    content: str | None,
+    font_size: FontSize | str = FontSize.M,
+) -> float:
+    """Estimate the bounding-box height a node needs to fit `content` at `width`.
+
+    Returns 0.0 for content-less or non-content-sized types. Accounts for shape
+    geometry: text inside a diamond/ellipse occupies an inscribed rect, so the
+    box must be taller (and wrap narrower) than a plain rectangle's.
+    """
+    if node_type not in CONTENT_SIZED_TYPES or width <= 0:
+        return 0.0
+    width_factor, height_factor = _SHAPE_FACTORS.get(node_type, (1.0, 1.0))
+    text_width = max(MIN_WIDTH, width * width_factor)
+    content_height = estimate_markdown_height(content, text_width, font_size)
+    if content_height <= 0.0:
+        return 0.0
+    return min(content_height / height_factor, MAX_ESTIMATED_HEIGHT)
+
+
+# Document-style types keep a fixed reading width; only their height fits.
+_FIXED_WIDTH_TYPES: frozenset[NodeType] = frozenset({NodeType.SHEET, NodeType.CODE_SANDBOX})
+
+# Minimum height as a fraction of width, so geometric shapes don't collapse to
+# slivers once width also shrinks. Square shapes (diamond/ellipse) stay ~square;
+# naturally-wide ones (capsule/tag) get a gentler floor. Types absent here
+# (rectangle/text/sheet) fit height freely.
+_MIN_ASPECT: dict[NodeType, float] = {
+    NodeType.DIAMOND: 1.0,
+    NodeType.LAYERED_DIAMOND: 1.0,
+    NodeType.SOFT_DIAMOND: 1.0,
+    NodeType.ELLIPSE: 1.0,
+    NodeType.LAYERED_CIRCLE: 1.0,
+    NodeType.THOUGHT_CLOUD: 0.6,
+    NodeType.CAPSULE: 0.35,
+    NodeType.TAG: 0.35,
+}
+
+
+def _natural_text_width(content: str, char_w: float) -> float:
+    """Return the widest unwrapped line of `content` in px (markers stripped)."""
+    widest = 0.0
+    for is_code, segment in _iter_segments(content):
+        for line in segment.split("\n"):
+            display = line if is_code else _display_text(line)
+            widest = max(widest, len(display) * char_w)
+    return widest
+
+
+def estimate_node_size(
+    node_type: NodeType,
+    default_width: float,
+    content: str | None,
+    font_size: FontSize | str = FontSize.M,
+) -> tuple[float, float] | None:
+    """Fit a node's (width, height) to its content, shape-aware.
+
+    Returns None for empty content or non-content-sized types (the caller keeps
+    the default size). Width shrinks toward the content's natural width, clamped
+    to [MIN_NODE_WIDTH, default_width], for shapes and text labels; document
+    types (sheet, code-sandbox) keep their reading width and only fit height. A
+    per-shape minimum aspect keeps diamonds/ellipses from collapsing to slivers.
+    """
+    text = (content or "").strip()
+    if node_type not in CONTENT_SIZED_TYPES or not text:
+        return None
+
+    if node_type in _FIXED_WIDTH_TYPES:
+        width = default_width
+    else:
+        key = font_size.value if isinstance(font_size, FontSize) else str(font_size)
+        char_w = _FONT_SIZE_PX.get(key, _FONT_SIZE_PX["M"]) * CHAR_WIDTH_FACTOR
+        width_factor = _SHAPE_FACTORS.get(node_type, (1.0, 1.0))[0]
+        box_width = (_natural_text_width(text, char_w) + HORIZONTAL_PADDING) / width_factor
+        lower = min(MIN_NODE_WIDTH, default_width)
+        width = max(lower, min(default_width, float(ceil(box_width))))
+
+    height = estimate_node_height(node_type, width, text, font_size)
+    min_aspect = _MIN_ASPECT.get(node_type)
+    if min_aspect is not None:
+        height = max(height, width * min_aspect)
+    return width, height


### PR DESCRIPTION
Improves how agent-generated notes and mindmaps render, plus a higher plan-agent turn ceiling.

## Node sizing — fit to content
- New `topix/utils/graph/text_measure.py`: a linear, shape-aware Python port of the canvas markdown height probe.
- `build_note` now fits each node's box to its content — width shrinks toward the content's natural width (clamped to `[120, default]`); document types (sheet/code-sandbox) keep their reading width; geometric shapes keep a square min-aspect so short labels don't collapse to slivers.
- `rearrange_created_notes` feeds the same estimate into Sugiyama gap spacing so layout reflects rendered heights.

## Color & shape defaults — frontend parity
- New `topix/utils/colors.py`: byte-for-byte port of the canvas paper-adapted Tailwind palette.
- Agent-created notes and the document-import path now fill shapes from the adapted shade-200 palette; built-in shapes default to sharp corners (`roundness 0`). `Style` class defaults realigned to the frontend rectangle.

## Edges — border to border
- `rearrange_created_notes` persists node-local `start_point`/`end_point` anchors (inset 1.5px) so edges run border-to-border instead of center-to-center. Round/diamond shapes stay center-anchored for clean radial spokes. Uses the model's existing `is_local_offset` fields — backward compatible (unset links fall back to center).

## Mindmap hub shape
- The diagram skill now makes a taxonomy/mindmap root a `layered-circle` hub with `rectangle` branches, keeping `ellipse` for flow terminals. Matches the document-import (mapify) path so both share one visual language.

## Agent turn ceiling
- Centralized as `ASSISTANT_MAX_TURNS = 30` (was 5 for `run`, 8 for `run_streamed`) so research-heavy turns finish instead of getting cut off. Replaced the stale "Max 8 actions" prompt budget with efficiency guidance.

## Tests
New unit tests for `text_measure`, `colors`, default note style/sizing, and edge anchoring; updated note-tool and diagram-skill tests to the new semantics. Full backend unit suite green (506 passed), ruff clean.

## Performance
All new computation is CPU-only, linear, and bounded by nodes created per turn (≤25) — it does not scale with board size. Edge anchoring adds a single batched `update_links` (1 read + 1 write) per turn. No new board-wide scans.