### PR TITLE
tweak(charts): dot-with-caption graph nodes + tuned force spacing

### DIFF
--- a/webui/src/components/charts/graph-layout-force.ts
+++ b/webui/src/components/charts/graph-layout-force.ts
@@ -20,12 +20,15 @@ import {
 import type { SimulationLinkDatum, SimulationNodeDatum } from "d3-force"
 
 
-// Tuned against NODE_RADIUS (23) so spacing reads at the same scale as the
-// hand-laid manual examples: links settle ~90u apart, charge keeps clusters
-// from collapsing, collide guarantees circles never overlap.
-const LINK_DISTANCE = 90
+// Sized for the dot-with-caption chrome (NODE_RADIUS 12, sublabel sitting
+// R+28 below center). LINK_DISTANCE leaves the edge-label chip (22×18) at
+// the midpoint with clear space to either dot. COLLIDE_RADIUS guarantees
+// no two nodes sit close enough for one's caption to collide with the
+// other's circle. CHARGE_STRENGTH keeps dense clusters from collapsing
+// without spreading sparse graphs to the corners.
+const LINK_DISTANCE = 140
 const CHARGE_STRENGTH = -320
-const COLLIDE_RADIUS = 34
+const COLLIDE_RADIUS = 40
 const TICKS = 300
 
 

--- a/webui/src/components/charts/graph-layout.test.ts
+++ b/webui/src/components/charts/graph-layout.test.ts
@@ -66,7 +66,9 @@ describe("layoutGraph — color resolution and defaults", () => {
       edges: [],
     })
     expect(g.nodes[0].color).toBe("var(--card)")
-    expect(g.nodes[0].border).toBe("var(--border)")
+    expect(g.nodes[0].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
     expect(g.nodes[0].textColor).toBe("var(--foreground)")
   })
 
@@ -111,7 +113,10 @@ describe("layoutGraph — color resolution and defaults", () => {
         { a: "A", b: "B", color: "chart-3" },
       ],
     })
-    expect(g.edges[0].color).toBe("var(--border)")
+    // Edge default is a 50%-opacity foreground stroke (low-contrast thread).
+    expect(g.edges[0].color).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
     expect(g.edges[1].color).toBe("var(--chart-3)")
   })
 })
@@ -346,12 +351,18 @@ describe("layoutGraph — auto color ramp", () => {
       nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
       edges: [{ a: "A", b: "B" }],
     })
-    expect(g.nodes[0].border).toBe("var(--chart-1)")
-    expect(g.nodes[1].border).toBe("var(--chart-2)")
-    expect(g.nodes[2].border).toBe("var(--chart-3)")
-    // Fill is a soft tint of the same token, not the neutral card default.
-    expect(g.nodes[0].color).toContain("--chart-1")
-    expect(g.nodes[0].color).toContain("color-mix")
+    // Color identity lives on the fill — solid chart token per node.
+    expect(g.nodes[0].color).toBe("var(--chart-1)")
+    expect(g.nodes[1].color).toBe("var(--chart-2)")
+    expect(g.nodes[2].color).toBe("var(--chart-3)")
+    // Border stays neutral on every node so the colored dot is the only
+    // cluster cue. Now a 50%-opacity foreground stroke for visibility.
+    expect(g.nodes[0].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
+    expect(g.nodes[1].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
   })
 
 
@@ -374,8 +385,8 @@ describe("layoutGraph — auto color ramp", () => {
         { a: "r", b: "e" },
       ],
     })
-    // 6th node (index 5) wraps back to chart-1.
-    expect(g.nodes[5].border).toBe("var(--chart-1)")
+    // 6th node (index 5) wraps back to chart-1 on the fill.
+    expect(g.nodes[5].color).toBe("var(--chart-1)")
   })
 
 
@@ -388,7 +399,9 @@ describe("layoutGraph — auto color ramp", () => {
       edges: [],
     })
     expect(g.nodes[0].color).toBe("var(--card)")
-    expect(g.nodes[0].border).toBe("var(--border)")
+    expect(g.nodes[0].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
   })
 
 
@@ -400,9 +413,14 @@ describe("layoutGraph — auto color ramp", () => {
     })
     // A keeps its explicit color and the neutral default border.
     expect(g.nodes[0].color).toBe("var(--primary)")
-    expect(g.nodes[0].border).toBe("var(--border)")
-    // B is still ramped.
-    expect(g.nodes[1].border).toBe("var(--chart-2)")
+    expect(g.nodes[0].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
+    // B is still ramped on the fill; border stays neutral on every node.
+    expect(g.nodes[1].color).toBe("var(--chart-2)")
+    expect(g.nodes[1].border).toBe(
+      "color-mix(in srgb, var(--foreground) 50%, transparent)",
+    )
   })
 })
 

--- a/webui/src/components/charts/graph-layout.ts
+++ b/webui/src/components/charts/graph-layout.ts
@@ -23,21 +23,20 @@ import type {
 // Default token names used when the agent doesn't supply a color. Pulled
 // from shadcn / index.css so they auto-adapt to light/dark mode.
 const DEFAULT_NODE_FILL = "card"
-const DEFAULT_NODE_BORDER = "border"
 const DEFAULT_NODE_TEXT = "foreground"
-const DEFAULT_EDGE_COLOR = "border"
+
+// 50%-opacity foreground stroke, shared by the node border ring and the
+// default edge color. Keeping one source for both so the dot ring and
+// connecting edges always read with matching weight; --border was too
+// washed-out for either role.
+const STROKE_FG_50 = "color-mix(in srgb, var(--foreground) 50%, transparent)"
+const DEFAULT_NODE_BORDER = STROKE_FG_50
+const DEFAULT_EDGE_COLOR = STROKE_FG_50
 
 
 // Padding (in viewBox units) added around node extent when auto-computing
 // the viewBox. Matches the visual feel of hand-laid examples like Dijkstra.
 const AUTO_VIEWBOX_PADDING = 30
-
-
-// How much of the chart color is mixed into the card surface for an
-// auto-colored node fill. Low enough that the label (foreground) stays
-// readable in both light and dark mode; the full chart color goes on the
-// border, which carries the visible hue.
-const AUTO_FILL_MIX_PCT = 18
 
 
 type Point = { x: number; y: number }
@@ -120,11 +119,12 @@ function positionNode(
   index: number,
   autoColor: boolean,
 ): PositionedNode {
-  // A fully unstyled node under an auto layout gets the chart ramp: a soft
-  // tinted fill plus a full-strength chart border. Any explicit color or
-  // border opts the node out, so agent-decorated nodes are never overridden.
+  // A fully unstyled node under an auto layout gets the chart ramp on its
+  // fill — the visible cluster cue. Border stays neutral (--border) so a
+  // thin halo separates the dot from incoming edges without competing
+  // with the fill for color identity. Any explicit color or border opts
+  // the node out so agent-decorated nodes are never overridden.
   const ramp = autoColor && n.color == null && n.border == null
-  const token = `chart-${(index % 5) + 1}`
   return {
     id: n.id,
     x: pos.x,
@@ -132,11 +132,9 @@ function positionNode(
     label: n.label ?? n.id,
     sublabel: n.sublabel ?? null,
     color: ramp
-      ? `color-mix(in oklch, var(--${token}) ${AUTO_FILL_MIX_PCT}%, var(--card))`
-      : resolveColor(n.color ?? DEFAULT_NODE_FILL),
-    border: ramp
       ? defaultPaletteColor(index)
-      : resolveColor(n.border ?? DEFAULT_NODE_BORDER),
+      : resolveColor(n.color ?? DEFAULT_NODE_FILL),
+    border: resolveColor(n.border ?? DEFAULT_NODE_BORDER),
     textColor: resolveColor(n.textColor ?? DEFAULT_NODE_TEXT),
   }
 }

--- a/webui/src/components/charts/graph.tsx
+++ b/webui/src/components/charts/graph.tsx
@@ -16,16 +16,18 @@ import type {
 } from "./graph-types"
 
 
-// Visual constants. Picked to match the reference Dijkstra HTML widget
-// the agent originally produced — matches the "feel" so existing widgets
-// don't have to be re-tuned when switching renderers.
-const NODE_RADIUS = 23
+// Visual constants. Dot-with-caption aesthetic: nodes render as small
+// filled circles with a neutral border ring, label and sublabel sit
+// stacked below the dot. Color identity lives on the fill (chart-token
+// for auto-laid graphs, --card for manual), so the ring stays neutral
+// across every node and edges read as low-contrast threads.
+const NODE_RADIUS = 12
 const NODE_STROKE_WIDTH = 2
-const NODE_LABEL_FONT_SIZE = 16
+const NODE_LABEL_FONT_SIZE = 12
 const NODE_LABEL_FONT_WEIGHT = 600
-const NODE_LABEL_DY = 5                    // text baseline offset to vertically center inside circle
+const NODE_LABEL_DY = NODE_RADIUS + 14     // label baseline sits just below the circle
 const SUBLABEL_FONT_SIZE = 11
-const SUBLABEL_DY = NODE_RADIUS + 15       // distance below circle center
+const SUBLABEL_DY = NODE_RADIUS + 28       // sublabel stacks below the label
 const EDGE_STROKE_WIDTH = 3
 const EDGE_LABEL_FONT_SIZE = 11
 const EDGE_LABEL_CHIP_WIDTH = 22

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -105,6 +105,14 @@ export function HarnessCanvas() {
   // `setHideFrames` on this so slide chrome (border + label) drops out
   // and only the contents show.
   const rendererRef = useRef<Renderer | null>(null)
+  // Stable so `<Canvas>` doesn't tear down + recreate its renderer on
+  // every re-render. A fresh renderer always starts with frames shown,
+  // so re-apply the present-mode hide here — otherwise a re-render
+  // mid-presentation (e.g. chrome hiding) would resurrect the frames.
+  const handleRenderer = useCallback((r: Renderer) => {
+    rendererRef.current = r
+    if (useBoardAppStore.getState().presentationMode) r.setHideFrames(true)
+  }, [])
   const queryClient = useQueryClient()
 
   // Bridge for the agent's post-stream apply block (lives outside this
@@ -308,9 +316,7 @@ export function HarnessCanvas() {
             onCreateDrag={handleCreateDrag}
             onClick={handleClick}
             onDoubleClick={handleDoubleClick}
-            onRenderer={(r) => {
-              rendererRef.current = r
-            }}
+            onRenderer={handleRenderer}
           />
           <CanvasContextMenu wrapRef={wrapRef} store={store} rendererRef={rendererRef} />
         </div>


### PR DESCRIPTION
## Summary

Reshape the `<graph>` element to a dot-with-caption aesthetic instead of bubble-with-inside-label, and retune force spacing so dense graphs stop crowding their own labels.

**Before:** circles with `NODE_RADIUS=23`, label rendered inside the circle, soft-tinted fill + bold chart-color border. Inside-label vanished on zoomed-out dense graphs; node-border carried the cluster identity but the colored ring competed with crossing edges.

**After:** small filled dot (`NODE_RADIUS=12`) with label + sublabel stacked below, chart palette on the fill, neutral 50%-opacity foreground stroke on the ring and on the default edge. Reads as small colored markers connected by visible threads — the pattern most force-directed knowledge-graph viewers use.

### Geometry
- `NODE_RADIUS` 23 → 12
- `NODE_LABEL_FONT_SIZE` 16 → 12
- Label position: inside (`dy 5`) → below (`dy = R + 14`)
- Sublabel position: `R + 15` → `R + 28` (stacked below label)

### Color
- Auto-color ramp moved from `border` to `color` (chart token, full strength)
- Node border + default edge: unified at `color-mix(in srgb, var(--foreground) 50%, transparent)` via a shared `STROKE_FG_50` constant
- `AUTO_FILL_MIX_PCT` (the soft-tinted-fill recipe) removed — invisible on a 12u dot

### Spacing ([graph-layout-force.ts](webui/src/components/charts/graph-layout-force.ts))
- `LINK_DISTANCE` 90 → 140 (edge-label chip clears both endpoints)
- `COLLIDE_RADIUS` 34 → 40 (no two captions overlap the neighbor's dot)
- `CHARGE_STRENGTH` unchanged at -320

### Universal — no mode branching
Algorithm visualizers (Dijkstra, BFS) get the same treatment as force-laid graphs. The label-below pattern reads well in both contexts, and the manual-vs-auto distinction stays a *coloring* distinction (manual stays neutral card-fill, auto gets the chart ramp), not a layout-chrome distinction.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test --run` — 320/320 green (4 chart-layout test groups updated to match new contract)
- [ ] Dense force-laid graph (10+ nodes): dot/caption read cleanly, no label-on-neighbor collisions
- [ ] Sparse force-laid (3-5 nodes): doesn't feel stretched/lonely
- [ ] Tree layout: parent above children, captions clear
- [ ] Manual layout (Dijkstra-style): visited count + distance both legible as label/sublabel
- [ ] Directed graphs: arrowhead still lands on the circle boundary (uses `NODE_RADIUS` — auto-tracks)
- [ ] Edge label chip: doesn't feel oversized next to the smaller dots