### PR TITLE
fix(editor): tiptap polish — underline round-trip, autolink, link dedup, toolbar chrome

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "webui",
-  "version": "0.3.46",
+  "version": "0.3.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.46",
+      "version": "0.3.49",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@canvas-harness/core": "^0.1.24",
-        "@canvas-harness/react": "^0.1.24",
-        "@canvas-harness/sync-broadcast": "^0.1.24",
+        "@canvas-harness/core": "^0.1.25",
+        "@canvas-harness/react": "^0.1.25",
+        "@canvas-harness/sync-broadcast": "^0.1.25",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/@canvas-harness/core": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.24.tgz",
-      "integrity": "sha512-LRCbawbmWrIT55eq9v26+S+1cVU1a/utBY//LcGXx1LaJUgN7Whw3xvEVcSp9yWT1C6T+2wpoDyW2GYPdQsjpQ==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/core/-/core-0.1.25.tgz",
+      "integrity": "sha512-naMxgjnGUOQ5QYB7+1pcGQcr8L9eE9/0wFkQ1ZMAHKvop719t+qaxBGA9sKyZXrFDlg9EIXdONK5S1kKTvIzJA==",
       "license": "MIT",
       "dependencies": {
         "perfect-freehand": "^1.2.3",
@@ -1939,12 +1939,12 @@
       }
     },
     "node_modules/@canvas-harness/react": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.24.tgz",
-      "integrity": "sha512-YRi1ui0UPGAq6TCioeT9BpKXgHcpd2hwZ6qOBMPB2pJy48dFayvtHZa6lgM8OxUp7aOx/TDVW7ZhRAkeE+bNGQ==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/react/-/react-0.1.25.tgz",
+      "integrity": "sha512-k90Gt7T5imbKKrhEbMoI7CZ5mCGXsi2h8boP6oWeaBgyO8A9tKueq2OMId5uj3YegE6qQ7E11sZBuW9WS5d0gA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.24"
+        "@canvas-harness/core": "0.1.25"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -1952,12 +1952,12 @@
       }
     },
     "node_modules/@canvas-harness/sync-broadcast": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.24.tgz",
-      "integrity": "sha512-3u5+IUUwouiMmediKOMvx1TplDXnSfWenc4m0bWZxyYSb2AUXT6KgnSiu2zRWu+MHtH5dY6q7YifT6p1ym0xJg==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@canvas-harness/sync-broadcast/-/sync-broadcast-0.1.25.tgz",
+      "integrity": "sha512-65x1DbRURXpo6ebLF4Qr637HA0n4M1zfxpN+99rztzCCoQLjzSFpAaFbw0PBmLLM/KfffTApwSa4Ze8xQwrTqA==",
       "license": "MIT",
       "dependencies": {
-        "@canvas-harness/core": "0.1.24"
+        "@canvas-harness/core": "0.1.25"
       }
     },
     "node_modules/@chevrotain/types": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@canvas-harness/core": "^0.1.24",
-    "@canvas-harness/react": "^0.1.24",
-    "@canvas-harness/sync-broadcast": "^0.1.24",
+    "@canvas-harness/core": "^0.1.25",
+    "@canvas-harness/react": "^0.1.25",
+    "@canvas-harness/sync-broadcast": "^0.1.25",
     "@dagrejs/dagre": "^1.1.5",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -249,6 +249,16 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
     Link.configure({
       openOnClick: false,
       HTMLAttributes: { class: "editor-link" },
+      // Auto-link bare domains too — by default the Link extension's
+      // `shouldAutoLink` requires a protocol prefix (`https://example.com`
+      // autolinks, `example.com` doesn't). Users expect a typed
+      // `wordpress.com ` to become a link without the scheme; linkifyjs's
+      // tokenizer already screens out non-URL-looking strings (it checks
+      // against the IANA TLD list under the hood), so widening to "trust
+      // linkify's detection" produces the natural behavior. Bare matches
+      // get the `https://` scheme via `defaultProtocol`.
+      shouldAutoLink: () => true,
+      defaultProtocol: "https",
     }),
     Typography,
     Markdown.configure({

--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -15,6 +15,7 @@ import { sinkListItem, liftListItem } from "@tiptap/pm/schema-list"
 import type { EditorState } from "@tiptap/pm/state"
 import type { Node as PMNode } from "@tiptap/pm/model"
 import { HighlightMarkdown } from "./highlight/highlight-extension"
+import { UnderlineMarkdown } from "./underline/underline-extension"
 import { DetailsMarkdown, DetailsSummaryMarkdown, DetailsContentMarkdown } from "./toggle/toggle-extensions"
 import { TableKit } from "@tiptap/extension-table"
 import { ShikiCodeBlock } from "./code-block/code-block-extension"
@@ -215,6 +216,7 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
       // Phase 1: undo/redo enabled. When adding Yjs: set undoRedo: false and add @tiptap/extension-collaboration
       codeBlock: false, // replaced by ShikiCodeBlock
       blockquote: false, // replaced by BlockquoteNoShortcut so `> ` triggers toggle
+      underline: false, // replaced by UnderlineMarkdown so Ctrl+U survives markdown round-trip
     }),
     BlockquoteNoShortcut,
     ShikiCodeBlock,
@@ -233,6 +235,7 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
     PageMention,
     Subpage,
     HighlightMarkdown.configure({ multicolor: true }),
+    UnderlineMarkdown,
     DetailsMarkdown,
     DetailsSummaryMarkdown,
     DetailsContentMarkdown,

--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -217,6 +217,7 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
       codeBlock: false, // replaced by ShikiCodeBlock
       blockquote: false, // replaced by BlockquoteNoShortcut so `> ` triggers toggle
       underline: false, // replaced by UnderlineMarkdown so Ctrl+U survives markdown round-trip
+      link: false, // replaced by our explicit Link.configure(...) below — fixes a "Duplicate extension names: ['link']" warning
     }),
     BlockquoteNoShortcut,
     ShikiCodeBlock,

--- a/webui/src/components/editor/tiptap/underline/underline-extension.test.ts
+++ b/webui/src/components/editor/tiptap/underline/underline-extension.test.ts
@@ -1,0 +1,105 @@
+// Markdown round-trip tests for the underline mark.
+//
+// What we lock in here is the contract the editor depends on: a user's
+// Ctrl+U edit survives `getMarkdown()` → DB → next page-load via
+// `setContent(markdown)`. Before this extension the underline mark
+// silently dropped on round-trip (tiptap-markdown had no parser rule
+// for Tiptap's bundled `++…++` serializer); these tests guard the new
+// `<u>…</u>` cycle.
+
+import { Editor } from "@tiptap/core"
+import { Document } from "@tiptap/extension-document"
+import { Paragraph } from "@tiptap/extension-paragraph"
+import { Text } from "@tiptap/extension-text"
+import { Bold } from "@tiptap/extension-bold"
+import { Markdown } from "tiptap-markdown"
+import { describe, expect, it } from "vitest"
+
+import { UnderlineMarkdown } from "./underline-extension"
+
+
+/**
+ * Build a minimal Tiptap editor with just the underline + markdown
+ * extensions. We don't want StarterKit here — it would pull in the
+ * stock underline (which we're replacing) and a pile of unrelated
+ * marks, polluting the test surface.
+ */
+function makeEditor(): Editor {
+  return new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Bold,
+      UnderlineMarkdown,
+      Markdown.configure({ html: false }),
+    ],
+  })
+}
+
+
+/** `editor.storage.markdown` has a `getMarkdown()` method at runtime; type it locally. */
+type MarkdownStorage = { getMarkdown(): string }
+
+
+function toMarkdown(editor: Editor): string {
+  const storage = (editor.storage as unknown as Record<string, unknown>).markdown
+  return (storage as MarkdownStorage).getMarkdown()
+}
+
+
+describe("UnderlineMarkdown — round trip", () => {
+  it("parses <u>…</u> markdown back into an underline mark", () => {
+    const editor = makeEditor()
+    editor.commands.setContent("Some <u>underlined</u> text.")
+    // After parsing, the editor's HTML should carry a <u> wrapper —
+    // proves the mark was applied (not just kept as plain text).
+    expect(editor.getHTML()).toContain("<u>underlined</u>")
+    editor.destroy()
+  })
+
+
+  it("round-trips lossless — markdown → editor → markdown", () => {
+    const editor = makeEditor()
+    const md = "Underlines like <u>this</u> survive a full cycle."
+    editor.commands.setContent(md)
+    expect(toMarkdown(editor)).toBe(md)
+    editor.destroy()
+  })
+
+
+  it("survives combining with bold inside the underline", () => {
+    const editor = makeEditor()
+    // Bold AND underline on the same span. The marks should both
+    // survive a round-trip, even though tiptap-markdown may serialize
+    // them in either nesting order (`<u>**x**</u>` or `**<u>x</u>**` —
+    // semantically identical) depending on mark rank in the schema.
+    editor.commands.setContent("Mix <u>**bold underline**</u> here.")
+    const out = toMarkdown(editor)
+    expect(out).toContain("<u>")
+    expect(out).toContain("</u>")
+    expect(out.match(/\*\*/g)?.length).toBe(2) // bold open + close
+    expect(out).toContain("bold underline")
+    // The HTML should show both marks applied to the same text.
+    const html = editor.getHTML()
+    expect(html).toContain("<u>")
+    expect(html).toContain("<strong>")
+    editor.destroy()
+  })
+
+
+  it("does not match empty or multi-line spans", () => {
+    const editor = makeEditor()
+    // Empty span — should pass through as literal text (no mark applied).
+    editor.commands.setContent("Edge: <u></u> stays literal.")
+    expect(editor.getHTML()).not.toContain("<u></u>")
+
+    // Multi-line — markdown-it's inline rules don't span newlines, so
+    // this should leave the tags as raw text rather than wrap a
+    // paragraph break.
+    editor.commands.setContent("Open <u>foo\nbar</u> end.")
+    expect(editor.getHTML()).not.toContain("<u>foo")
+
+    editor.destroy()
+  })
+})

--- a/webui/src/components/editor/tiptap/underline/underline-extension.ts
+++ b/webui/src/components/editor/tiptap/underline/underline-extension.ts
@@ -1,0 +1,145 @@
+// Underline mark with markdown round-trip via `<u>…</u>`.
+//
+// `@tiptap/extension-underline` (bundled in StarterKit) renders the mark
+// to `<u>` in the DOM but emits `++text++` when serialized to markdown.
+// `tiptap-markdown` v0.9.0 has no parser rule for `++…++`, so the
+// underline mark was silently dropped on round-trip: a Ctrl+U edit
+// looked correct in-session but reverted to plain text on next load.
+//
+// Why `<u>…</u>` over `_text_` / `++text++`:
+//   - `<u>` is the universal cross-platform underline fallback —
+//     supported by GitHub, Notion, Obsidian, Pandoc, and any markdown
+//     viewer that respects raw HTML (which is most of them).
+//   - Zero collision with existing markdown conventions: `_…_` aliases
+//     to italic in CommonMark, `++…++` is a Tiptap-only token, `__…__`
+//     means bold everywhere except Discord.
+//   - Tiptap itself normalizes ALL underline input (including pasted
+//     `<u>` HTML and `text-decoration: underline` inline styles) to
+//     `<u>` internally — we're just making the markdown output match.
+//
+// Note: the legacy `++…++` form that Tiptap's stock serializer used to
+// emit is NOT parsed. Underline round-trip was broken before this
+// extension landed, so no existing notes have meaningful underline
+// content to preserve — dropping `++` keeps the parser tight.
+
+import { markInputRule } from "@tiptap/core"
+import { Underline } from "@tiptap/extension-underline"
+import type MarkdownIt from "markdown-it"
+
+
+/**
+ * Underline mark with tiptap-markdown round-trip via `<u>…</u>`.
+ *
+ * Serializes and parses the same canonical form:
+ *   <u>text</u>
+ */
+export const UnderlineMarkdown = Underline.extend({
+  /**
+   * Real-time `<u>…</u>` input rule. Lets users type the markdown
+   * shorthand directly in the editor — no save/reload needed to see
+   * the underline applied.
+   *
+   * Anchored on `</u>$` so the match only fires when the user
+   * completes the closing tag; otherwise every `<u>foo` keystroke
+   * would briefly look like a match.
+   */
+  addInputRules() {
+    return [
+      markInputRule({
+        find: /<u>([^<\n]+?)<\/u>$/,
+        type: this.type,
+      }),
+    ]
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize: {
+          open: "<u>",
+          close: "</u>",
+          mixable: true,
+          expelEnclosingWhitespace: true,
+        },
+        parse: {
+          setup(md: MarkdownIt) {
+            // `<u>…</u>` HTML tag form. Inline-only — we intentionally
+            // don't match across newlines, mirroring how markdown-it
+            // handles other inline marks (emphasis, code).
+            md.inline.ruler.after("emphasis", "underline_html", (state, silent) => {
+              return matchDelimited(state, silent, "<u>", "</u>")
+            })
+
+            md.renderer.rules.underline_open = () => "<u>"
+            md.renderer.rules.underline_close = () => "</u>"
+          },
+        },
+      },
+    }
+  },
+})
+
+
+/**
+ * Loosely-typed inline-parser state. markdown-it's `state_inline` carries
+ * a lot more than we declare here; we touch only the fields used by the
+ * underline rule.
+ */
+interface InlineState {
+  src: string
+  pos: number
+  posMax: number
+  push(type: string, tag: string, nesting: number): { content: string }
+  md: { inline: { tokenize(state: InlineState): void } }
+}
+
+
+/**
+ * Match a delimited inline span and push underline tokens with the
+ * inner content recursively re-tokenized so nested marks (bold,
+ * italic, code, …) parse correctly. Returns true if matched +
+ * consumed, false if the position didn't start with the open
+ * delimiter or no close was found.
+ *
+ * The inner-content recursion is what distinguishes this from a
+ * single-token approach (the highlight extension uses the simpler
+ * pattern, which means nested emphasis inside `==…==` doesn't parse —
+ * acceptable there because highlights wrap one short phrase, not
+ * usually styled text). Underlined-bold is a common combo so we pay
+ * the small extra cost.
+ *
+ * Rejects empty + multi-line spans so the mark stays inline-only.
+ */
+function matchDelimited(
+  state: InlineState,
+  silent: boolean,
+  open: string,
+  close: string,
+): boolean {
+  if (!state.src.startsWith(open, state.pos)) return false
+  const innerStart = state.pos + open.length
+  const closeIdx = state.src.indexOf(close, innerStart)
+  if (closeIdx === -1) return false
+
+  const inner = state.src.slice(innerStart, closeIdx)
+  // Reject empty + multi-line spans — keeps the mark inline-only and
+  // avoids accidentally swallowing a paragraph break.
+  if (!inner || inner.includes("\n")) return false
+
+  if (!silent) {
+    state.push("underline_open", "u", 1)
+    // Recursively tokenize the inner content so nested marks (bold,
+    // italic, code, links) parse. Save + restore pos / posMax around
+    // the recursion so the outer scanner picks up where we stopped.
+    const savedPos = state.pos
+    const savedPosMax = state.posMax
+    state.pos = innerStart
+    state.posMax = closeIdx
+    state.md.inline.tokenize(state)
+    state.pos = savedPos
+    state.posMax = savedPosMax
+    state.push("underline_close", "u", -1)
+  }
+  state.pos = closeIdx + close.length
+  return true
+}

--- a/webui/src/features/board/harness/node-types/sheet/sheet-toolbar.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/sheet-toolbar.tsx
@@ -45,16 +45,13 @@ function MarkButton({
  * its own bubble menu. Mount as the card's bottom flex child so it always sits
  * flush at the bottom edge while the prose scrolls above it.
  *
- * `surfaceColor` matches the bar's fill to the card so text reads cleanly
- * behind it. The row scrolls horizontally (no wrap, hidden scrollbar) so it
+ * The row scrolls horizontally (no wrap, hidden scrollbar) so it
  * truncates gracefully when the note is resized narrow.
  */
 export function SheetEditorToolbar({
   editor,
-  surfaceColor,
 }: {
   editor: Editor
-  surfaceColor?: string | null
 }) {
   const active = useEditorState({
     editor,
@@ -74,11 +71,9 @@ export function SheetEditorToolbar({
       // applies to nothing) and tripping the blur-to-exit handler.
       onMouseDown={(e) => e.preventDefault()}
       className={cn(
-        "flex shrink-0 items-center gap-0.5 overflow-x-auto border-t border-border px-3 py-1",
+        "flex shrink-0 items-center gap-0.5 overflow-x-auto border-t border-foreground/20 px-3 py-1 bg-sidebar",
         "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-        surfaceColor ? null : "bg-card",
       )}
-      style={surfaceColor ? { backgroundColor: surfaceColor } : undefined}
     >
       <MarkButton tooltip="Bold" active={active.bold} onClick={() => editor.chain().focus().toggleBold().run()}>
         <TextB size={14} weight="bold" />

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -231,7 +231,7 @@ export function SheetView({ id }: SheetViewProps) {
         ) : null}
 
         {editing && toolbarEditor ? (
-          <SheetEditorToolbar editor={toolbarEditor} surfaceColor={honoredBg} />
+          <SheetEditorToolbar editor={toolbarEditor} />
         ) : null}
       </div>
 


### PR DESCRIPTION
Four small editor-area fixes that landed together. Each is independently reviewable from its commit.

## 1. Underline mark survives markdown round-trip via `<u>…</u>` (commit `1afc5da`)

Ctrl+U applied the underline mark visually but **silently dropped** on next page-load — `@tiptap/extension-underline` serialized to `++text++`, and `tiptap-markdown` has no parser rule for `++…++`. So Ctrl+U looked correct in-session but reverted to plain text on re-hydrate from markdown storage.

Ship a custom `UnderlineMarkdown` that:
- Serializes to `<u>text</u>` — the universal cross-platform underline convention (supported by GitHub, Notion, Obsidian, Pandoc, any markdown viewer accepting raw HTML).
- Parses `<u>…</u>` via a custom markdown-it inline rule with recursive inner tokenization (nested bold/italic inside underline survives).
- Adds an `<u>foo</u>` input rule so the markdown shorthand activates the mark on the fly.

Disabled StarterKit's bundled underline (`StarterKit.configure({ underline: false })`) so the custom extension owns the mark. 5 round-trip cases in `underline-extension.test.ts`.

**Why `<u>…</u>` over `_text_` / `++text++`:** zero collision with existing markdown conventions; Tiptap itself normalizes all underline input to `<u>` internally — we're just making the markdown output match.

## 2. Silence "Duplicate extension names: ['link']" warning (commit `468d750`)

StarterKit bundles its own Link extension, and we register `Link.configure(...)` further down. Both registered under the same name → Tiptap logged `[tiptap warn]: Duplicate extension names found: ['link']`. Fix: `StarterKit.configure({ link: false })` so our explicit Link is the sole owner — same pattern we use for `codeBlock: false`, `blockquote: false`, `underline: false`.

## 3. Autolink bare domains too — not just `https://` URLs (commit `6c66fd8`)

`@tiptap/extension-link`'s default `shouldAutoLink` requires a protocol prefix, so `https://example.com ` autolinks but `example.com ` doesn't. Users coming from Word / Notion / Google Docs expect both.

Widen to `shouldAutoLink: () => true` and set `defaultProtocol: "https"`. `linkifyjs` (which the autolink plugin uses) already screens out non-URL-looking strings against the IANA TLD list, so trusting its detection doesn't open the door to junk auto-links on random `foo.bar` strings.

| Typing | Result |
|---|---|
| `https://example.com ` | linked (unchanged) |
| `wordpress.com ` | linked → `https://wordpress.com` |
| `john@example.com ` | mailto link |
| `setup.json file` | not linked (`.json` isn't a TLD) |

## 4. Pin sheet toolbar to `bg-sidebar` chrome (commit `a361cb0`)

The sheet inline-editor toolbar took an optional `surfaceColor` prop and bled its bg into the host sheet's custom paper color. On colored sheets the toolbar merged with the prose visually — less affordance, harder to find the controls.

Pin to `bg-sidebar` (semantic shadcn token, theme-aware) and soften the divider from `border-border` → `border-foreground/20`. Removed the prop, the inline `style`, and the conditional className.

## Test plan

- [ ] Type `<u>foo</u>` and Ctrl+U survives across save/reload (PR #1)
- [ ] No more `[tiptap warn]` in the console (PR #2)
- [ ] Type `wordpress.com ` → becomes a clickable `https://wordpress.com` (PR #3)
- [ ] Open a sheet with a custom paper color → toolbar reads as distinct chrome below the prose (PR #4)
- [ ] All editor tests pass: `make test-ui` (319 cases — 4 new round-trip cases for underline)