### PR TITLE
fix(board): gate iframe pointer-events on selection so canvas gestures survive

### DIFF
--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useRef } from "react"
 
 import { CursorClickIcon } from "@phosphor-icons/react"
 import { type NodeId } from "@canvas-harness/core"
-import { useCanvasStore, useNode } from "@canvas-harness/react"
+import { useCanvasStore, useNode, useSelection } from "@canvas-harness/react"
 
 import { MiniAppMount } from "@/features/mini-app"
 import { cn } from "@/lib/utils"
@@ -56,6 +56,14 @@ export function MiniAppView({ id }: MiniAppViewProps) {
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const wrapRef = useRef<HTMLDivElement>(null)
   const isInView = useIsInView(wrapRef, "200px")
+  // Gate iframe interaction on selection so canvas pan/zoom gestures
+  // pass cleanly through unselected mini-apps. Without this, the
+  // iframe's `pointer-events-auto` captures the pointer the moment
+  // the user's drag crosses into the card → canvas-harness loses
+  // gesture tracking → pan dies mid-swipe. Same pattern sheet uses for
+  // its inline editor (gated on `editing` instead of selection).
+  const selection = useSelection()
+  const isSelected = selection.includes(id)
 
   // rAF-throttled grow-only resize. The widget posts `mini-app:resize`
   // through MiniAppMount on every content-size change; we batch those
@@ -116,7 +124,10 @@ export function MiniAppView({ id }: MiniAppViewProps) {
             <MiniAppMount
               noteId={id as unknown as string}
               source={source}
-              className="pointer-events-auto h-full w-full bg-transparent"
+              className={cn(
+                "h-full w-full bg-transparent",
+                isSelected ? "pointer-events-auto" : "pointer-events-none",
+              )}
               onContentHeightChange={onContentHeightChange}
             />
           ) : (

--- a/webui/src/features/board/harness/node-types/widget/view.tsx
+++ b/webui/src/features/board/harness/node-types/widget/view.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react"
 import { LayoutIcon } from "@phosphor-icons/react"
 import { type NodeId } from "@canvas-harness/core"
-import { useCanvasStore, useNode } from "@canvas-harness/react"
+import { useCanvasStore, useNode, useSelection } from "@canvas-harness/react"
 import { cn } from "@/lib/utils"
 import { WidgetIframe } from "@/features/board/components/flow/widget-iframe"
 import type { NoteNodeData } from "../../convert/note-to-node"
@@ -33,6 +33,13 @@ export function WidgetView({ id }: WidgetViewProps) {
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const wrapRef = useRef<HTMLDivElement>(null)
   const isInView = useIsInView(wrapRef, "200px")
+  // Gate iframe interaction on selection so canvas pan/zoom gestures
+  // pass through unselected widgets cleanly — without this the
+  // iframe's `pointer-events-auto` captures the pointer mid-drag and
+  // the canvas gesture dies. See mini-app/view.tsx for the same
+  // pattern.
+  const selection = useSelection()
+  const isSelected = selection.includes(id)
   if (!node) return null
 
   const data = (node.data ?? {}) as Partial<NoteNodeData>
@@ -54,7 +61,10 @@ export function WidgetView({ id }: WidgetViewProps) {
             <WidgetIframe
               html={html}
               title="Widget"
-              className="pointer-events-auto h-full w-full bg-transparent"
+              className={cn(
+                "h-full w-full bg-transparent",
+                isSelected ? "pointer-events-auto" : "pointer-events-none",
+              )}
             />
           ) : (
             <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
Mini-app and HTML widget cards put `pointer-events-auto` on their inner iframe unconditionally. Result: any pan/zoom drag that crossed into an iframe's bounding rect had its pointer stolen by the iframe → canvas-harness lost gesture tracking → swipe died mid-motion.

Gate the iframe's `pointer-events-auto` on the node being selected, via `useSelection()` from canvas-harness. Same shape as sheet's `editing`-gated editor wrapper, just keyed on canvas selection instead of edit state.

## Behavior

| User action | Before | After |
|---|---|---|
| Pan/zoom drag crosses an unselected mini-app | Gesture dies | Passes through ✓ |
| Click on the card | Selects the node (iframe stole on subsequent moves) | Selects the node, iframe stays inert |
| Click again inside the selected card | Works | Works ✓ |
| Click outside | Deselects, but iframe stayed live | Deselects + iframe goes inert again |
| Traffic-light buttons (delete/expand) | Always work | Always work (unchanged) |
| Title caption below the card | Always works | Always works (unchanged) |

## Notes
- Same change applied to both `mini-app/view.tsx` AND `widget/view.tsx` — HTML widgets have the identical issue
- Iframe JS, postMessage handshake, theme propagation, auto-grow all keep running while the iframe is inert (`pointer-events: none` only blocks pointer input, not script execution)
- Slight UX cost: first click on an unselected widget *selects* the node rather than activating the button under the cursor; a second click then interacts. Matches how sheets behave (double-click to edit). Acceptable trade for unbreakable canvas pan.

## Test plan
- [ ] Open a board with at least one mini-app, pan across it without first selecting → pan survives the crossing
- [ ] Click an unselected mini-app, it gets selected
- [ ] Click again on a button inside → button works
- [ ] Click elsewhere on the board, mini-app deselects
- [ ] Repeat the above with an HTML widget — same behavior
- [ ] Confirm delete + expand traffic lights still work on hover regardless of selection