### PR TITLE
docs(readme): replace em-dash with comma in title and alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="docs/images/long-affiche-with-icon.png" alt="Dim0 — Your canvas thinks back. Together. Notes, mini-apps, and agents on one infinite board." width="100%" />
+  <img src="docs/images/long-affiche-with-icon.png" alt="Dim0, Your canvas thinks back. Together. Notes, mini-apps, and agents on one infinite board." width="100%" />
 </p>
 
-<h1 align="center">Dim0 — The Thinking Canvas</h1>
+<h1 align="center">Dim0, The Thinking Canvas</h1>
 
 <p align="center">
   <a href="https://github.com/vcmf/dim0/releases"><img src="https://img.shields.io/github/v/release/vcmf/dim0?style=flat&labelColor=171611&color=965e30" alt="Release" /></a>


### PR DESCRIPTION
Minor copy tweak: swaps the em-dash for a comma in the README title heading and the affiche image alt text.