### PR TITLE
feat(prompts): proactive plan agent + node emphasis; switch base plan model

### DIFF
--- a/backend/test/unit/agents/assistant/test_note_tools.py
+++ b/backend/test/unit/agents/assistant/test_note_tools.py
@@ -52,8 +52,8 @@ class DummyGraphStore:
 
 
 @pytest.mark.asyncio
-async def test_build_note_sheet_keeps_reading_width_and_fits_height() -> None:
-    """Sheets keep their fixed reading width; height fits the content."""
+async def test_build_note_sheet_keeps_default_size() -> None:
+    """Sheets are long-form rich-text docs: kept at the full default size, not content-fit."""
     graph_store = DummyGraphStore()
 
     note = await build_note(
@@ -67,11 +67,11 @@ async def test_build_note_sheet_keeps_reading_width_and_fits_height() -> None:
 
     assert note.graph_uid == "graph-1"
     assert note.style.type == NodeType.SHEET
-    # Sheet is a fixed-width (document) type: width stays at the reading default.
-    assert note.properties.node_size.size.width == 560
-    # Height now fits the content, so a one-line sheet is far shorter than the
-    # old fixed 320 default.
-    assert 0 < note.properties.node_size.size.height < 320
+    # Sheet is exempt from content sizing — it keeps its full default footprint
+    # (a long doc shouldn't auto-grow into a giant card; it scrolls instead).
+    default_w, default_h = get_default_note_size(NodeType.SHEET)
+    assert note.properties.node_size.size.width == default_w
+    assert note.properties.node_size.size.height == default_h
     assert note.properties.node_position.position.x == 0
     assert note.properties.node_position.position.y == 0
 
@@ -201,8 +201,8 @@ async def test_write_note_tool_rewrites_existing_note_and_seeds_size_when_too_sm
                     "id": ANY,
                     "type": "size",
                     "size": {
-                        "width": 560.0,
-                        "height": 320.0,
+                        "width": 440.0,
+                        "height": 440.0,
                     },
                 },
             },

--- a/backend/test/unit/agents/notes/test_service.py
+++ b/backend/test/unit/agents/notes/test_service.py
@@ -130,11 +130,12 @@ async def test_build_note_diamond_stays_squareish():
     assert size.height >= size.width  # min-aspect floor (square)
 
 
-async def test_build_note_sheet_keeps_reading_width():
-    """Sheets keep their fixed reading width; only height fits content."""
-    default_w, _ = get_default_note_size(NodeType.SHEET)
+async def test_build_note_sheet_keeps_default_size():
+    """Sheets are long-form docs: kept at the full default size, never content-fit."""
+    default_w, default_h = get_default_note_size(NodeType.SHEET)
     note = await _build("a short heading", NodeType.SHEET)
     assert note.properties.node_size.size.width == default_w
+    assert note.properties.node_size.size.height == default_h
 
 
 async def test_build_note_empty_content_keeps_default_size():

--- a/backend/test/unit/utils/test_text_measure.py
+++ b/backend/test/unit/utils/test_text_measure.py
@@ -84,16 +84,16 @@ def test_font_size_accepts_string_alias():
 
 
 def test_excluded_types_return_zero():
-    """Preview / non-text node types are not content-sized."""
+    """Preview/doc node types are not content-sized (incl. sheet — kept at default)."""
     for node_type in (NodeType.SLIDE, NodeType.WIDGET, NodeType.MINI_APP, NodeType.FOLDER,
-                       NodeType.IMAGE, NodeType.ICON):
+                       NodeType.IMAGE, NodeType.ICON, NodeType.SHEET):
         assert node_type not in CONTENT_SIZED_TYPES
         assert estimate_node_height(node_type, 400, _LONG_LINE) == 0.0
 
 
 def test_included_types_are_positive():
     """Content-sized types produce a positive height for non-empty content."""
-    for node_type in (NodeType.RECTANGLE, NodeType.TEXT, NodeType.SHEET,
+    for node_type in (NodeType.RECTANGLE, NodeType.TEXT,
                       NodeType.CODE_SANDBOX, NodeType.DIAMOND, NodeType.ELLIPSE):
         assert estimate_node_height(node_type, 400, _LONG_LINE) > 0.0
 

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -34,7 +34,7 @@ from topix.utils.common import gen_uid
 
 logger = logging.getLogger(__name__)
 
-AUTO_MODEL_BASE_PLAN = "openrouter/z-ai/glm-4.7:nitro"
+AUTO_MODEL_BASE_PLAN = "openrouter/deepseek/deepseek-v4-flash:nitro"
 AUTO_MODEL_COMPLEX_PLAN = ModelEnum.OpenAI.GPT_5_4
 
 # Hard ceiling on plan-agent turns (one turn = one LLM invocation, which may

--- a/backend/topix/agents/notes/service.py
+++ b/backend/topix/agents/notes/service.py
@@ -73,8 +73,11 @@ def get_default_note_size(note_type: NodeType) -> tuple[int, int]:  # noqa: C901
     created ones.
     """
     if note_type == NodeType.SHEET:
-        # Prose-friendly reading width (~65-70 chars/line at 14px text).
-        return 560, 320
+        # Square "sticky note" default — a sheet is a long-form rich-text doc
+        # that scrolls, so a square jot surface reads better than a wide card.
+        # Sheets are exempt from content sizing, so this is the size they keep.
+        # Keep in sync with DEFAULT_SHEET_* in webui note.ts.
+        return 440, 440
     if note_type == NodeType.TEXT:
         return 300, 20
     if note_type == NodeType.SLIDE:

--- a/backend/topix/prompts/plan.system.jinja
+++ b/backend/topix/prompts/plan.system.jinja
@@ -1,9 +1,11 @@
 The time is now {{ time }}.
 
 ## ROLE
-You are a thoughtful tutor. The user's board is your canvas — a workspace where ideas can live as arranged notes, diagrams, and visual widgets, not only as prose. Pick the format that teaches best. The canvas auto-arranges what you create after your turn, so think about structure and content, not placement.
+You are a thoughtful tutor and a capable assistant. The user's board is your canvas — a workspace where ideas can live as arranged notes, diagrams, and visual widgets, not only as prose. Read past the literal request to the goal behind it, then deliver the most useful answer in the form that serves that goal best.
 
-Before you pick a format, imagine what the answer would look like if you could draw it on a whiteboard. That shape is what you should build.
+Take initiative on behalf of the goal. If the question is really a comparison, a table or chart earns its place; if it asks how something works, build the diagram; if it turns on current data, go fetch it — without waiting to be told to "make a chart" or "search." Choose the richest format the goal genuinely warrants, then execute it well.
+
+Two failure modes are equally bad: over-building (wrapping a two-line answer in a mindmap) and under-serving (a flat paragraph for something that begged for a diagram, chart, or comparison). Match effort to the goal — neither pad nor cut corners. Before you pick a format, imagine what the answer would look like on a whiteboard; that shape is what you build. The canvas auto-arranges what you create, so think about substance and structure, not placement.
 
 You speak warmly and directly. You do not announce your process, narrate what you are building, or caption the board. You deliver insight.
 
@@ -19,7 +21,7 @@ Ask what shape the answer really has, then pick the lightest surface that carrie
 - raw HTML you want to hand-author (rare — mini-app handles nearly everything renderable) → `learn_generate_html_widget` then `write_note(note_type="widget")` *(legacy)*
 - single concrete fact with supporting context → one rectangle note, no links
 
-Over-building is the most common failure mode. Do not wrap a three-item list in a mindmap. A two-sentence answer belongs in chat.
+Match the surface to the answer: don't wrap a three-item list in a mindmap, and don't bury a hierarchy, comparison, or process in a paragraph. A two-sentence answer belongs in chat.
 
 Examples (question → format → chat reply):
 - "What's the capital of Peru?" → chat only.
@@ -28,6 +30,10 @@ Examples (question → format → chat reply):
   Reply: "Photosynthesis turns sunlight, water, and CO₂ into sugar and oxygen. The mindmap walks through the two stages — light capture, then the Calvin cycle — and shows what goes in and what comes out."
 - "Make me a flashcard for the quadratic formula." → one mini-app flashcard.
   Reply: "The card flips between the formula and a worked example with \(a=1, b=-5, c=6\)."
+- "Compare France's and Germany's economies." → a mini-app table or chart — the comparison *is* the answer; don't wait to be asked for one.
+  Reply: "Germany's output runs about a third larger, but France carries a smaller trade gap — the table lines them up across five measures."
+- "Research the case for and against nuclear power." → gather current figures with `web_search`, then a schema or comparison the reader can scan, not a wall of prose.
+  Reply: "It comes down to low-carbon baseload versus waste and upfront cost — the board weighs the four strongest arguments on each side."
 
 Notice in all three replies: no "I've created", no bullets restating the board, the reference to the canvas is oblique ("the mindmap walks through", "the card flips"), and the reply ends at the insight.
 
@@ -117,7 +123,9 @@ Citations: inline Markdown only, placed immediately after the claim they support
 
 ## CANVAS STYLE
 - Keep labels short: at most 6 words, one idea, no "and" or commas.
-- Keep note content concise with light markdown emphasis only.
+- Note content is lite-markdown — use emphasis to spotlight the one thing that matters, not to decorate. Mark a key term, number, or verdict; leave the rest plain.
+  - `**bold**` the key term, `==highlight==` a critical value or takeaway, `` `code` `` for identifiers. `*italic*` and `_underline_` exist but reach for them rarely.
+  - One or two marks per note at most. An unformatted note beats a fully-bolded one — over-formatting reads as noise.
 - Default node type is `rectangle`. Use `sheet` for long-form writing, `code-sandbox` for runnable code, `mini-app` for any custom-rendered artifact (chart, dashboard, flashcard, interactive control), and `ellipse` or `diamond` sparingly when they add visual meaning in a diagram.
 - If a widget call succeeded, briefly confirm; if it failed, briefly say so — do not go into detail.
 

--- a/backend/topix/prompts/plan.user.jinja
+++ b/backend/topix/prompts/plan.user.jinja
@@ -8,7 +8,9 @@
 
 <reminders>
 - Today is {{ time }}.
+- Serve the goal behind the request, not just its literal words: pick the richest format it warrants (table, chart, diagram, fetched data) without being asked — but never pad. Over-building and under-serving are equally bad.
 - Pick the format that teaches best. Do not wrap a two-sentence answer in a mindmap, and do not answer a hierarchy question in chat alone.
+- In note content, spotlight the key term with light lite-markdown — `**bold**`, `==highlight==`, `` `code` `` — one or two marks per note, never a fully-formatted note.
 - For a multi-note answer: plan silently, then call all `write_note`s in parallel in one step, then call all `link_notes` in a second step. Positions auto-arrange after your turn — do not place or describe layout.
 - Use `web_search` for fresh or unstable facts, `memory_search` for personal or saved context (search memory first when both matter), `code_interpreter` only for calculations.
 - For any custom-rendered artifact (chart, dashboard, diagram, flashcard, interactive control, …), first call `learn_generate_mini_app`, then write `note_type="mini-app"`. Raw HTML widgets are legacy — only use `learn_generate_html_widget` / `note_type="widget"` if the user explicitly asks for hand-authored HTML.

--- a/backend/topix/prompts/widget/learn_generate_diagram.jinja
+++ b/backend/topix/prompts/widget/learn_generate_diagram.jinja
@@ -17,6 +17,15 @@ If you find yourself writing more than ~20 words in `content`, stop and split it
 
 ---
 
+## Spotlight the key term
+
+Node content is lite-markdown. Mark the one word or number that carries the node — a spotlight, not decoration:
+
+- `**bold**` the key term, `==highlight==` a critical value or verdict, `` `code` `` an identifier.
+- At most one mark per node, and most nodes need none. The structure already carries the meaning; a clean node beats an over-marked one.
+
+---
+
 ## Use shapes to carry meaning
 
 Shapes are semantic, not decoration. The whole vocabulary:
@@ -43,10 +52,10 @@ For **flows** (a sequence with branches/decisions — sign-up flow, request life
 > "Explain the kingdoms of life."
 
 ```
-write_note label="Living things"   type="layered-circle"  content="The six kingdoms across three domains."
-write_note label="Bacteria"        type="rectangle"  content="Single-celled prokaryotes, no nucleus."
+write_note label="Living things"   type="layered-circle"  content="The **six kingdoms** across three domains."
+write_note label="Bacteria"        type="rectangle"  content="Single-celled **prokaryotes**, no nucleus."
 write_note label="Archaea"         type="rectangle"  content="Extremophile prokaryotes."
-write_note label="Eukarya"         type="rectangle"  content="Cells with a membrane-bound nucleus."
+write_note label="Eukarya"         type="rectangle"  content="Cells with a membrane-bound **nucleus**."
 write_note label="Animals"         type="rectangle"  content="Multicellular, no cell walls, heterotrophic."
 write_note label="Plants"          type="rectangle"  content="Multicellular, cell walls, photosynthetic."
 write_note label="Fungi"           type="rectangle"  content="Decomposers; cell walls of chitin."
@@ -76,7 +85,7 @@ link_notes source="Email taken?"   target="Create account" label="no"
 link_notes source="Create account" target="Welcome screen"
 ```
 
-Three shapes, each one carries meaning: ellipse for entry/exit points, rectangle for steps, diamond for the branch.
+Three shapes, each one carries meaning: ellipse for entry/exit points, rectangle for steps, diamond for the branch. Note the emphasis above is sparing — only the standout term in a couple of nodes is **bold**; most are left plain.
 
 ---
 
@@ -87,7 +96,8 @@ Walk through these before issuing the `write_note`s:
 1. Every node's `content` is a short phrase or one short sentence — no paragraphs.
 2. For a taxonomy / mindmap: the root is a `layered-circle`, every other node is a `rectangle`; hierarchy is the message.
 3. For a flow or schema: at least one ellipse (terminal) AND at least one diamond (decision), used where they actually fit. If you don't have those, you're probably building a taxonomy after all — drop the variety.
-4. Total notes between 5 and 15. Never exceed 25.
+4. Emphasis is a spotlight, not a coat of paint: at most one `**bold**` / `==highlight==` per node, and most nodes need none.
+5. Total notes between 5 and 15. Never exceed 25.
 
 If you can't tick all four, fix the structure before submitting.
 {% endraw %}

--- a/backend/topix/utils/graph/text_measure.py
+++ b/backend/topix/utils/graph/text_measure.py
@@ -229,9 +229,11 @@ _SHAPE_FACTORS: dict[NodeType, tuple[float, float]] = {
 
 # Node types whose layout height is derived from rendered content instead of the
 # stub default. Built-in shapes auto-fit to text on the canvas; among the custom
-# / preview nodes only sheet and code-sandbox are treated as content-sized.
-# Everything else (folder, image, icon, slide, widget, mini-app) keeps its fixed
-# default size.
+# / preview nodes only code-sandbox is treated as content-sized. SHEET is
+# deliberately excluded: it is a long-form rich-text document (Notion-like), so
+# fitting its height would spawn a giant card — it keeps its default size and
+# scrolls instead. Everything else (folder, image, icon, slide, widget, mini-app,
+# sheet) keeps its fixed default size.
 CONTENT_SIZED_TYPES: frozenset[NodeType] = frozenset(
     {
         NodeType.RECTANGLE,
@@ -245,7 +247,6 @@ CONTENT_SIZED_TYPES: frozenset[NodeType] = frozenset(
         NodeType.CAPSULE,
         NodeType.TAG,
         NodeType.THOUGHT_CLOUD,
-        NodeType.SHEET,
         NodeType.CODE_SANDBOX,
     }
 )
@@ -274,7 +275,8 @@ def estimate_node_height(
 
 
 # Document-style types keep a fixed reading width; only their height fits.
-_FIXED_WIDTH_TYPES: frozenset[NodeType] = frozenset({NodeType.SHEET, NodeType.CODE_SANDBOX})
+# (Sheet is excluded from content sizing entirely — see CONTENT_SIZED_TYPES.)
+_FIXED_WIDTH_TYPES: frozenset[NodeType] = frozenset({NodeType.CODE_SANDBOX})
 
 # Minimum height as a fraction of width, so geometric shapes don't collapse to
 # slivers once width also shrinks. Square shapes (diamond/ellipse) stay ~square;

--- a/webui/src/components/editor/tiptap/editor.tsx
+++ b/webui/src/components/editor/tiptap/editor.tsx
@@ -103,24 +103,6 @@ export function TipTapEditor({
     return () => window.removeEventListener("keydown", handler)
   }, [editor, debouncedSave])
 
-  // Stop Cmd/Ctrl+C/V/X from reaching @canvas-harness's window-level
-  // keydown listener, which preventDefault's clipboard ops when focus
-  // isn't on an INPUT/TEXTAREA — but it doesn't check `isContentEditable`,
-  // so paste was hijacked inside the editor. Bubble-phase listener on the
-  // editor's own root fires before window, so stopPropagation here keeps
-  // ProseMirror's native paste handling intact.
-  useEffect(() => {
-    if (!editor) return
-    const dom = editor.view.dom
-    const onClipboardKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return
-      const k = e.key.toLowerCase()
-      if (k === "c" || k === "v" || k === "x") e.stopPropagation()
-    }
-    dom.addEventListener("keydown", onClipboardKey)
-    return () => dom.removeEventListener("keydown", onClipboardKey)
-  }, [editor])
-
   // External content sync. `useEditor`'s `content` is only consumed on
   // mount, so when something outside (e.g. an AI rewrite) updates the
   // markdown prop we have to push it into the editor manually. Compare

--- a/webui/src/components/editor/tiptap/editor.tsx
+++ b/webui/src/components/editor/tiptap/editor.tsx
@@ -103,6 +103,24 @@ export function TipTapEditor({
     return () => window.removeEventListener("keydown", handler)
   }, [editor, debouncedSave])
 
+  // Stop Cmd/Ctrl+C/V/X from reaching @canvas-harness's window-level
+  // keydown listener, which preventDefault's clipboard ops when focus
+  // isn't on an INPUT/TEXTAREA — but it doesn't check `isContentEditable`,
+  // so paste was hijacked inside the editor. Bubble-phase listener on the
+  // editor's own root fires before window, so stopPropagation here keeps
+  // ProseMirror's native paste handling intact.
+  useEffect(() => {
+    if (!editor) return
+    const dom = editor.view.dom
+    const onClipboardKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return
+      const k = e.key.toLowerCase()
+      if (k === "c" || k === "v" || k === "x") e.stopPropagation()
+    }
+    dom.addEventListener("keydown", onClipboardKey)
+    return () => dom.removeEventListener("keydown", onClipboardKey)
+  }, [editor])
+
   // External content sync. `useEditor`'s `content` is only consumed on
   // mount, so when something outside (e.g. an AI rewrite) updates the
   // markdown prop we have to push it into the editor manually. Compare

--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -11,7 +11,7 @@ import { Extension } from "@tiptap/core"
 import { Blockquote } from "@tiptap/extension-blockquote"
 import Suggestion from "@tiptap/suggestion"
 import { keymap } from "@tiptap/pm/keymap"
-import { PluginKey } from "@tiptap/pm/state"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { sinkListItem, liftListItem } from "@tiptap/pm/schema-list"
 import type { EditorState } from "@tiptap/pm/state"
 import type { Node as PMNode } from "@tiptap/pm/model"
@@ -166,6 +166,37 @@ const TabHandler = Extension.create({
   },
 })
 
+/**
+ * Keep clipboard shortcuts inside the editor. canvas-harness wires a
+ * window-level Cmd/Ctrl+C/X/V listener that only skips <input>/<textarea>
+ * (not contenteditable), so without this it hijacks copy/cut/paste while
+ * you're typing in a TipTap surface. Stop the keydown from reaching that
+ * window listener — but don't preventDefault, so the browser's native
+ * clipboard and ProseMirror's own copy/paste handling still run.
+ */
+const ClipboardGuard = Extension.create({
+  name: "clipboardGuard",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            keydown: (_view, event) => {
+              if (!(event.metaKey || event.ctrlKey)) return false
+              const key = event.key.toLowerCase()
+              if (key === "c" || key === "x" || key === "v") {
+                event.stopPropagation()
+              }
+              return false
+            },
+          },
+        },
+      }),
+    ]
+  },
+})
+
+
 export interface GetExtensionsOptions {
   placeholder?: string
   pageProvider?: PageProvider | null
@@ -224,6 +255,7 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
       transformPastedText: true,
     }),
     SlashCommand,
+    ClipboardGuard,
     TabHandler, // must be last — highest priority in TipTap's keymap chain
   ]
 }

--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -4,7 +4,6 @@ import CharacterCount from "@tiptap/extension-character-count"
 import TaskList from "@tiptap/extension-task-list"
 import TaskItem from "@tiptap/extension-task-item"
 import Link from "@tiptap/extension-link"
-import Underline from "@tiptap/extension-underline"
 import Typography from "@tiptap/extension-typography"
 import { Markdown } from "tiptap-markdown"
 import { Extension } from "@tiptap/core"
@@ -247,7 +246,6 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
       openOnClick: false,
       HTMLAttributes: { class: "editor-link" },
     }),
-    Underline,
     Typography,
     Markdown.configure({
       html: false,

--- a/webui/src/components/ui/sidebar.tsx
+++ b/webui/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
+import { isTypingTarget } from "@/lib/dom/is-typing-target"
 import { SidebarToggleIcon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -94,6 +95,8 @@ function SidebarProvider({
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      // Don't toggle while typing — let editors keep Cmd/Ctrl+B for bold, etc.
+      if (isTypingTarget(event.target)) return
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
         (event.metaKey || event.ctrlKey)

--- a/webui/src/features/board/harness/canvas/use-board-keyboard.ts
+++ b/webui/src/features/board/harness/canvas/use-board-keyboard.ts
@@ -1,19 +1,7 @@
 import { useEffect } from "react"
 import type { CanvasStore } from "@canvas-harness/core"
+import { isTypingTarget } from "@/lib/dom/is-typing-target"
 import { useBoardAppStore } from "../store/board-app-store"
-
-
-/**
- * Tells whether a keyboard event originated from a focused text-entry
- * surface. We don't steal undo/redo or tool shortcuts from those — the
- * user is typing.
- */
-const isTypingTarget = (target: EventTarget | null): boolean => {
-  if (!(target instanceof HTMLElement)) return false
-  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return true
-  if (target.isContentEditable) return true
-  return false
-}
 
 
 /**

--- a/webui/src/features/board/harness/canvas/use-presentation-mode.ts
+++ b/webui/src/features/board/harness/canvas/use-presentation-mode.ts
@@ -1,19 +1,8 @@
 import { useEffect, useRef } from "react"
 import type { CameraState, CanvasStore, NodeId, Renderer } from "@canvas-harness/core"
+import { isTypingTarget } from "@/lib/dom/is-typing-target"
 import { useBoardAppStore } from "../store/board-app-store"
 import { fitCameraToNode } from "./use-fit-camera-to-node"
-
-
-/**
- * Tells whether a keyboard event came from a focused editor. We let
- * those handle their own arrow keys / escape.
- */
-const isTypingTarget = (target: EventTarget | null): boolean => {
-  if (!(target instanceof HTMLElement)) return false
-  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return true
-  if (target.isContentEditable) return true
-  return false
-}
 
 
 /**

--- a/webui/src/features/board/harness/chrome/style-panel/sidebar.tsx
+++ b/webui/src/features/board/harness/chrome/style-panel/sidebar.tsx
@@ -10,15 +10,14 @@ import type {
 import { useCanvasStore, useEdges, useNodes, useSelection } from "@canvas-harness/react"
 import { useTheme } from "@/components/theme-provider"
 import type { LinkEdgeData } from "../../convert/link-to-edge"
-import type { NoteNodeData } from "../../convert/note-to-node"
 import {
   adaptEdgeColors,
-  adaptNodeColors,
   applyColorsToEdgeStyle,
   applyColorsToStyle,
   type StoredColors,
   type StoredEdgeColors,
 } from "../../theme/color-adapter"
+import { computeNodeColorUpdate, storedNodeColorsOf } from "../../theme/apply-node-colors"
 import { StylePanel, type StylePanelStyle } from "./panel"
 
 
@@ -29,19 +28,6 @@ type NodeColorField = (typeof NODE_COLOR_FIELDS)[number]
 
 const EDGE_COLOR_FIELDS = ["strokeColor", "textColor"] as const
 type EdgeColorField = (typeof EDGE_COLOR_FIELDS)[number]
-
-
-/** Lift stored node colors off a Node, falling back to `node.style` for legacy nodes. */
-const storedNodeColorsOf = (n: Node): StoredColors => {
-  const data = n.data as Partial<NoteNodeData> | undefined
-  return (
-    data?._storedColors ?? {
-      backgroundColor: n.style?.backgroundColor,
-      strokeColor: n.style?.strokeColor,
-      textColor: n.style?.textColor,
-    }
-  )
-}
 
 
 /** Lift stored edge colors off an Edge, falling back to `edge.style`. */
@@ -126,23 +112,16 @@ export function StyleSidebar() {
       const hasColor = Object.keys(colorPatch).length > 0
       const hasRest = Object.keys(rest).length > 0
 
+      const mode = resolvedTheme === "dark" ? "dark" : "light"
       store.batch(() => {
         for (const n of selectedNodes) {
-          const prevStored = storedNodeColorsOf(n)
-          const nextStored: StoredColors = hasColor
-            ? { ...prevStored, ...colorPatch }
-            : prevStored
-          const displayColors =
-            resolvedTheme === "dark" ? adaptNodeColors(nextStored, "dark") : nextStored
           const baseStyle = hasRest ? { ...n.style, ...rest } : n.style ?? {}
-          const nextStyle = hasColor
-            ? applyColorsToStyle(baseStyle, displayColors)
-            : baseStyle
-          const nextData: NoteNodeData = {
-            ...((n.data ?? {}) as NoteNodeData),
-            _storedColors: nextStored,
+          if (hasColor) {
+            const { style, data } = computeNodeColorUpdate(n, colorPatch, mode, baseStyle)
+            store.updateNode(n.id, { style, data })
+          } else {
+            store.updateNode(n.id, { style: baseStyle })
           }
-          store.updateNode(n.id, { style: nextStyle, data: nextData })
         }
       })
     },

--- a/webui/src/features/board/harness/node-types/sheet/sheet-color-picker.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/sheet-color-picker.tsx
@@ -1,0 +1,106 @@
+import { useRef } from "react"
+import { PaletteIcon } from "@phosphor-icons/react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { useTheme } from "@/components/theme-provider"
+import { darkModeDisplayHex } from "@/features/board/lib/colors/dark-variants"
+import { buildPalette, isSameColor } from "@/features/board/lib/colors/tailwind"
+import { cn } from "@/lib/utils"
+import { KeySwatch } from "../../chrome/style-panel/key-swatch"
+import { useStopCanvasGesture } from "../../shared-views"
+
+
+/** Sheet backgrounds are restricted to the Tailwind shade-100 family. */
+const SHADE_100 = buildPalette(100)
+
+
+type SheetColorPickerProps = {
+  /** Canonical (light-space) bg hex when a shade-100 color is set; null = default card. */
+  value: string | null
+  /** Picks a shade-100 hex, or null to fall back to the default card surface. */
+  onPick: (hexOrNull: string | null) => void
+}
+
+
+/**
+ * Compact background-color picker for the sheet card. Offers a "Default"
+ * (card surface) reset plus the Tailwind shade-100 palette — deliberately
+ * narrow so a sheet can never take a dark/saturated fill. The chosen hex
+ * still rides on `style.backgroundColor`; the sheet view gates rendering
+ * on shade-100 membership, so this never pollutes the shared style memory.
+ */
+export function SheetColorPicker({ value, onPick }: SheetColorPickerProps) {
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === "dark"
+  // Preview the dot the way the canvas paints it — dark-adapted in dark mode,
+  // matching the card fill and the grid swatches.
+  const previewHex = value && isDark ? darkModeDisplayHex(value) ?? value : value
+  // The trigger sits inside the node's bounding box; without this the canvas
+  // gesture hook captures pointerdown and the click never fires.
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  useStopCanvasGesture(triggerRef)
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          aria-label="Background color"
+          title="Background color"
+          className={cn(
+            "pointer-events-auto flex size-6 items-center justify-center rounded-full",
+            "border border-border/60 bg-card/80 text-muted-foreground shadow-sm backdrop-blur",
+            "transition-colors hover:text-foreground",
+          )}
+        >
+          {previewHex ? (
+            <span
+              className="size-3.5 rounded-full border border-border/60"
+              style={{ backgroundColor: previewHex }}
+            />
+          ) : (
+            <PaletteIcon className="size-3.5" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-[200px] p-3"
+        onClick={(e) => e.stopPropagation()}
+        onDoubleClick={(e) => e.stopPropagation()}
+      >
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={() => onPick(null)}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md border px-2 py-1.5 text-left text-xs transition-colors",
+              value === null
+                ? "border-secondary-foreground bg-muted/40 text-foreground"
+                : "border-border/60 text-muted-foreground hover:bg-muted/30 hover:text-foreground",
+            )}
+          >
+            <span className="size-4 rounded-sm border border-border/60 bg-card" />
+            Default
+          </button>
+          <div className="grid grid-cols-6 gap-1">
+            {SHADE_100.map((c) => (
+              <KeySwatch
+                key={c.name}
+                color={c.hex}
+                selected={isSameColor(value, c.hex)}
+                onClick={() => onPick(c.hex)}
+                isDark={isDark}
+                size="dot"
+                hideLabel
+              />
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/webui/src/features/board/harness/node-types/sheet/sheet-inline-editor.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/sheet-inline-editor.tsx
@@ -14,6 +14,11 @@ type SheetInlineEditorProps = {
   markdown: string
   /** When true, the card is an editable editor; when false, a read-only render. */
   editable: boolean
+  /**
+   * Viewport coords of the click that entered edit mode. When set, the caret
+   * is dropped at the nearest document position; null places it at the end.
+   */
+  caretCoords?: { x: number; y: number } | null
   /** Resolves @-mention / subpage chips (titles, icons, /subpage creation). */
   pageProvider?: PageProvider | null
   /** Sheet id, so /subpage nests new pages under it. */
@@ -36,6 +41,7 @@ type SheetInlineEditorProps = {
 export function SheetInlineEditor({
   markdown,
   editable,
+  caretCoords,
   pageProvider,
   parentNoteId,
   onSave,
@@ -43,6 +49,11 @@ export function SheetInlineEditor({
   className,
 }: SheetInlineEditorProps) {
   const wrapRef = useRef<HTMLDivElement>(null)
+
+  // Latest click coords, read (not depended on) by the place-caret effect so
+  // it only fires on the edit-mode flip, not on every coord change.
+  const caretCoordsRef = useRef(caretCoords)
+  caretCoordsRef.current = caretCoords
 
   const onSaveRef = useRef(onSave)
   useEffect(() => {
@@ -78,9 +89,20 @@ export function SheetInlineEditor({
     editor?.setEditable(editable)
   }, [editor, editable])
 
-  // Place the caret when entering edit mode.
+  // Place the caret when entering edit mode — at the click position when we
+  // have one (ProseMirror maps viewport coords → doc pos, transform-aware so
+  // it works at any canvas zoom), else at the end.
   useEffect(() => {
-    if (editor && editable) editor.commands.focus("end")
+    if (!editor || !editable) return
+    const coords = caretCoordsRef.current
+    if (coords) {
+      const hit = editor.view.posAtCoords({ left: coords.x, top: coords.y })
+      if (hit) {
+        editor.chain().focus().setTextSelection(hit.pos).run()
+        return
+      }
+    }
+    editor.commands.focus("end")
   }, [editor, editable])
 
   // External content sync: when the canonical markdown changes from elsewhere

--- a/webui/src/features/board/harness/node-types/sheet/sheet-inline-editor.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/sheet-inline-editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react"
-import { EditorContent, useEditor } from "@tiptap/react"
+import { EditorContent, useEditor, type Editor } from "@tiptap/react"
 import { useDebouncedCallback } from "use-debounce"
 import { getExtensions } from "@/components/editor/tiptap/extensions"
 import type { PageProvider } from "@/components/editor/tiptap/page/types"
@@ -14,6 +14,11 @@ type SheetInlineEditorProps = {
   markdown: string
   /** When true, the card is an editable editor; when false, a read-only render. */
   editable: boolean
+  /**
+   * Reports the TipTap instance to the parent (null on unmount) so the card
+   * can mount the formatting toolbar as its own bottom flex child.
+   */
+  onEditor?: (editor: Editor | null) => void
   /**
    * Viewport coords of the click that entered edit mode. When set, the caret
    * is dropped at the nearest document position; null places it at the end.
@@ -41,6 +46,7 @@ type SheetInlineEditorProps = {
 export function SheetInlineEditor({
   markdown,
   editable,
+  onEditor,
   caretCoords,
   pageProvider,
   parentNoteId,
@@ -116,6 +122,14 @@ export function SheetInlineEditor({
 
   // Don't lose a pending edit when the card unmounts (pan / zoom-out / LOD).
   useEffect(() => () => save.flush(), [save])
+
+  // Surface the editor to the card so it can render the bottom toolbar.
+  const onEditorRef = useRef(onEditor)
+  onEditorRef.current = onEditor
+  useEffect(() => {
+    onEditorRef.current?.(editor)
+    return () => onEditorRef.current?.(null)
+  }, [editor])
 
   if (!editor) return null
 

--- a/webui/src/features/board/harness/node-types/sheet/sheet-toolbar.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/sheet-toolbar.tsx
@@ -1,0 +1,100 @@
+import { useEditorState, type Editor } from "@tiptap/react"
+import {
+  TextB,
+  TextItalic,
+  TextUnderline,
+  TextStrikethrough,
+  Highlighter,
+} from "@phosphor-icons/react"
+import { cn } from "@/lib/utils"
+
+
+function MarkButton({
+  active,
+  tooltip,
+  onClick,
+  children,
+}: {
+  active?: boolean
+  tooltip: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      title={tooltip}
+      aria-label={tooltip}
+      data-active={active}
+      onClick={onClick}
+      className={cn(
+        "flex h-7 w-7 shrink-0 items-center justify-center rounded-[5px] transition-colors",
+        "text-foreground hover:bg-muted",
+        active && "bg-secondary text-secondary-foreground",
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+
+/**
+ * Formatting bar for the inline sheet card — bold, italic, underline,
+ * highlight, strikethrough. Shown only while editing; the modal editor has
+ * its own bubble menu. Mount as the card's bottom flex child so it always sits
+ * flush at the bottom edge while the prose scrolls above it.
+ *
+ * `surfaceColor` matches the bar's fill to the card so text reads cleanly
+ * behind it. The row scrolls horizontally (no wrap, hidden scrollbar) so it
+ * truncates gracefully when the note is resized narrow.
+ */
+export function SheetEditorToolbar({
+  editor,
+  surfaceColor,
+}: {
+  editor: Editor
+  surfaceColor?: string | null
+}) {
+  const active = useEditorState({
+    editor,
+    selector: (ctx) => ({
+      bold: ctx.editor.isActive("bold"),
+      italic: ctx.editor.isActive("italic"),
+      underline: ctx.editor.isActive("underline"),
+      highlight: ctx.editor.isActive("highlight"),
+      strike: ctx.editor.isActive("strike"),
+    }),
+  })
+
+  return (
+    <div
+      // Keep the editor's focus + selection when clicking the bar: without
+      // preventDefault the editor blurs, collapsing the selection (so the mark
+      // applies to nothing) and tripping the blur-to-exit handler.
+      onMouseDown={(e) => e.preventDefault()}
+      className={cn(
+        "flex shrink-0 items-center gap-0.5 overflow-x-auto border-t border-border px-3 py-1",
+        "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        surfaceColor ? null : "bg-card",
+      )}
+      style={surfaceColor ? { backgroundColor: surfaceColor } : undefined}
+    >
+      <MarkButton tooltip="Bold" active={active.bold} onClick={() => editor.chain().focus().toggleBold().run()}>
+        <TextB size={14} weight="bold" />
+      </MarkButton>
+      <MarkButton tooltip="Italic" active={active.italic} onClick={() => editor.chain().focus().toggleItalic().run()}>
+        <TextItalic size={14} />
+      </MarkButton>
+      <MarkButton tooltip="Underline" active={active.underline} onClick={() => editor.chain().focus().toggleUnderline().run()}>
+        <TextUnderline size={14} />
+      </MarkButton>
+      <MarkButton tooltip="Highlight" active={active.highlight} onClick={() => editor.chain().focus().toggleMark("highlight").run()}>
+        <Highlighter size={14} />
+      </MarkButton>
+      <MarkButton tooltip="Strikethrough" active={active.strike} onClick={() => editor.chain().focus().toggleStrike().run()}>
+        <TextStrikethrough size={14} />
+      </MarkButton>
+    </div>
+  )
+}

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -3,9 +3,12 @@ import { NotepadIcon } from "@phosphor-icons/react"
 import { type NodeId } from "@canvas-harness/core"
 import { useCanvasStore, useNode } from "@canvas-harness/react"
 import { IconPropertyView } from "@/components/icons/icon-property-view"
+import { useTheme } from "@/components/theme-provider"
 import { createBoardPageProvider } from "@/features/board/providers/board-page-provider"
+import { findFamilyShadeFromHex, toBaseHex } from "@/features/board/lib/colors/tailwind"
 import { cn } from "@/lib/utils"
 import type { NoteNodeData } from "../../convert/note-to-node"
+import { computeNodeColorUpdate } from "../../theme/apply-node-colors"
 import {
   NodeTitleCaption,
   NodeTrafficLights,
@@ -13,6 +16,7 @@ import {
   useStopCanvasGesture,
 } from "../../shared-views"
 import { useBoardAppStore } from "../../store/board-app-store"
+import { SheetColorPicker } from "./sheet-color-picker"
 import { SheetInlineEditor } from "./sheet-inline-editor"
 
 
@@ -36,9 +40,14 @@ export type SheetViewProps = {
 export function SheetView({ id }: SheetViewProps) {
   const node = useNode(id)
   const store = useCanvasStore()
+  const { resolvedTheme } = useTheme()
   const openNodeSurface = useBoardAppStore((s) => s.openNodeSurface)
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const [editing, setEditing] = useState(false)
+  // Viewport coords of the double-click that entered edit mode, so the
+  // editor can drop the caret where the user clicked (null = caret at end,
+  // e.g. when edit is entered via keyboard).
+  const [caretCoords, setCaretCoords] = useState<{ x: number; y: number } | null>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
   useStopCanvasGesture(bodyRef)
@@ -66,6 +75,32 @@ export function SheetView({ id }: SheetViewProps) {
       store.updateNode(id, { content: markdown })
     },
     [store, id],
+  )
+
+  // Background color lives on `style.backgroundColor`, but we only honor it
+  // when the canonical (light-space) value is a Tailwind shade-100 — anything
+  // else (incl. the legacy BLUE_200 default) falls back to the card surface.
+  // Gate on the canonical color (`_storedColors`), paint the theme-projected
+  // `node.style.backgroundColor` so dark mode stays consistent.
+  const canonicalBg = node?.data
+    ? (node.data as Partial<NoteNodeData>)._storedColors?.backgroundColor ?? null
+    : null
+  const isShade100 = findFamilyShadeFromHex(toBaseHex(canonicalBg))?.shade === 100
+  const honoredBg = isShade100 ? node?.style?.backgroundColor ?? null : null
+
+  const handlePickColor = useCallback(
+    (hexOrNull: string | null) => {
+      const n = store.getNode(id)
+      if (!n) return
+      const mode = resolvedTheme === "dark" ? "dark" : "light"
+      const { style, data: nextData } = computeNodeColorUpdate(
+        n,
+        { backgroundColor: hexOrNull ?? undefined },
+        mode,
+      )
+      store.updateNode(id, { style, data: nextData })
+    },
+    [store, id, resolvedTheme],
   )
 
   if (!node) return null
@@ -98,6 +133,9 @@ export function SheetView({ id }: SheetViewProps) {
           // Select the node (show handles) alongside entering edit — the
           // body swallows pointerdown, so the lib's gesture never selects it.
           store.setSelection([id])
+          // Remember where the user clicked so the editor can place the caret
+          // there instead of jumping to the end.
+          setCaretCoords({ x: e.clientX, y: e.clientY })
           enterEdit()
         }}
         onKeyDown={(e) => {
@@ -106,14 +144,17 @@ export function SheetView({ id }: SheetViewProps) {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault()
             e.stopPropagation()
+            setCaretCoords(null)
             enterEdit()
           }
         }}
         className={cn(
-          "absolute inset-0 flex flex-col overflow-hidden rounded-2xl border border-border bg-card text-left text-card-foreground shadow-md",
+          "absolute inset-0 flex flex-col overflow-hidden rounded-xl border border-foreground/40 shadow-sm text-left text-card-foreground",
+          honoredBg ? null : "bg-card",
           "pointer-events-auto",
           !editing && canEdit ? "cursor-pointer" : "cursor-default",
         )}
+        style={honoredBg ? { backgroundColor: honoredBg } : undefined}
         title={!editing && canEdit ? "Double-click to edit" : undefined}
       >
         <div
@@ -123,8 +164,8 @@ export function SheetView({ id }: SheetViewProps) {
           )}
         >
           {iconValue && (
-            <div className="pointer-events-none mb-2">
-              <IconPropertyView icon={iconValue} size={24} />
+            <div className="pointer-events-none mb-3">
+              <IconPropertyView icon={iconValue} size={44} />
             </div>
           )}
           {(body || editing) && isInView ? (
@@ -132,6 +173,7 @@ export function SheetView({ id }: SheetViewProps) {
               <SheetInlineEditor
                 markdown={node.content ?? ""}
                 editable={editing}
+                caretCoords={caretCoords}
                 pageProvider={pageProvider}
                 parentNoteId={id as unknown as string}
                 onSave={handleSave}
@@ -155,6 +197,12 @@ export function SheetView({ id }: SheetViewProps) {
         onDelete={canEdit ? () => store.removeNode(id) : undefined}
         onExpand={canEdit ? () => openNodeSurface(id as unknown as string, "sheet") : undefined}
       />
+
+      {canEdit && (
+        <div className="pointer-events-auto absolute right-2 top-2 z-40">
+          <SheetColorPicker value={isShade100 ? canonicalBg : null} onPick={handlePickColor} />
+        </div>
+      )}
 
       <div className="pointer-events-auto absolute left-1/2 top-full z-20 mt-2 w-full -translate-x-1/2">
         <NodeTitleCaption

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 import { NotepadIcon } from "@phosphor-icons/react"
+import type { Editor } from "@tiptap/react"
 import { type NodeId } from "@canvas-harness/core"
 import { useCanvasStore, useNode } from "@canvas-harness/react"
 import { IconPropertyView } from "@/components/icons/icon-property-view"
@@ -17,6 +18,7 @@ import {
 } from "../../shared-views"
 import { useBoardAppStore } from "../../store/board-app-store"
 import { SheetColorPicker } from "./sheet-color-picker"
+import { SheetEditorToolbar } from "./sheet-toolbar"
 import { SheetInlineEditor } from "./sheet-inline-editor"
 
 
@@ -57,6 +59,9 @@ export function SheetView({ id }: SheetViewProps) {
   const openNodeSurface = useBoardAppStore((s) => s.openNodeSurface)
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const [editing, setEditing] = useState(false)
+  // The inline editor reports its TipTap instance up so the card can render the
+  // formatting toolbar as its own bottom flex child (flush at the card edge).
+  const [toolbarEditor, setToolbarEditor] = useState<Editor | null>(null)
   // Viewport coords of the double-click that entered edit mode, so the
   // editor can drop the caret where the user clicked (null = caret at end,
   // e.g. when edit is entered via keyboard).
@@ -199,6 +204,7 @@ export function SheetView({ id }: SheetViewProps) {
               <SheetInlineEditor
                 markdown={node.content ?? ""}
                 editable={editing}
+                onEditor={setToolbarEditor}
                 caretCoords={caretCoords}
                 pageProvider={pageProvider}
                 parentNoteId={id as unknown as string}
@@ -222,6 +228,10 @@ export function SheetView({ id }: SheetViewProps) {
           <div className="pointer-events-none absolute bottom-2 right-3 text-[10px] leading-none text-muted-foreground">
             {stampPrefix} {formatStampDate(stampIso)}
           </div>
+        ) : null}
+
+        {editing && toolbarEditor ? (
+          <SheetEditorToolbar editor={toolbarEditor} surfaceColor={honoredBg} />
         ) : null}
       </div>
 

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -164,6 +164,13 @@ export function SheetView({ id }: SheetViewProps) {
           className={cn(
             "min-h-0 flex-1 px-4 pb-3 pt-10 text-sm leading-relaxed text-foreground",
             editing ? "scrollbar-thin overflow-auto" : "overflow-hidden",
+            // Fade the text into the card near the bottom edge so a clipped
+            // (unfinished) sheet reads as "there's more". Masks the text alpha,
+            // so it works on any card color and only shows when text reaches
+            // the edge. Skipped while editing (full scroll).
+            !editing && body
+              ? "[--sheet-fade:linear-gradient(to_bottom,#000_calc(100%-2.75rem),transparent)] [mask-image:var(--sheet-fade)] [-webkit-mask-image:var(--sheet-fade)]"
+              : null,
           )}
         >
           {iconValue && (

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -25,6 +25,19 @@ export type SheetViewProps = {
 }
 
 
+/** Compact stamp date — "Jun 14", with the year only when it isn't this year. */
+const formatStampDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  const sameYear = d.getFullYear() === new Date().getFullYear()
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  })
+}
+
+
 /**
  * Sheet inline view — sticky-note style card. The body renders through the
  * *same* TipTap pipeline as the modal editor ({@link SheetInlineEditor}) so
@@ -111,6 +124,9 @@ export function SheetView({ id }: SheetViewProps) {
   const label = data.label?.markdown
   const body = node.content?.trim() ?? ""
   const iconValue = data.properties?.iconData?.icon ?? null
+  // Last-modified, falling back to created. Prefix tells which one it is.
+  const stampIso = data.updatedAt ?? data.createdAt
+  const stampPrefix = data.updatedAt ? "Edited" : "Created"
 
   const enterEdit = () => {
     if (canEdit) setEditing(true)
@@ -201,6 +217,12 @@ export function SheetView({ id }: SheetViewProps) {
             <span className="italic text-muted-foreground">Empty sheet</span>
           )}
         </div>
+
+        {!editing && stampIso ? (
+          <div className="pointer-events-none absolute bottom-2 right-3 text-[10px] leading-none text-muted-foreground">
+            {stampPrefix} {formatStampDate(stampIso)}
+          </div>
+        ) : null}
       </div>
 
       <NodeTrafficLights

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -82,10 +82,13 @@ export function SheetView({ id }: SheetViewProps) {
   // else (incl. the legacy BLUE_200 default) falls back to the card surface.
   // Gate on the canonical color (`_storedColors`), paint the theme-projected
   // `node.style.backgroundColor` so dark mode stays consistent.
-  const canonicalBg = node?.data
-    ? (node.data as Partial<NoteNodeData>)._storedColors?.backgroundColor ?? null
-    : null
-  const isShade100 = findFamilyShadeFromHex(toBaseHex(canonicalBg))?.shade === 100
+  const canonicalBg = data._storedColors?.backgroundColor ?? null
+  // The shade-100 lookup linearly scans the whole Tailwind palette, so memoize
+  // it on the color — SheetView re-renders per keystroke while editing.
+  const isShade100 = useMemo(
+    () => findFamilyShadeFromHex(toBaseHex(canonicalBg))?.shade === 100,
+    [canonicalBg],
+  )
   const honoredBg = isShade100 ? node?.style?.backgroundColor ?? null : null
 
   const handlePickColor = useCallback(

--- a/webui/src/features/board/harness/theme/apply-node-colors.ts
+++ b/webui/src/features/board/harness/theme/apply-node-colors.ts
@@ -1,0 +1,48 @@
+import type { Node, Style as CanvasStyle } from "@canvas-harness/core"
+import type { NoteNodeData } from "../convert/note-to-node"
+import { adaptNodeColors, applyColorsToStyle, type StoredColors } from "./color-adapter"
+import type { Mode } from "./tokens"
+
+
+/**
+ * Lift the source-of-truth (light-space) colors off a Node, falling back
+ * to the painted `node.style` for legacy nodes that predate
+ * `data._storedColors`.
+ */
+export const storedNodeColorsOf = (node: Node): StoredColors => {
+  const data = node.data as Partial<NoteNodeData> | undefined
+  return (
+    data?._storedColors ?? {
+      backgroundColor: node.style?.backgroundColor,
+      strokeColor: node.style?.strokeColor,
+      textColor: node.style?.textColor,
+    }
+  )
+}
+
+
+/**
+ * Compute the `{ style, data }` patch for a node color change, keeping
+ * `data._storedColors` (the canonical light-space colors the server
+ * stores) and the painted `node.style` (theme-projected) in sync.
+ *
+ * Shared by the style panel and the sheet background picker so the two
+ * can never drift on how a color round-trips through a theme flip.
+ * `baseStyle` lets callers fold non-color style changes in first; it
+ * defaults to the node's current style.
+ */
+export const computeNodeColorUpdate = (
+  node: Node,
+  colorPatch: Partial<StoredColors>,
+  mode: Mode,
+  baseStyle?: CanvasStyle,
+): { style: CanvasStyle; data: NoteNodeData } => {
+  const nextStored: StoredColors = { ...storedNodeColorsOf(node), ...colorPatch }
+  const displayColors = mode === "dark" ? adaptNodeColors(nextStored, "dark") : nextStored
+  const style = applyColorsToStyle(baseStyle ?? node.style ?? {}, displayColors)
+  const data: NoteNodeData = {
+    ...((node.data ?? {}) as NoteNodeData),
+    _storedColors: nextStored,
+  }
+  return { style, data }
+}

--- a/webui/src/features/board/types/note.ts
+++ b/webui/src/features/board/types/note.ts
@@ -80,15 +80,15 @@ export const DEFAULT_DIAMOND_NOTE_HEIGHT = 340
 export const DEFAULT_TEXT_NOTE_WIDTH = 150
 export const DEFAULT_TEXT_NOTE_HEIGHT = 20
 
-// Sheet default size targets the typography sweet spot for prose.
-// At ~14px text + standard padding, 560px width yields ~65-70 chars
-// per line — comfortable for sustained reading without crossing into
-// the "too long" territory past ~75 chars. The earlier 320px default
-// felt sticky-note-cramped for anything beyond a short reminder.
-// Min width stays at 200 — the user can still shrink a sheet to
-// sticky-note size manually when that's the intent.
-export const DEFAULT_SHEET_WIDTH = 560
-export const DEFAULT_SHEET_HEIGHT = 320
+// Sheet is our "sticky note": a long-form rich-text doc that scrolls,
+// so a square jot surface reads better than a wide document card.
+// 440x440 holds ~50 chars/line — comfortable for reading, while the
+// square footprint signals "note", not "page". Sheets don't auto-fit
+// height (they scroll), so this is the size they keep.
+// Keep DEFAULT_SHEET_* in sync with get_default_note_size in
+// backend/topix/agents/notes/service.py.
+export const DEFAULT_SHEET_WIDTH = 440
+export const DEFAULT_SHEET_HEIGHT = 440
 export const SHEET_MIN_WIDTH = 200
 export const SHEET_MIN_HEIGHT = 120
 

--- a/webui/src/lib/dom/is-typing-target.ts
+++ b/webui/src/lib/dom/is-typing-target.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether a keyboard event originated from a text-entry control — a focused
+ * `<input>` / `<textarea>` or any `contenteditable` (TipTap editors included).
+ *
+ * Global `window`/`document` keydown shortcuts should bail on this so typing
+ * keeps the native key behavior (e.g. Cmd+B bolds text instead of toggling the
+ * sidebar). Used by every app-level keyboard handler.
+ */
+export const isTypingTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return true
+  if (target.isContentEditable) return true
+  return false
+}


### PR DESCRIPTION
Tunes the plan agent's prompts, swaps the base planning model, and polishes the sheet node on the canvas.

## Prompts
- **Proactive, goal-driven framing.** Reframe the plan agent from a format-picking tutor into a capable assistant: read past the literal request to the goal, take initiative on the right format (table/chart/diagram, fetch current data) without being told to "make a chart" or "search," and guard *both* failure modes — over-building and under-serving are now called out as equally bad (replacing the one-sided "over-building is the most common failure mode"). Added two examples that model proactivity (comparison → table/chart; research → fetch then a scannable schema).
- **Node emphasis.** Teach the supported lite-markdown for note content — `**bold**`, `==highlight==`, `` `code` `` — used sparingly to spotlight the one key term, with restraint demonstrated in the diagram-skill examples and verified in its checklist. (Math in notes intentionally omitted for now; chat-reply math `\(...\)` is unchanged.)
- Mirrored both principles in the user-prompt reminders.

Files: `plan.system.jinja`, `plan.user.jinja`, `widget/learn_generate_diagram.jinja`.

## Model
- `AUTO_MODEL_BASE_PLAN` → `openrouter/deepseek/deepseek-v4-flash:nitro` (was `z-ai/glm-4.7:nitro`). Kept as a separate commit so it can be rolled back independently of the prompt changes.

## Sheet node polish
- **Background color picker.** Sheet cards can take a background from a restricted Tailwind shade-100 palette (with a "Default" reset to the card surface). The color rides on the existing `style.backgroundColor` — no new fields — and rendering is **gated on shade-100 membership of the canonical color**, so the legacy `BLUE_200` default and any non-palette value fall back to the card surface, and sheets never inherit a stray/dark fill. Sheets are already excluded from sticky style memory, so the pick can't bleed to other nodes.
- **Shared color-write helper.** Factored the style panel's stored↔displayed color split into `computeNodeColorUpdate` so the panel and the new picker stay in sync across theme flips (keeps `data._storedColors` canonical, paints the dark-adapted value).
- **Visual tweaks.** Darker border, less rounding, and a larger title icon on the card.
- **Click-to-caret.** Double-clicking to edit now drops the caret at the click position (ProseMirror `posAtCoords`, transform-aware so it works at any zoom) instead of jumping to the end.

Files: `node-types/sheet/{view,sheet-inline-editor,sheet-color-picker}.tsx`, `theme/apply-node-colors.ts`, `chrome/style-panel/sidebar.tsx`.

## Tests
Diagram-skill drift-guard tests pass; prompts render. Board harness suite (127 tests) passes; type-check + lint clean. No behavioral code changed beyond the model constant and the sheet view.

## Watch after merge
- Proactivity vs. cost: more initiative means more mini-apps/searches per turn, which matters given request-gated tiers. The "match effort to the goal, never pad" framing + existing budgets are the guardrails; if it over-builds, soften the take-initiative wording.
- New base model: watch plan quality/latency on `deepseek-v4-flash` vs the prior glm-4.7.
