### PR TITLE
tweak(notes): exempt code-sandbox from autofit + bump default to 560x360

### DIFF
--- a/backend/test/unit/agents/assistant/test_note_tools.py
+++ b/backend/test/unit/agents/assistant/test_note_tools.py
@@ -77,6 +77,32 @@ async def test_build_note_sheet_keeps_default_size() -> None:
 
 
 @pytest.mark.asyncio
+async def test_build_note_code_sandbox_keeps_default_size() -> None:
+    """Code sandboxes are scrolling surfaces: kept at the full default size, not content-fit.
+
+    Same rationale as sheets — code can be arbitrarily long (whole programs),
+    so fitting the box to content would create giant cards. The default 560x360
+    rectangle is sized for ~75 chars/line at typical monospace, close to the
+    80-char code convention. Long snippets scroll inside the box.
+    """
+    graph_store = DummyGraphStore()
+
+    note = await build_note(
+        graph_store=graph_store,
+        graph_uid="graph-1",
+        content="print('hello, world')\n",
+        label="Snippet",
+        note_type=NodeType.CODE_SANDBOX,
+        parent_id=None,
+    )
+
+    assert note.style.type == NodeType.CODE_SANDBOX
+    default_w, default_h = get_default_note_size(NodeType.CODE_SANDBOX)
+    assert note.properties.node_size.size.width == default_w
+    assert note.properties.node_size.size.height == default_h
+
+
+@pytest.mark.asyncio
 async def test_build_widget_note_uses_widget_defaults() -> None:
     """Widget notes should use dedicated widget defaults."""
     graph_store = DummyGraphStore()

--- a/backend/test/unit/utils/test_text_measure.py
+++ b/backend/test/unit/utils/test_text_measure.py
@@ -84,9 +84,9 @@ def test_font_size_accepts_string_alias():
 
 
 def test_excluded_types_return_zero():
-    """Preview/doc node types are not content-sized (incl. sheet — kept at default)."""
+    """Preview/doc node types are not content-sized (incl. sheet + code-sandbox — kept at default)."""
     for node_type in (NodeType.SLIDE, NodeType.WIDGET, NodeType.MINI_APP, NodeType.FOLDER,
-                       NodeType.IMAGE, NodeType.ICON, NodeType.SHEET):
+                       NodeType.IMAGE, NodeType.ICON, NodeType.SHEET, NodeType.CODE_SANDBOX):
         assert node_type not in CONTENT_SIZED_TYPES
         assert estimate_node_height(node_type, 400, _LONG_LINE) == 0.0
 
@@ -94,7 +94,7 @@ def test_excluded_types_return_zero():
 def test_included_types_are_positive():
     """Content-sized types produce a positive height for non-empty content."""
     for node_type in (NodeType.RECTANGLE, NodeType.TEXT,
-                      NodeType.CODE_SANDBOX, NodeType.DIAMOND, NodeType.ELLIPSE):
+                      NodeType.DIAMOND, NodeType.ELLIPSE):
         assert estimate_node_height(node_type, 400, _LONG_LINE) > 0.0
 
 

--- a/backend/topix/agents/notes/service.py
+++ b/backend/topix/agents/notes/service.py
@@ -85,7 +85,12 @@ def get_default_note_size(note_type: NodeType) -> tuple[int, int]:  # noqa: C901
     if note_type == NodeType.FOLDER:
         return 150, 150
     if note_type == NodeType.CODE_SANDBOX:
-        return 320, 320
+        # Code-friendly rectangle — ~75 chars/line at typical monospace,
+        # close to the 80-char convention. Like sheet, code-sandbox is a
+        # scrolling fixed-surface node (overflow handles long content), so
+        # it's exempt from content-fit sizing in CONTENT_SIZED_TYPES.
+        # Keep in sync with DEFAULT_CODE_SANDBOX_* in webui note.ts.
+        return 560, 360
     if note_type == NodeType.WIDGET:
         return 800, 500
     if note_type == NodeType.MINI_APP:

--- a/backend/topix/utils/graph/text_measure.py
+++ b/backend/topix/utils/graph/text_measure.py
@@ -228,12 +228,13 @@ _SHAPE_FACTORS: dict[NodeType, tuple[float, float]] = {
 }
 
 # Node types whose layout height is derived from rendered content instead of the
-# stub default. Built-in shapes auto-fit to text on the canvas; among the custom
-# / preview nodes only code-sandbox is treated as content-sized. SHEET is
-# deliberately excluded: it is a long-form rich-text document (Notion-like), so
-# fitting its height would spawn a giant card — it keeps its default size and
-# scrolls instead. Everything else (folder, image, icon, slide, widget, mini-app,
-# sheet) keeps its fixed default size.
+# stub default. Only built-in shapes are content-sized — they're text-on-canvas
+# primitives that should hug their label. Document-style custom nodes (SHEET,
+# CODE_SANDBOX) are deliberately excluded: they're long-form scrolling surfaces
+# (Notion-like prose; arbitrary code), so fitting their height would spawn giant
+# cards. They keep their fixed default size and the inner content scrolls.
+# Everything else (folder, image, icon, slide, widget, mini-app, sheet,
+# code-sandbox) keeps its fixed default size.
 CONTENT_SIZED_TYPES: frozenset[NodeType] = frozenset(
     {
         NodeType.RECTANGLE,
@@ -247,7 +248,6 @@ CONTENT_SIZED_TYPES: frozenset[NodeType] = frozenset(
         NodeType.CAPSULE,
         NodeType.TAG,
         NodeType.THOUGHT_CLOUD,
-        NodeType.CODE_SANDBOX,
     }
 )
 

--- a/webui/src/components/icons/icon-picker.tsx
+++ b/webui/src/components/icons/icon-picker.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react"
+import { useTheme } from "@/components/theme-provider"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { resolveIconDisplayColor } from "./icon-color-resolver"
 import {
   filterPickerCategories,
   ICON_COLOR_PRESETS,
@@ -49,6 +51,8 @@ const DEFAULT_COLOR = ICON_COLOR_PRESETS[0].value
 export const IconPicker = ({ value, onChange, onRemove, className }: IconPickerProps) => {
   const [query, setQuery] = useState("")
   const [activeColor, setActiveColor] = useState<string | null>(value?.color ?? DEFAULT_COLOR)
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === "dark"
 
   const selectedName = value?.name ?? null
 
@@ -99,6 +103,7 @@ export const IconPicker = ({ value, onChange, onRemove, className }: IconPickerP
                 category={category}
                 selectedName={selectedName}
                 activeColor={activeColor}
+                isDark={isDark}
                 onSelect={handleIconClick}
               />
             ),
@@ -113,6 +118,7 @@ export const IconPicker = ({ value, onChange, onRemove, className }: IconPickerP
       <ColorStrip
         activeColor={activeColor}
         canRemove={selectedName !== null && onRemove !== undefined}
+        isDark={isDark}
         onColorClick={handleColorClick}
         onRemove={onRemove ?? (() => {})}
       />
@@ -125,11 +131,12 @@ type CategorySectionProps = {
   category: PickerCategory
   selectedName: string | null
   activeColor: string | null
+  isDark: boolean
   onSelect: (name: string) => void
 }
 
 
-const CategorySection = ({ category, selectedName, activeColor, onSelect }: CategorySectionProps) => {
+const CategorySection = ({ category, selectedName, activeColor, isDark, onSelect }: CategorySectionProps) => {
   return (
     <section className="mb-3 last:mb-0">
       <h3 className="mb-1 px-1 text-xs font-medium text-muted-foreground">
@@ -142,6 +149,7 @@ const CategorySection = ({ category, selectedName, activeColor, onSelect }: Cate
             icon={icon}
             isSelected={selectedName === icon.name}
             color={activeColor}
+            isDark={isDark}
             onSelect={onSelect}
           />
         ))}
@@ -155,12 +163,18 @@ type IconCellProps = {
   icon: PickerIconEntry
   isSelected: boolean
   color: string | null
+  isDark: boolean
   onSelect: (name: string) => void
 }
 
 
-const IconCell = ({ icon, isSelected, color, onSelect }: IconCellProps) => {
+const IconCell = ({ icon, isSelected, color, isDark, onSelect }: IconCellProps) => {
   const Glyph = icon.component
+  // Resolve through the same helper IconPropertyView uses so the picker
+  // grid previews match the icon's final on-canvas appearance in dark
+  // mode — without this the grid stayed in light-mode hex while the
+  // saved icon rendered dark-adapted.
+  const displayColor = resolveIconDisplayColor(color, isDark)
 
   return (
     <button
@@ -168,7 +182,7 @@ const IconCell = ({ icon, isSelected, color, onSelect }: IconCellProps) => {
       title={icon.name}
       aria-label={icon.name}
       onClick={() => onSelect(icon.name)}
-      style={{ color: color ?? undefined }}
+      style={{ color: displayColor }}
       className={cn(
         "flex aspect-square items-center justify-center rounded-md transition-colors hover:bg-accent",
         !color && "text-foreground",
@@ -184,12 +198,13 @@ const IconCell = ({ icon, isSelected, color, onSelect }: IconCellProps) => {
 type ColorStripProps = {
   activeColor: string | null
   canRemove: boolean
+  isDark: boolean
   onColorClick: (color: string | null) => void
   onRemove: () => void
 }
 
 
-const ColorStrip = ({ activeColor, canRemove, onColorClick, onRemove }: ColorStripProps) => {
+const ColorStrip = ({ activeColor, canRemove, isDark, onColorClick, onRemove }: ColorStripProps) => {
   return (
     <div className="flex items-center gap-1 border-t p-2">
       <div className="flex flex-1 items-center gap-1">
@@ -198,6 +213,7 @@ const ColorStrip = ({ activeColor, canRemove, onColorClick, onRemove }: ColorStr
             key={preset.id}
             preset={preset}
             isActive={preset.value === activeColor}
+            isDark={isDark}
             onClick={() => onColorClick(preset.value)}
           />
         ))}
@@ -219,11 +235,17 @@ const ColorStrip = ({ activeColor, canRemove, onColorClick, onRemove }: ColorStr
 type ColorChipProps = {
   preset: ColorPreset
   isActive: boolean
+  isDark: boolean
   onClick: () => void
 }
 
 
-const ColorChip = ({ preset, isActive, onClick }: ColorChipProps) => {
+const ColorChip = ({ preset, isActive, isDark, onClick }: ColorChipProps) => {
+  // Same resolver as the grid + the on-canvas IconPropertyView so the
+  // chip swatch matches what the icon will actually look like once
+  // committed. CSS-var presets (e.g. "Default") pass through unchanged.
+  const displayColor = resolveIconDisplayColor(preset.value, isDark)
+
   return (
     <button
       type="button"
@@ -231,7 +253,7 @@ const ColorChip = ({ preset, isActive, onClick }: ColorChipProps) => {
       aria-label={preset.label}
       aria-pressed={isActive}
       onClick={onClick}
-      style={{ backgroundColor: preset.value ?? undefined }}
+      style={{ backgroundColor: preset.value ? displayColor : undefined }}
       className={cn(
         "h-5 w-5 rounded-full border border-border transition-transform hover:scale-110",
         !preset.value && "bg-foreground",

--- a/webui/src/features/board/types/note.ts
+++ b/webui/src/features/board/types/note.ts
@@ -97,8 +97,13 @@ export const DEFAULT_SLIDE_HEIGHT = 540
 
 export const DEFAULT_FOLDER_WIDTH = 150
 export const DEFAULT_FOLDER_HEIGHT = 150
-export const DEFAULT_CODE_SANDBOX_WIDTH = 320
-export const DEFAULT_CODE_SANDBOX_HEIGHT = 320
+// Code-sandbox: rectangle sized for code line-length (~75 chars/line at
+// typical monospace, close to the 80-char convention). Like sheet, it's a
+// scrolling fixed-surface node — exempt from content-fit sizing, so this
+// is the size it keeps. Keep in sync with get_default_note_size in
+// backend/topix/agents/notes/service.py.
+export const DEFAULT_CODE_SANDBOX_WIDTH = 560
+export const DEFAULT_CODE_SANDBOX_HEIGHT = 360
 export const DEFAULT_WIDGET_WIDTH = 800
 export const DEFAULT_WIDGET_HEIGHT = 500
 // Mini-apps trend toward interactive dashboards (charts + controls, lists


### PR DESCRIPTION
## Summary
Code snippets are arbitrarily long (entire programs), so the backend's content-fit sizing was spawning giant code-sandbox cards — same problem sheets had before they were exempted. Mirror sheet's treatment for code-sandbox: make it a fixed-surface scrolling node.

| Before | After |
|---|---|
| Backend `build_note` content-fits height via `estimate_node_size` | Backend uses the fixed default from `get_default_note_size()` |
| Default size: 320×320 | Default size: 560×360 |
| Long snippets → giant card | Long snippets → scroll inside the card |

Frontend `AUTOFIT_DISABLED_TYPES` already includes code-sandbox, so canvas-harness's native autofit is already off. This PR only changes the backend write-path + the default size on both sides.

## Why 560×360 (not 440 square like sheet)

Sheet's 440-square jot-pad shape works because prose reads in any aspect. Code's bottleneck is **horizontal real estate for line length** — most code conventions land at 80 chars/line. 560px width at typical monospace yields ~75 chars/line, close to the convention without dominating the board.

| Width | Chars/line | Verdict |
|---|---|---|
| 320 (old) | ~30-35 | Cramped — most lines wrapped |
| 440 (sheet parity) | ~50-55 | OK for short snippets, tight for real code |
| **560 (chosen)** | **~75-80** | Hits the 80-char convention |
| 720 (mini-app size) | ~95-105 | Comfortable but starts dominating |

## Migration
Existing code-sandbox notes keep their current size — only newly-created ones land at the new 560×360 default. No DB script needed. Same risk profile as the recent sheet bump.

## Files touched
- `backend/topix/utils/graph/text_measure.py` — remove `CODE_SANDBOX` from `CONTENT_SIZED_TYPES`, update the explanatory comment
- `backend/topix/agents/notes/service.py` — bump default to 560×360, add cross-reference comment
- `webui/src/features/board/types/note.ts` — mirror constants 560×360 with reciprocal "keep in sync" comment
- `backend/test/unit/utils/test_text_measure.py` — move `CODE_SANDBOX` from "included" to "excluded" tuple
- `backend/test/unit/agents/assistant/test_note_tools.py` — new `test_build_note_code_sandbox_keeps_default_size` mirroring the sheet test

## Test plan
- [x] `make lint-ui` + `make test-ui` pass (no regressions)
- [x] `ruff check` + `pytest test/unit` pass — 507 backend tests, including the new code-sandbox sizing case
- [x] After deploy: ask the agent for a long Python script, verify the new code-sandbox card stays at 560×360 and the code scrolls inside (not the card growing tall)
- [x] Create a code-sandbox via the canvas toolbar — also lands at 560×360
- [x] Existing code-sandbox notes on existing boards keep their current size (no surprise resize on load)