### PR TITLE
fix(board): exclude frames from dbl-click text editor + style memory

### DIFF
--- a/webui/src/features/board/harness/canvas/custom-node-types.test.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_CUSTOM_TYPES = [
   // No text concept — dbl-click must not open the lib's inline editor.
   "icon",
   "image",
+  "frame",
 ].sort()
 
 

--- a/webui/src/features/board/harness/canvas/custom-node-types.ts
+++ b/webui/src/features/board/harness/canvas/custom-node-types.ts
@@ -5,11 +5,13 @@
  *   - Dim0's custom node defs (see `node-types/`) — these own their
  *     editing surface elsewhere (an expand dialog, a side panel, or
  *     folder navigation), so the inline text editor would compete.
- *   - canvas-harness built-ins that have no text-content concept at
- *     all (icon, image) — the inline editor opens an invisible text
- *     caret on top of the SVG/raster and any typed text becomes junk
- *     `node.content` data. Suppress the editor so dbl-click is a
- *     no-op (just selects).
+ *   - canvas-harness built-ins that have no own text-content concept
+ *     (icon, image, frame) — the inline editor opens an invisible
+ *     text caret on top of the glyph / slide chrome and any typed
+ *     text becomes junk `node.content` data. Suppress the editor so
+ *     dbl-click is a no-op (just selects). Frame is the slide
+ *     container used by presentation mode — its visible chrome is
+ *     the slide border, not a text body.
  *
  * Keep the Dim0-custom subset in sync with the defs registered in
  * `node-types/index.ts → boardNodeTypes`; `custom-node-types.test.ts`
@@ -27,4 +29,5 @@ export const CUSTOM_NODE_TYPES: ReadonlySet<string> = new Set([
   // than open an invisible inline text editor.
   "icon",
   "image",
+  "frame",
 ])

--- a/webui/src/features/board/harness/canvas/use-style-memory.ts
+++ b/webui/src/features/board/harness/canvas/use-style-memory.ts
@@ -50,6 +50,10 @@ const EXCLUDED_TYPES: ReadonlySet<string> = new Set([
   // would inherit the rectangle's stroke / fill — visually surprising.
   "icon",
   "image",
+  // Frames are slide containers (presentation mode). Their chrome is a
+  // fixed visual identity — they should never sponge styles from
+  // neighboring shapes nor donate styles back.
+  "frame",
 ])
 
 


### PR DESCRIPTION
## Summary

Double-clicking a frame (canvas-harness's slide container, used by presentation mode) was popping the lib's inline text editor — an invisible caret on top of the slide chrome that turned any keystrokes into junk \`node.content\`. Frames have no own text body; the dbl-click should just select.

The two parity-paired exclusion sets — [\`CUSTOM_NODE_TYPES\`](webui/src/features/board/harness/canvas/custom-node-types.ts) (the dbl-click handler at [harness-canvas.tsx:227](webui/src/features/board/harness/canvas/harness-canvas.tsx#L227) calls \`store.cancelEdit()\` for any type in this set) and [\`EXCLUDED_TYPES\`](webui/src/features/board/harness/canvas/use-style-memory.ts) (sticky style memory) — already had every Dim0 custom def + icon + image. Frame was the missing canvas-harness built-in.

## Why both sets

The parity test at [custom-node-types.test.ts:47](webui/src/features/board/harness/canvas/custom-node-types.test.ts#L47) enforces that every entry in \`CUSTOM_NODE_TYPES\` is also non-stylable. Beyond satisfying the test, the style-memory exclusion is independently correct: frames have a fixed visual identity (slide chrome) and should never sponge styles from neighboring shapes nor donate styles back, same reasoning as folder/sheet/icon.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm test --run custom-node-types\` — 5/5 green
- [x] Dbl-click a frame on the board: just selects, no text-caret appears
- [x] Style a rect, then create a new frame: frame doesn't inherit the rect's fill/stroke
- [x] Resize/move a frame: unaffected (this PR only changes dbl-click + style-memory dispatch)
- [x] Presentation mode: still steps through frames normally