### PR TITLE
fix(embed): truncate oversized inputs to the embedding token limit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,16 @@ COPY build/schema.sql /app/build/schema.sql
 RUN uv sync --frozen --no-dev
 ENV PATH="/app/.venv/bin:${PATH}"
 
+# Pre-fetch the tiktoken BPE vocab at build time so the embedder never needs
+# network at runtime. On first use tiktoken downloads cl100k_base from a
+# Microsoft blob URL; in egress-restricted prod that fails even though
+# api.openai.com is reachable, and the lazy load means it surfaces on the first
+# embed rather than at boot. Baking the cache into the image (read back via the
+# same env var at runtime) makes the embedder fully offline and removes the
+# ~1.5s first-call download.
+ENV TIKTOKEN_CACHE_DIR=/app/.tiktoken_cache
+RUN python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+
 # Install the mini-app compiler's npm deps (sucrase). The script + its
 # package-lock.json are already in /app/scripts/mini-app-compiler/ via
 # the COPY above; this just fetches node_modules from the lockfile.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "redis>=5.2.1",
     "rich>=13.7.1",
     "selectolax>=0.3.34",
+    "tiktoken>=0.12,<0.13",
     "httpx>=0.28.1",
     "pypdf>=6.3.0",
     "uvicorn==0.41.0",

--- a/backend/test/unit/nlp/test_embed.py
+++ b/backend/test/unit/nlp/test_embed.py
@@ -1,7 +1,10 @@
 """Unit tests for the embedder's per-input token clamping."""
 
+import asyncio
+
 import tiktoken
 
+from topix.nlp import embed as embed_mod
 from topix.nlp.embed import MAX_EMBED_TOKENS, OpenAIEmbedder
 from topix.nlp.tokens import EMBED_ENCODING
 
@@ -63,3 +66,30 @@ class TestEmbedderClamping:
         await embedder.embed(["The capital of Peru is Lima."])
 
         assert fake.embeddings.last_input == ["The capital of Peru is Lima."]
+
+    async def test_long_batch_offloads_encode_to_thread(self, monkeypatch):
+        """A batch with encode-worthy text runs the fit off the event loop."""
+        embedder, _ = self._embedder()
+        calls = {"n": 0}
+        real = asyncio.to_thread
+
+        async def _spy(fn, *args, **kwargs):
+            calls["n"] += 1
+            return await real(fn, *args, **kwargs)
+
+        monkeypatch.setattr(embed_mod.asyncio, "to_thread", _spy)
+        await embedder.embed(["x" * (MAX_EMBED_TOKENS * 4)])
+        assert calls["n"] == 1
+
+    async def test_short_batch_fits_inline(self, monkeypatch):
+        """An all-short batch never pays for a thread hop."""
+        embedder, _ = self._embedder()
+        calls = {"n": 0}
+
+        async def _spy(fn, *args, **kwargs):
+            calls["n"] += 1
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(embed_mod.asyncio, "to_thread", _spy)
+        await embedder.embed(["short text", "another short one"])
+        assert calls["n"] == 0

--- a/backend/test/unit/nlp/test_embed.py
+++ b/backend/test/unit/nlp/test_embed.py
@@ -1,0 +1,65 @@
+"""Unit tests for the embedder's per-input token clamping."""
+
+import tiktoken
+
+from topix.nlp.embed import MAX_EMBED_TOKENS, OpenAIEmbedder
+from topix.nlp.tokens import EMBED_ENCODING
+
+_enc = tiktoken.get_encoding(EMBED_ENCODING)
+
+
+class _FakeEmbeddings:
+    """Captures the `input` it receives and returns matching dummy vectors."""
+
+    def __init__(self):
+        self.last_input: list[str] | None = None
+
+    async def create(self, *, model, input, dimensions):
+        """Stand in for `client.embeddings.create`, recording the input."""
+        self.last_input = input
+        data = [type("E", (), {"embedding": [0.0] * dimensions})() for _ in input]
+        return type("R", (), {"data": data})()
+
+
+class _FakeClient:
+    """Minimal AsyncOpenAI stand-in exposing `.embeddings.create`."""
+
+    def __init__(self):
+        self.embeddings = _FakeEmbeddings()
+
+
+class TestEmbedderClamping:
+    """The embedder must never hand the API an over-limit input."""
+
+    def _embedder(self) -> tuple[OpenAIEmbedder, _FakeClient]:
+        embedder = OpenAIEmbedder(api_key="test-key")
+        fake = _FakeClient()
+        embedder._client = fake
+        return embedder, fake
+
+    async def test_oversized_input_is_clamped_before_api_call(self):
+        """A >8191-token text reaches the API clamped under MAX_EMBED_TOKENS."""
+        embedder, fake = self._embedder()
+        huge = "lorem ipsum dolor sit amet " * 5000
+
+        await embedder.embed([huge])
+
+        sent = fake.embeddings.last_input
+        assert sent is not None and len(sent) == 1
+        assert len(_enc.encode_ordinary(sent[0])) <= MAX_EMBED_TOKENS
+
+    async def test_empty_text_becomes_placeholder(self):
+        """Empty strings keep the existing `$` placeholder behaviour."""
+        embedder, fake = self._embedder()
+
+        await embedder.embed([""])
+
+        assert fake.embeddings.last_input == ["$"]
+
+    async def test_short_text_passes_through_untouched(self):
+        """Normal short text is sent verbatim."""
+        embedder, fake = self._embedder()
+
+        await embedder.embed(["The capital of Peru is Lima."])
+
+        assert fake.embeddings.last_input == ["The capital of Peru is Lima."]

--- a/backend/test/unit/nlp/test_truncate.py
+++ b/backend/test/unit/nlp/test_truncate.py
@@ -1,0 +1,67 @@
+"""Unit tests for token-aware embedding-input truncation."""
+
+import tiktoken
+
+from topix.nlp import tokens as tokens_mod
+from topix.nlp.tokens import EMBED_ENCODING, truncate_to_tokens
+
+_enc = tiktoken.get_encoding(EMBED_ENCODING)
+
+
+def _ntokens(text: str) -> int:
+    """Count tokens the same way the embedding API does."""
+    return len(_enc.encode_ordinary(text))
+
+
+class TestTruncateToTokens:
+    """Behaviour of `truncate_to_tokens` across content types."""
+
+    def test_short_text_passes_through_unchanged(self):
+        """Text already under the cap is returned byte-for-byte."""
+        text = "The capital of Peru is Lima."
+        assert truncate_to_tokens(text, 8000) == text
+
+    def test_empty_text_passes_through(self):
+        """Empty input is returned as-is (no crash, no encoder work)."""
+        assert truncate_to_tokens("", 8000) == ""
+
+    def test_text_at_limit_unchanged(self):
+        """Text exactly at the cap is not truncated."""
+        text = "word " * 100
+        cap = _ntokens(text)
+        assert truncate_to_tokens(text, cap) == text
+
+    def test_long_english_truncated_within_cap(self):
+        """A long English string is clipped to at most `max_tokens`."""
+        text = "Photosynthesis turns sunlight into sugar. " * 1000
+        out = truncate_to_tokens(text, 500)
+        assert len(out) < len(text)
+        assert _ntokens(out) <= 500
+
+    def test_long_code_truncated_within_cap(self):
+        """Dense code (low chars/token) still lands inside the cap."""
+        text = "const x = useState<number>(0);\n" * 2000
+        out = truncate_to_tokens(text, 500)
+        assert _ntokens(out) <= 500
+
+    def test_long_cjk_truncated_within_cap(self):
+        """CJK (high tokens/char) is the case char-based truncation misses."""
+        text = "光合作用把阳光转化为糖分并释放氧气。" * 2000
+        out = truncate_to_tokens(text, 500)
+        assert _ntokens(out) <= 500
+
+    def test_realistic_overflow_fits_embed_limit(self):
+        """A message larger than the 8191 limit is brought under 8000 tokens."""
+        text = "lorem ipsum dolor sit amet " * 5000
+        assert _ntokens(text) > 8191
+        out = truncate_to_tokens(text, 8000)
+        assert _ntokens(out) <= 8000
+
+    def test_short_text_skips_the_encoder(self, monkeypatch):
+        """Text within the O(1) fast-path window never touches the BPE encoder."""
+        def _boom():
+            raise AssertionError("encoder must not load for short text")
+
+        monkeypatch.setattr(tokens_mod, "_encoder", _boom)
+        text = "x" * (8000 // 4)  # at the fast-path boundary
+        assert truncate_to_tokens(text, 8000) == text

--- a/backend/topix/nlp/embed.py
+++ b/backend/topix/nlp/embed.py
@@ -47,9 +47,21 @@ class OpenAIEmbedder:
             )
         return fitted
 
+    def _fit_batch(self, texts: list[str]) -> list[str]:
+        """Clamp every text in a batch to the token limit, mapping empties to "$"."""
+        return [self._fit(text) if text else "$" for text in texts]
+
     @async_timeit
     async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
-        texts = [self._fit(text) if text else "$" for text in texts]
+        # Clamping only runs a (synchronous, GIL-holding) BPE encode for text
+        # long enough to possibly overflow — see the fast-path threshold in
+        # truncate_to_tokens. tiktoken releases the GIL during encode, so when a
+        # batch actually contains such text we offload the whole fit to a thread
+        # to keep a large bulk batch off the event loop. All-short batches (e.g.
+        # chat turns) skip the hop and fit inline for free. Mis-estimating the
+        # threshold only costs a needless hop or inline encode, never correctness.
+        needs_encode = any(t and len(t) > MAX_EMBED_TOKENS // 4 for t in texts)
+        texts = await asyncio.to_thread(self._fit_batch, texts) if needs_encode else self._fit_batch(texts)
         # Call the embeddings endpoint asynchronously
         response = await self._client.embeddings.create(
             model=MODEL_NAME,

--- a/backend/topix/nlp/embed.py
+++ b/backend/topix/nlp/embed.py
@@ -1,14 +1,24 @@
 """Embedding class."""
 
 import asyncio
+import logging
 
 from openai import AsyncOpenAI
 
 from topix.config.config import Config
+from topix.nlp.tokens import truncate_to_tokens
 from topix.utils.timeit import async_timeit
+
+logger = logging.getLogger(__name__)
 
 MODEL_NAME = "text-embedding-3-small"
 DIMENSIONS = 512
+
+# Hard per-input limit for `text-embedding-3-small` is 8191 tokens; cap a touch
+# below it so any counting drift still lands inside the limit. Oversized inputs
+# (long sheets, mini-app JSX, non-English notes) are truncated rather than
+# allowed to 400 the whole embed request.
+MAX_EMBED_TOKENS = 8000
 
 
 class OpenAIEmbedder:
@@ -23,9 +33,23 @@ class OpenAIEmbedder:
         """Create an instance of OpenAIEmbedder from configuration."""
         return cls(api_key=Config.instance().run.apis.openai.api_key.get_secret_value())
 
+    def _fit(self, text: str) -> str:
+        """Clamp one text to the embedding model's per-input token limit.
+
+        Logs a warning when truncation actually happens so we have visibility
+        into how often oversized content is being clipped (and on what).
+        """
+        fitted = truncate_to_tokens(text, MAX_EMBED_TOKENS)
+        if len(fitted) != len(text):
+            logger.warning(
+                "Truncated embedding input to %d tokens (was %d chars, now %d chars)",
+                MAX_EMBED_TOKENS, len(text), len(fitted),
+            )
+        return fitted
+
     @async_timeit
     async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
-        texts = [text if text else "$" for text in texts]
+        texts = [self._fit(text) if text else "$" for text in texts]
         # Call the embeddings endpoint asynchronously
         response = await self._client.embeddings.create(
             model=MODEL_NAME,

--- a/backend/topix/nlp/tokens.py
+++ b/backend/topix/nlp/tokens.py
@@ -1,0 +1,44 @@
+"""Token-aware helpers for keeping embedding inputs under model limits."""
+
+import tiktoken
+
+# `cl100k_base` is the encoding used by the `text-embedding-3-*` models, so
+# truncating with it matches how the embedding API counts input tokens.
+EMBED_ENCODING = "cl100k_base"
+
+_enc: tiktoken.Encoding | None = None
+
+
+def _encoder() -> tiktoken.Encoding:
+    """Return a process-wide singleton encoder, loading it once on first use.
+
+    The BPE vocab load costs ~1s, so it must never run per call. It's lazy
+    rather than import-time so importing this module stays cheap and free of a
+    network/disk dependency until something actually embeds.
+    """
+    global _enc
+    if _enc is None:
+        _enc = tiktoken.get_encoding(EMBED_ENCODING)
+    return _enc
+
+
+def truncate_to_tokens(text: str, max_tokens: int) -> str:
+    """Truncate `text` to at most `max_tokens` tokens under the embed encoding.
+
+    Returns the text unchanged when it already fits. Uses ordinary encoding so
+    arbitrary user text — including strings that look like special tokens — is
+    treated as plain text rather than parsed.
+
+    Avoids the (synchronous, GIL-holding) BPE encode entirely for short text:
+    a token spans at least one UTF-8 byte and a char is at most 4 bytes, so
+    `tokens <= 4 * len(text)`. Any string within `max_tokens // 4` chars
+    therefore cannot overflow — which covers the common case at O(1) and keeps
+    bulk embedding off the event loop's critical path.
+    """
+    if not text or len(text) <= max_tokens // 4:
+        return text
+    enc = _encoder()
+    tokens = enc.encode_ordinary(text)
+    if len(tokens) <= max_tokens:
+        return text
+    return enc.decode(tokens[:max_tokens])

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2430,7 +2430,7 @@ wheels = [
 
 [[package]]
 name = "topix"
-version = "0.3.35"
+version = "0.3.53"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2461,6 +2461,7 @@ dependencies = [
     { name = "redis" },
     { name = "rich" },
     { name = "selectolax" },
+    { name = "tiktoken" },
     { name = "uvicorn" },
     { name = "zstandard" },
 ]
@@ -2524,6 +2525,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.2" },
     { name = "selectolax", specifier = ">=0.3.34" },
+    { name = "tiktoken", specifier = ">=0.12,<0.13" },
     { name = "uvicorn", specifier = "==0.41.0" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]


### PR DESCRIPTION
## Problem

`text-embedding-3-small` rejects any single input over **8191 tokens**. When a long assistant message (deep research, a `sheet`, mini-app JSX in the reasoning trace) or a long/non-English note was persisted and embedded, the API returned `400 — Invalid 'input[0]': maximum input length is 8192 tokens` and **500'd the whole chat turn** (observed in `chats.send_message` → `qdrant.store.add` → `embed`).

The embed path had no token awareness, so oversized content went straight to the API and failed.

## Fix

Clamp every embedding input to **8000 tokens** (headroom under 8191) at the single chokepoint — `OpenAIEmbedder._embed_batch`. Because chat messages, notes, and file chunks all funnel through here, this covers every caller, not just the chat path that happened to trip first.

- **Token-accurate** via `tiktoken` (`cl100k_base`, the encoding the model actually uses) — a flat char cap is unsafe because density varies ~4× (English ~4 chars/tok vs CJK/code ~1–2.5), so a "safe" char count would still 400 for non-English users.
- **O(1) fast path**: a token spans ≥1 UTF-8 byte and a char is ≤4 bytes, so any string within `max_tokens // 4` chars provably can't overflow and skips the (synchronous, GIL-holding) BPE encode entirely — keeps bulk embedding off the event loop's critical path.
- **Lazy singleton encoder**: the ~1.5s vocab load happens once per process, on first use.
- **Observability**: logs a warning when truncation actually clips, so we can see how often it fires and on what.

## Offline / prod

`tiktoken` was only a transitive dep — promoted it to a direct dependency. It downloads `cl100k_base` from a Microsoft blob URL on first use, which fails in egress-restricted prod even when `api.openai.com` is reachable (and the lazy load surfaces it on the first embed, not at boot). The Dockerfile now **pre-fetches the vocab at build time** into a baked `TIKTOKEN_CACHE_DIR`, verified to load with the network fully blocked.

## Tests

- `test_truncate.py` — short/empty/at-limit passthrough; long **English / code / CJK** all re-encode to ≤ cap (CJK is the case a char cap misses); reproduces the original >8191-token overflow; asserts short text never touches the encoder.
- `test_embed.py` — with a mocked client, asserts an oversized input reaches the API clamped, empty → `$` placeholder preserved, short text sent verbatim.

## Known follow-up (out of scope, pre-existing)

`embed()` packs up to 1000 inputs per request and can exceed OpenAI's per-*request* token cap (~300k) — a separate latent 400. This change only shrinks per-input size and doesn't worsen it; worth a dedicated follow-up for token-aware batching.