### PR TITLE
feat(editor): autolink bare domains too — not just `https://` URLs

### DIFF
--- a/webui/src/components/editor/tiptap/extensions.ts
+++ b/webui/src/components/editor/tiptap/extensions.ts
@@ -245,6 +245,16 @@ export function getExtensions(options: GetExtensionsOptions = {}) {
     Link.configure({
       openOnClick: false,
       HTMLAttributes: { class: "editor-link" },
+      // Auto-link bare domains too — by default the Link extension's
+      // `shouldAutoLink` requires a protocol prefix (`https://example.com`
+      // autolinks, `example.com` doesn't). Users expect a typed
+      // `wordpress.com ` to become a link without the scheme; linkifyjs's
+      // tokenizer already screens out non-URL-looking strings (it checks
+      // against the IANA TLD list under the hood), so widening to "trust
+      // linkify's detection" produces the natural behavior. Bare matches
+      // get the `https://` scheme via `defaultProtocol`.
+      shouldAutoLink: () => true,
+      defaultProtocol: "https",
     }),
     Typography,
     Markdown.configure({


### PR DESCRIPTION
## Summary
Today, typing `https://wordpress.com ` in a sheet auto-creates a link (Tiptap's default behavior). But typing `wordpress.com ` doesn't — the default `shouldAutoLink(url)` in `@tiptap/extension-link` requires a protocol prefix. Users coming from Word, Notion, or Google Docs expect bare domains to work too.

Widen `Link.configure(...)` to:

```ts
shouldAutoLink: () => true,
defaultProtocol: "https",
```

Behavior after:
| Typing | Result |
|---|---|
| `https://example.com ` | linked (unchanged) |
| `wordpress.com ` | linked → `https://wordpress.com` |
| `john@example.com ` | mailto link |
| `not.a.real.tld` | not linked (linkifyjs filters against the real IANA TLD list) |
| `setup.json file` | not linked (`.json` isn't a TLD) |

`linkifyjs` (which the autolink plugin uses under the hood) already screens out non-URL-looking strings against the IANA TLD list, so trusting its detection doesn't open the door to junk auto-links on random `foo.bar` strings.

## Test plan
- [ ] Type `wordpress.com ` in a sheet → it becomes a clickable link with `https://wordpress.com` as the href
- [ ] Type `https://wordpress.com ` → still works (no regression)
- [ ] Type `john@example.com ` → becomes a `mailto:` link
- [ ] Type `package.json` → stays as plain text (`.json` isn't a TLD)
- [ ] Existing notes with explicit `[label](url)` markdown links still render correctly