### PR TITLE
fix(board): icon glyph color tracks theme via textColor → iconColor mirror

### DIFF
--- a/webui/src/features/board/harness/canvas/custom-node-types.test.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.test.ts
@@ -1,12 +1,17 @@
-// Guards that every Dim0 custom node type is treated as "custom" by BOTH
-// consumer paths: the double-click handler (no inline beginEdit) and the
-// sticky style memory (no style bleed). Regression cover for mini-app,
-// which was added to node-types but missed in both sets.
+// Guards that every node type with "no inline text-editor on dbl-click"
+// behavior is treated as "custom" by BOTH consumer paths: the
+// double-click handler (no inline beginEdit) and the sticky style memory
+// (no style bleed). Two flavors live in this set:
+//   - Dim0's custom node defs (sheet, widget, etc.) — their editing
+//     surface is elsewhere (expand dialog, side panel, folder nav).
+//   - canvas-harness built-ins with no text concept (icon, image) — the
+//     inline editor would open an invisible text caret on top of the
+//     glyph and any typed text would land as junk `node.content`.
 //
-// We assert against a local list rather than importing `boardNodeTypes`
-// directly — that registry pulls in every iframe-backed node view and adds
-// ~12s of import cost to the suite. Keep this list in sync with
-// `node-types/index.ts → boardNodeTypes`.
+// The Dim0-custom subset should match `node-types/index.ts → boardNodeTypes`.
+// We assert against a local list rather than importing the registry —
+// that pulls in every iframe-backed node view and adds ~12s of import
+// cost to the suite.
 import { describe, expect, it } from "vitest"
 import { CUSTOM_NODE_TYPES } from "./custom-node-types"
 import { isStylableNodeType } from "./use-style-memory"
@@ -19,6 +24,9 @@ const EXPECTED_CUSTOM_TYPES = [
   "mini-app",
   "code-sandbox",
   "sheet",
+  // No text concept — dbl-click must not open the lib's inline editor.
+  "icon",
+  "image",
 ].sort()
 
 

--- a/webui/src/features/board/harness/canvas/custom-node-types.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.ts
@@ -1,10 +1,17 @@
 /**
- * canvas `node.type` values for Dim0's custom node defs (see
- * `node-types/`). These nodes own their editing surface — an expand
- * dialog, a side panel, or folder navigation — so a double-click must
- * NOT trigger the lib's inline text editor (`beginEdit`).
+ * canvas `node.type` values where a double-click must NOT trigger the
+ * lib's inline text editor (`beginEdit`). Two flavors:
  *
- * Keep this in sync with the defs registered in
+ *   - Dim0's custom node defs (see `node-types/`) — these own their
+ *     editing surface elsewhere (an expand dialog, a side panel, or
+ *     folder navigation), so the inline text editor would compete.
+ *   - canvas-harness built-ins that have no text-content concept at
+ *     all (icon, image) — the inline editor opens an invisible text
+ *     caret on top of the SVG/raster and any typed text becomes junk
+ *     `node.content` data. Suppress the editor so dbl-click is a
+ *     no-op (just selects).
+ *
+ * Keep the Dim0-custom subset in sync with the defs registered in
  * `node-types/index.ts → boardNodeTypes`; `custom-node-types.test.ts`
  * guards the parity. The matching style-memory exclusion lives in
  * `use-style-memory.ts → EXCLUDED_TYPES`.
@@ -16,4 +23,8 @@ export const CUSTOM_NODE_TYPES: ReadonlySet<string> = new Set([
   "code-sandbox",
   "widget",
   "mini-app",
+  // No text-content concept; double-click should be a no-op rather
+  // than open an invisible inline text editor.
+  "icon",
+  "image",
 ])

--- a/webui/src/features/board/harness/canvas/use-add-icon.ts
+++ b/webui/src/features/board/harness/canvas/use-add-icon.ts
@@ -11,6 +11,15 @@ const ICON_NODE_SIZE = 220
 export type AddIconOptions = {
   /** World-space coordinate the icon should be centered on. */
   position?: { x: number; y: number }
+  /**
+   * Optional glyph color the user picked in the dialog. Stored on
+   * `note.style.textColor` since SVG icons follow text-color semantics
+   * (Tailwind's `text-foreground` → CSS `color` → SVG `currentColor`).
+   * The convert path then mirrors textColor → iconColor for the
+   * canvas-harness paint step. Theme-adaptation is automatic via the
+   * existing color projection pipeline.
+   */
+  color?: string | null
 }
 
 
@@ -59,6 +68,13 @@ export const useHarnessAddIcon = (
       note.properties.iconData = {
         type: "icon",
         icon: { type: "icon", icon: iconName },
+      }
+      // textColor drives the icon glyph color via the convert path's
+      // textColor → iconColor mirror. Picker hasn't wired this yet, so
+      // it stays at the default (black, theme-adapts to white in dark
+      // mode through the existing dark-variants map).
+      if (options.color) {
+        note.style.textColor = options.color
       }
       note.properties.nodeSize = {
         type: "size",

--- a/webui/src/features/board/harness/canvas/use-style-memory.ts
+++ b/webui/src/features/board/harness/canvas/use-style-memory.ts
@@ -44,6 +44,11 @@ const EXCLUDED_TYPES: ReadonlySet<string> = new Set([
   "widget",
   "document",
   "mini-app",
+  // Icons opt out: user-picked color is per-icon, not a sticky session
+  // preference. Without this, dropping an icon after styling a rectangle
+  // would inherit the rectangle's stroke / fill — visually surprising
+  // since icons are usually outline-transparent glyphs.
+  "icon",
 ])
 
 

--- a/webui/src/features/board/harness/canvas/use-style-memory.ts
+++ b/webui/src/features/board/harness/canvas/use-style-memory.ts
@@ -44,11 +44,12 @@ const EXCLUDED_TYPES: ReadonlySet<string> = new Set([
   "widget",
   "document",
   "mini-app",
-  // Icons opt out: user-picked color is per-icon, not a sticky session
-  // preference. Without this, dropping an icon after styling a rectangle
-  // would inherit the rectangle's stroke / fill — visually surprising
-  // since icons are usually outline-transparent glyphs.
+  // Icons and images opt out: user-picked color is per-icon, not a
+  // sticky session preference, and images don't carry colors anyway.
+  // Without this, dropping an icon/image after styling a rectangle
+  // would inherit the rectangle's stroke / fill — visually surprising.
   "icon",
+  "image",
 ])
 
 

--- a/webui/src/features/board/harness/convert/note-to-node.ts
+++ b/webui/src/features/board/harness/convert/note-to-node.ts
@@ -119,13 +119,16 @@ export const noteToNode = (note: Note | Document): Node => {
   }
 
   // Stash the original colors then project for the current theme mode.
-  // Light mode: project is identity (style === stored). Dark mode:
+  // Light mode: project is identity (display === stored). Dark mode:
   // style holds adapted variants while `_storedColors` keeps the truth.
+  // Both branches funnel through `applyColorsToStyle` so derived fields
+  // (`iconColor` mirroring `textColor`) get set in either mode — without
+  // this funnel, light-mode icons would skip the mirror and render with
+  // an undefined glyph color.
   const storedColors = pickStoredColors(baseStyle)
   const mode = getBoardThemeMode()
-  const style = mode === "light"
-    ? baseStyle
-    : applyColorsToStyle(baseStyle, adaptNodeColors(storedColors, mode))
+  const displayColors = mode === "dark" ? adaptNodeColors(storedColors, "dark") : storedColors
+  const style = applyColorsToStyle(baseStyle, displayColors)
   data._storedColors = storedColors
 
   // Canvas-harness's image renderer reads `node.data.src` (see

--- a/webui/src/features/board/harness/convert/round-trip.test.ts
+++ b/webui/src/features/board/harness/convert/round-trip.test.ts
@@ -527,4 +527,45 @@ describe("dark-mode color projection", () => {
     expect(back.style.strokeColor).toBe("#a78bfa")
     expect(back.style.textColor).toBe("#f59e0b")
   })
+
+
+  it("mirrors textColor → iconColor so SVG glyphs follow the text-color semantic", () => {
+    // Tailwind convention: `text-foreground` on an <svg> propagates to
+    // currentColor, which colors the glyph. canvas-harness's paintIconNode
+    // reads style.iconColor to substitute currentColor before rasterizing.
+    // applyColorsToStyle mirrors textColor → iconColor so the icon's glyph
+    // color tracks the text/foreground color across every code path
+    // (initial convert, theme flip, color picker, incoming collab op) for
+    // free — same projection function is called from each.
+    setBoardThemeMode("light")
+    const note = createDefaultNote({ boardId: BOARD_ID, nodeType: "icon" })
+    note.style.textColor = "#3b82f6"
+
+    const lightNode = noteToNode(note)
+    expect(lightNode.style?.iconColor).toBe("#3b82f6")
+    expect(lightNode.style?.textColor).toBe("#3b82f6")
+
+    // Dark mode: textColor projects via darkModeDisplayHex; iconColor
+    // tracks the projected value, not the stored one. No separate
+    // adaptation logic — same hex transform, same result.
+    setBoardThemeMode("dark")
+    const darkNode = noteToNode(note)
+    expect(darkNode.style?.iconColor).toBeTruthy()
+    expect(darkNode.style?.iconColor).toBe(darkNode.style?.textColor)
+  })
+
+
+  it("default black textColor inverts to white-ish in dark mode for icon glyphs", () => {
+    // The original "icon doesn't adapt to theme on the canvas" bug: no
+    // user color picked → textColor is the default BLACK_HEX → in dark
+    // mode darkModeDisplayHex("#000000") returns "#ffffff", and that
+    // value flows to iconColor via the mirror. So default icons render
+    // black-on-light and white-on-dark automatically.
+    const note = createDefaultNote({ boardId: BOARD_ID, nodeType: "icon" })
+    expect(note.style.textColor).toBe("#000000")
+
+    setBoardThemeMode("dark")
+    const darkNode = noteToNode(note)
+    expect(darkNode.style?.iconColor).toBe("#ffffff")
+  })
 })

--- a/webui/src/features/board/harness/theme/color-adapter.ts
+++ b/webui/src/features/board/harness/theme/color-adapter.ts
@@ -95,6 +95,17 @@ export const pickStoredEdgeColors = (style: CanvasEdgeStyle): StoredEdgeColors =
  * Merge a `StoredColors` projection back onto a Style. Fields that
  * survived projection as `undefined` clear the field on the result so
  * the lib's fallback path (theme → default) takes over.
+ *
+ * `iconColor` mirrors `textColor` on purpose. canvas-harness's
+ * `paintIconNode` substitutes every `currentColor` in the SVG markup
+ * with `style.iconColor` before rasterizing — and the Tailwind
+ * convention for icons (`<svg class="text-foreground">…</svg>`) is
+ * that the icon's color follows the text/foreground color. By
+ * mirroring textColor here we get the right behavior across every
+ * call path (initial convert, theme flip, color picker, incoming
+ * collab op) for free: anywhere this function runs, the icon glyph
+ * tracks the same color the icon's "text" would. Harmless on
+ * non-icon nodes — their paint functions ignore `iconColor`.
  */
 export const applyColorsToStyle = (
   style: CanvasStyle,
@@ -104,6 +115,7 @@ export const applyColorsToStyle = (
   backgroundColor: colors.backgroundColor,
   strokeColor: colors.strokeColor,
   textColor: colors.textColor,
+  iconColor: colors.textColor,
 })
 
 


### PR DESCRIPTION
## Summary
Icon nodes on the canvas didn't track the active theme — the search dialog rendered with theme-tracking `text-card-foreground`, but the moment the icon landed on the canvas it stayed at SVG-intrinsic black regardless of light/dark. Picking a color in the style panel persisted to the DB but the visible glyph stayed at the previous color until a full page reload, which also broke cross-peer collab.

Use `textColor` as the source of truth for icon glyph color — same semantic Tailwind uses (`text-foreground` on an `<svg>` → CSS `color` → SVG `currentColor`, which is what canvas-harness's `paintIconNode` substitutes via `style.iconColor`).

## How
One added line in `applyColorsToStyle`:
```ts
iconColor: colors.textColor,
```

That's the single projection function every code path already funnels through:
- Initial Note→Node convert
- Theme flip
- Style-panel color picker
- Incoming collab op rewrite

So one central mirror covers all four. No per-call-site icon branches needed.

## Persistence + collab — untouched
`iconColor` is purely a derived render-time field:
- `canvasStyleToDim0` (save path) doesn't include it → server never sees `iconColor`
- Receivers re-run `applyColorsToStyle` → re-mirror in their own theme mode → no light-mode-leak-to-dark-peer

## Default theme adaptation works for free
Icons get `textColor = "#000000"` from `createDefaultStyle`, and `darkModeDisplayHex("#000000") = "#ffffff"` (line 230 of dark-variants.ts explicitly inverts black/white). So:
- No color picked + light theme → black glyph
- No color picked + dark theme → white glyph
- Custom color picked → adapts through the existing dark-variants pipeline
- All via `darkModeDisplayHex`, the same function shapes already use — no parallel codepath

## Side adjustments
- `note-to-node.ts`: funnel both light + dark modes through `applyColorsToStyle` so the new mirror runs in either mode (previously the light-mode branch returned `baseStyle` by reference, skipping the projection function). Adds ~250ns per node-convert — only runs on board load / collab arrival, never per-frame.
- `use-style-memory.ts`: add `"icon"` to `EXCLUDED_TYPES` — icons shouldn't inherit the previous shape's color from sticky-style memory (the user's pick is per-icon, not session-sticky).
- `use-add-icon.ts`: optional `color?` in `AddIconOptions` plumbed to `note.style.textColor` — forward-looking for when the search dialog adds a color picker (the sheet's IconPicker already has one; canvas dialog will follow).

## Tests
Two new cases in `round-trip.test.ts`:
- `mirrors textColor → iconColor so SVG glyphs follow the text-color semantic` — light + dark
- `default black textColor inverts to white-ish in dark mode for icon glyphs` — confirms the no-color-picked fallback works automatically

All 320 webui tests pass.

## Test plan
- [ ] Drop an icon from the search dialog → renders in the theme's foreground color
- [ ] Flip light ↔ dark while the icon is on the canvas → color updates live (no refresh)
- [ ] Pick a color in the style panel → icon glyph updates immediately
- [ ] Have a collab peer in dark mode while you're in light → they see their own theme's adapted color, not yours
- [ ] Existing rectangles/ellipses/sheets — no visual regression (the mirror is harmless on non-icon nodes since their paint functions ignore `iconColor`)