### PR TITLE
feat(models): key-aware model catalog for minimal-key deploys

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,7 +14,10 @@ VITE_HOST_ORIGIN=http://localhost:${APP_PORT}
 VITE_MINI_APP_ORIGIN=http://localhost:${MINI_APP_PORT}
 
 # model providers API keys
-# make sure you set at least the key for OpenAI
+# Set at least ONE of OPENAI_API_KEY or OPENROUTER_API_KEY — that alone powers
+# chat, auto-model, and embeddings. OpenRouter unlocks every other model (and
+# embeddings) without their native keys; native keys below are optional and
+# preferred over OpenRouter when present.
 OPENAI_API_KEY=
 GEMINI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/backend/test/unit/agents/assistant/test_auto_model.py
+++ b/backend/test/unit/agents/assistant/test_auto_model.py
@@ -1,0 +1,72 @@
+"""Unit tests for the auto-model complexity classifier."""
+
+import pytest
+
+from topix.agents.assistant import auto_model
+
+PROVIDER_KEYS = [
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+]
+
+
+@pytest.fixture
+def clean_keys(monkeypatch):
+    """Start from no provider keys so each test sets only what it needs."""
+    for key in PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def _fake_response(content: str):
+    """Build a minimal object shaped like a litellm/OpenAI chat completion."""
+    message = type("M", (), {"content": content})()
+    choice = type("C", (), {"message": message})()
+    return type("R", (), {"choices": [choice]})()
+
+
+def test_parse_complexity_handles_valid_and_junk():
+    """JSON with a valid label parses; anything else falls back to medium."""
+    assert auto_model._parse_complexity('{"complexity": "complex"}') == "complex"
+    assert auto_model._parse_complexity('{"complexity": "nonsense"}') == "medium"
+    assert auto_model._parse_complexity("not json") == "medium"
+    assert auto_model._parse_complexity(None) == "medium"
+
+
+@pytest.mark.asyncio
+async def test_classifier_works_for_native_non_openai_provider(clean_keys, monkeypatch):
+    """The classifier routes via LiteLLM, so a native-only key still escalates.
+
+    Regression: the previous OpenAI-client classifier returned None (always
+    'medium') for providers like Anthropic that are not OpenAI-compatible.
+    """
+    clean_keys.setenv("ANTHROPIC_API_KEY", "an-x")
+
+    captured = {}
+
+    async def fake_acompletion(*, model, **kwargs):
+        captured["model"] = model
+        return _fake_response('{"complexity": "complex"}')
+
+    monkeypatch.setattr(auto_model.litellm, "acompletion", fake_acompletion)
+
+    result = await auto_model.classify_auto_model_complexity(
+        [{"role": "user", "content": "Build a multi-step interactive visualizer"}]
+    )
+
+    assert result == "complex"
+    # Routed through a native Anthropic model code, not an OpenAI-compatible one.
+    assert captured["model"].startswith("anthropic/")
+
+
+@pytest.mark.asyncio
+async def test_classifier_falls_back_to_medium_without_models(clean_keys):
+    """With no provider key, classification degrades to medium (no crash)."""
+    result = await auto_model.classify_auto_model_complexity(
+        [{"role": "user", "content": "hello"}]
+    )
+    assert result == "medium"

--- a/backend/test/unit/agents/assistant/test_manager.py
+++ b/backend/test/unit/agents/assistant/test_manager.py
@@ -202,15 +202,37 @@ async def test_run_streamed_flushes_reasoning_step_before_tool_call(monkeypatch:
     assert steps[2].message == "Inflation slowed."
 
 
+# Provider keys that catalog resolution reads from the environment. Auto-model
+# selection needs at least one reachable model, so the routing tests pin a known
+# key — otherwise they pass locally (real .env leaks in) but fail on CI (no keys).
+_PROVIDER_KEYS = (
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
+
+
+@pytest.fixture
+def openai_only(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """Resolve the catalog against OpenAI alone, deterministic across CI and local."""
+    for key in _PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    return monkeypatch
+
+
 @pytest.mark.asyncio
-async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest.MonkeyPatch):
+async def test_select_plan_model_uses_full_model_for_complex(openai_only: pytest.MonkeyPatch):
     """Auto mode should upgrade complex requests to the best available pro model."""
     manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
 
     async def fake_classify(messages: list[dict[str, str]]) -> str:
         return "complex"
 
-    monkeypatch.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
+    openai_only.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
 
     selected_model = await manager._select_plan_model([{"role": "user", "content": "Hard task"}])
 
@@ -218,14 +240,14 @@ async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
-async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.MonkeyPatch):
+async def test_select_plan_model_uses_mini_for_medium(openai_only: pytest.MonkeyPatch):
     """Auto mode should keep medium requests on the fast (lite) base plan."""
     manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
 
     async def fake_classify(messages: list[dict[str, str]]) -> str:
         return "medium"
 
-    monkeypatch.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
+    openai_only.setattr("topix.agents.assistant.manager.classify_auto_model_complexity", fake_classify)
 
     selected_model = await manager._select_plan_model([{"role": "user", "content": "Medium task"}])
 

--- a/backend/test/unit/agents/assistant/test_manager.py
+++ b/backend/test/unit/agents/assistant/test_manager.py
@@ -6,9 +6,12 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
-from topix.agents.assistant.manager import AUTO_MODEL_BASE_PLAN, AssistantManager
+from topix.agents.assistant.manager import (
+    AssistantManager,
+    _auto_base_model,
+    _auto_complex_model,
+)
 from topix.agents.datatypes.context import ReasoningContext
-from topix.agents.datatypes.model_enum import ModelEnum
 from topix.agents.datatypes.outputs import WebSearchOutput
 from topix.agents.datatypes.reasoning_step import ReasoningStep
 from topix.agents.datatypes.stream import (
@@ -41,7 +44,7 @@ class RecordingSession:
 class RecordingPlanAgent:
     """Minimal plan agent stub for manager routing tests."""
 
-    def __init__(self, model: str = AUTO_MODEL_BASE_PLAN):
+    def __init__(self, model: str = "openai/gpt-4.1"):
         """Store only the fields the manager needs to mutate."""
         self.model = model
 
@@ -201,7 +204,7 @@ async def test_run_streamed_flushes_reasoning_step_before_tool_call(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest.MonkeyPatch):
-    """Auto mode should upgrade only complex requests to the larger model."""
+    """Auto mode should upgrade complex requests to the best available pro model."""
     manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
 
     async def fake_classify(messages: list[dict[str, str]]) -> str:
@@ -211,12 +214,12 @@ async def test_select_plan_model_uses_full_model_for_complex(monkeypatch: pytest
 
     selected_model = await manager._select_plan_model([{"role": "user", "content": "Hard task"}])
 
-    assert selected_model == ModelEnum.OpenAI.GPT_5_4
+    assert selected_model == _auto_complex_model()
 
 
 @pytest.mark.asyncio
 async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.MonkeyPatch):
-    """Auto mode should keep medium requests on the fast Kimi base plan."""
+    """Auto mode should keep medium requests on the fast (lite) base plan."""
     manager = AssistantManager(plan_agent=RecordingPlanAgent(), auto_mode=True)
 
     async def fake_classify(messages: list[dict[str, str]]) -> str:
@@ -226,4 +229,4 @@ async def test_select_plan_model_uses_mini_for_medium(monkeypatch: pytest.Monkey
 
     selected_model = await manager._select_plan_model([{"role": "user", "content": "Medium task"}])
 
-    assert selected_model == AUTO_MODEL_BASE_PLAN
+    assert selected_model == _auto_base_model()

--- a/backend/test/unit/agents/datatypes/__init__.py
+++ b/backend/test/unit/agents/datatypes/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for topix.agents.datatypes."""

--- a/backend/test/unit/agents/datatypes/test_model_enum.py
+++ b/backend/test/unit/agents/datatypes/test_model_enum.py
@@ -1,0 +1,86 @@
+"""Unit tests for model capability detection (agents/datatypes/model_enum.py).
+
+These cover `_bare` (route/variant-agnostic name extraction) and the `support_*`
+capability checks directly, independent of the agent that consumes them.
+"""
+
+import pytest
+
+from agents.extensions.models.litellm_model import LitellmModel
+
+from topix.agents.datatypes.model_enum import (
+    ModelEnum,
+    _bare,
+    support_penalties,
+    support_reasoning,
+    support_reasoning_effort_none,
+    support_temperature,
+)
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        ("gpt-5.4", "gpt-5.4"),                          # bare id
+        ("openai/gpt-5.4", "gpt-5.4"),                   # native route prefix
+        ("openrouter/openai/gpt-5.4", "gpt-5.4"),        # double route prefix
+        ("openrouter/z-ai/glm-5.2:nitro", "glm-5.2"),    # prefix + :nitro variant
+        ("moonshotai/kimi-k2.6:nitro", "kimi-k2.6"),     # single prefix + variant
+        ("gpt-5.4:nitro", "gpt-5.4"),                    # variant only
+    ],
+)
+def test_bare_strips_route_prefix_and_variant(given, expected):
+    """_bare reduces any addressing form to the canonical bare model name."""
+    assert _bare(given) == expected
+
+
+def test_bare_unwraps_litellm_model():
+    """A LitellmModel wrapper resolves to its inner model's bare name."""
+    assert _bare(LitellmModel("openrouter/z-ai/glm-5.2:nitro")) == "glm-5.2"
+
+
+def test_bare_uses_enum_value_not_repr():
+    """Enum members resolve via their value, not str(EnumMember)."""
+    assert _bare(ModelEnum.OpenAI.GPT_5_4) == "gpt-5.4"
+    assert _bare(ModelEnum.OpenRouter.CLAUDE_OPUS) == "claude-opus-4.8"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openai/gpt-5.4",
+        "openrouter/openai/gpt-5.4",                    # routed, no :nitro
+        LitellmModel("openrouter/openai/gpt-5.4"),
+    ],
+)
+def test_current_openai_models_are_reasoning_no_temperature(model):
+    """The current OpenAI lineup is reasoning-capable and rejects temperature.
+
+    Holds across native, OpenRouter-routed, and LitellmModel addressing so the
+    capability never silently flips based on which key is configured.
+    """
+    assert support_reasoning(model) is True
+    assert support_temperature(model) is False
+    assert support_reasoning_effort_none(model) is True
+    assert support_penalties(model) is False
+
+
+def test_nitro_variant_does_not_change_capabilities():
+    """The :nitro throughput suffix must not affect capability detection."""
+    plain = "openrouter/z-ai/glm-5.2"
+    nitro = "openrouter/z-ai/glm-5.2:nitro"
+    assert support_reasoning(plain) == support_reasoning(nitro)
+    assert support_temperature(plain) == support_temperature(nitro)
+
+
+def test_non_lineup_models_default_to_permissive_capabilities():
+    """Models outside the curated sets allow temperature/penalties, no reasoning."""
+    glm = "openrouter/z-ai/glm-5.2:nitro"
+    assert support_reasoning(glm) is False
+    assert support_temperature(glm) is True
+    assert support_penalties(glm) is True
+
+
+def test_perplexity_sonar_is_reasoning_capable():
+    """Sonar stays reasoning-capable via its bare name."""
+    assert support_reasoning(ModelEnum.Perplexity.PERPLEXITY_SONAR) is True

--- a/backend/test/unit/agents/test_base.py
+++ b/backend/test/unit/agents/test_base.py
@@ -37,3 +37,34 @@ def test_adjust_model_settings_keeps_litellm_specific_extra_args():
         "drop_params": True,
         "additional_drop_params": ["frequency_penalty", "presence_penalty"],
     }
+
+
+def test_adjust_model_settings_detects_reasoning_for_openrouter_routed_model():
+    """An OpenAI reasoning model routed via OpenRouter must keep reasoning settings.
+
+    Regression: capability detection used to match only bare "openai/..." codes,
+    so the routed code "openrouter/openai/gpt-5.4" (wrapped in LitellmModel) was
+    mis-classified — reasoning dropped and temperature wrongly forced on.
+    """
+    agent = BaseAgent.__new__(BaseAgent)
+
+    settings = agent._adjust_model_settings(
+        LitellmModel("openrouter/openai/gpt-5.4"),
+        ModelSettings(),
+    )
+
+    assert settings.reasoning is not None
+    assert settings.temperature is None
+
+
+def test_adjust_model_settings_routed_matches_native_for_reasoning_model():
+    """Routed and native addressing of the same model yield the same capabilities."""
+    agent = BaseAgent.__new__(BaseAgent)
+
+    native = agent._adjust_model_settings("openai/gpt-5.4", ModelSettings())
+    routed = agent._adjust_model_settings(
+        LitellmModel("openrouter/openai/gpt-5.4"), ModelSettings()
+    )
+
+    assert (native.reasoning is None) == (routed.reasoning is None)
+    assert (native.temperature is None) == (routed.temperature is None)

--- a/backend/test/unit/agents/test_base.py
+++ b/backend/test/unit/agents/test_base.py
@@ -12,7 +12,7 @@ def test_adjust_model_settings_enables_openai_prompt_cache_retention():
     agent.name = "planner_agent"
 
     settings = agent._adjust_model_settings(
-        "openai/gpt-5-mini",
+        "openai/gpt-5.4-mini",
         ModelSettings(extra_args={"existing": "value"}),
     )
 

--- a/backend/test/unit/config/__init__.py
+++ b/backend/test/unit/config/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for topix.config."""

--- a/backend/test/unit/config/test_catalog.py
+++ b/backend/test/unit/config/test_catalog.py
@@ -1,0 +1,136 @@
+"""Unit tests for the model catalog resolver (config/catalog.py).
+
+The catalog reads provider keys live from the environment, so each test clears
+all provider keys and sets only the ones under test via monkeypatch.
+"""
+
+import pytest
+
+from topix.config import catalog
+
+PROVIDER_KEYS = [
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "LINKUP_API_KEY",
+    "TAVILY_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "EXA_API_KEY",
+]
+
+
+@pytest.fixture
+def clean_keys(monkeypatch):
+    """Remove all provider keys so each test starts from a known-empty state."""
+    for key in PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def test_no_keys_yields_nothing(clean_keys):
+    """With no keys set, nothing resolves and helpers return empty/None."""
+    assert catalog.available_providers() == []
+    assert catalog.available_llms() == []
+    assert catalog.available_embedding() is None
+    assert catalog.default_model_code() is None
+    assert catalog.resolve_code("gpt-4.1") is None
+
+
+def test_openai_only_routes_native(clean_keys):
+    """With only OpenAI, every model routes natively and OR-only models vanish."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+
+    providers = catalog.available_providers()
+    assert providers == ["openai"]
+
+    llms = catalog.available_llms()
+    # Every reachable model routes through the native OpenAI provider.
+    assert llms, "expected OpenAI models to be available"
+    assert all(m.provider == "openai" and m.call.startswith("openai/") for m in llms)
+
+    # OpenRouter-only models (z-ai/qwen/moonshot) are not reachable.
+    ids = {m.id for m in llms}
+    assert "glm-4.7" not in ids
+    assert "gpt-4.1" in ids
+
+    assert catalog.resolve_code("gpt-4.1") == "openai/gpt-4.1"
+    # A model with no native OpenAI route is unreachable here.
+    assert catalog.resolve_code("claude-opus-4.6") is None
+
+    emb = catalog.available_embedding()
+    assert emb is not None
+    assert emb.provider == "openai"
+    assert emb.model == "text-embedding-3-small"
+    assert emb.dim == 512
+
+
+def test_openrouter_only_routes_via_openrouter(clean_keys):
+    """With only OpenRouter, all models (incl. embeddings) route through it."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+
+    assert catalog.available_providers() == ["openrouter"]
+
+    llms = catalog.available_llms()
+    assert all(m.provider == "openrouter" and m.call.startswith("openrouter/") for m in llms)
+
+    # OpenAI models are reachable through OpenRouter.
+    assert catalog.resolve_code("gpt-4.1") == "openrouter/openai/gpt-4.1"
+    # So is Claude, with no native Anthropic key.
+    assert catalog.resolve_code("claude-opus-4.6") == "openrouter/anthropic/claude-opus-4.6"
+
+    # Embeddings work through OpenRouter (no OpenAI key required).
+    emb = catalog.available_embedding()
+    assert emb is not None
+    assert emb.provider == "openrouter"
+    assert emb.model == "openai/text-embedding-3-small"
+    assert emb.dim == 512
+
+
+def test_native_route_preferred_over_openrouter(clean_keys):
+    """Native routes win over OpenRouter when both keys are present."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    clean_keys.setenv("ANTHROPIC_API_KEY", "an-x")
+
+    # Native routes win when both a native key and OpenRouter are present.
+    assert catalog.resolve_code("gpt-4.1") == "openai/gpt-4.1"
+    assert catalog.resolve_code("claude-opus-4.6") == "anthropic/claude-opus-4-6"
+    # A model with no native key still falls back to OpenRouter.
+    assert catalog.resolve_code("kimi-k2.5") == "openrouter/moonshotai/kimi-k2.5:nitro"
+
+
+def test_default_model_code_by_tier(clean_keys):
+    """default_model_code/default_resolved honor the requested tier."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+
+    fast = catalog.default_model_code("lite")
+    smart = catalog.default_model_code("pro")
+    assert fast is not None and smart is not None
+
+    fast_resolved = catalog.default_resolved("lite")
+    smart_resolved = catalog.default_resolved("pro")
+    assert fast_resolved.tier == "lite"
+    assert smart_resolved.tier == "pro"
+
+
+@pytest.mark.parametrize(
+    "given",
+    [
+        "gpt-4.1-mini",                       # canonical id
+        "openai/gpt-4.1-mini",               # legacy provider-prefixed code
+        "openrouter/openai/gpt-4.1-mini",    # already-resolved call code
+    ],
+)
+def test_normalize_code_accepts_ids_codes_and_legacy(clean_keys, given):
+    """normalize_code maps ids, call codes, and legacy codes to a reachable call."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    assert catalog.normalize_code(given) == "openrouter/openai/gpt-4.1-mini"
+
+
+def test_normalize_code_unknown_returns_none(clean_keys):
+    """An unknown model reference normalizes to None."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+    assert catalog.normalize_code("totally-made-up-model") is None

--- a/backend/test/unit/config/test_catalog.py
+++ b/backend/test/unit/config/test_catalog.py
@@ -134,3 +134,29 @@ def test_normalize_code_unknown_returns_none(clean_keys):
     """An unknown model reference normalizes to None."""
     clean_keys.setenv("OPENAI_API_KEY", "sk-x")
     assert catalog.normalize_code("totally-made-up-model") is None
+
+
+def test_normalize_code_handles_non_str(clean_keys):
+    """Non-string input resolves to None instead of raising."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+    assert catalog.normalize_code(None) is None
+    assert catalog.resolve_code(None) is None
+
+
+def test_require_model_code_raises_without_keys(clean_keys):
+    """require_model_code raises a clear error when nothing resolves."""
+    with pytest.raises(ValueError):
+        catalog.require_model_code()
+
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+    assert catalog.require_model_code("lite") is not None
+
+
+def test_openai_compatible_client_only_for_openai_apis(clean_keys):
+    """A client is built for openai/openrouter routes, not native others."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    emb = catalog.available_embedding()
+    assert emb is not None and emb.provider == "openrouter"
+    client = catalog.openai_compatible_client(emb)
+    assert client is not None
+    assert str(client.base_url).rstrip("/").endswith("openrouter.ai/api/v1")

--- a/backend/test/unit/config/test_catalog.py
+++ b/backend/test/unit/config/test_catalog.py
@@ -36,7 +36,7 @@ def test_no_keys_yields_nothing(clean_keys):
     assert catalog.available_llms() == []
     assert catalog.available_embedding() is None
     assert catalog.default_model_code() is None
-    assert catalog.resolve_code("gpt-4.1") is None
+    assert catalog.resolve_code("gpt-5.4") is None
 
 
 def test_openai_only_routes_native(clean_keys):
@@ -51,14 +51,14 @@ def test_openai_only_routes_native(clean_keys):
     assert llms, "expected OpenAI models to be available"
     assert all(m.provider == "openai" and m.call.startswith("openai/") for m in llms)
 
-    # OpenRouter-only models (z-ai/qwen/moonshot) are not reachable.
+    # OpenRouter-only models (z-ai/qwen/deepseek/...) are not reachable.
     ids = {m.id for m in llms}
-    assert "glm-4.7" not in ids
-    assert "gpt-4.1" in ids
+    assert "glm-5.2" not in ids
+    assert "gpt-5.4" in ids
 
-    assert catalog.resolve_code("gpt-4.1") == "openai/gpt-4.1"
+    assert catalog.resolve_code("gpt-5.4") == "openai/gpt-5.4"
     # A model with no native OpenAI route is unreachable here.
-    assert catalog.resolve_code("claude-opus-4.6") is None
+    assert catalog.resolve_code("claude-opus-4.8") is None
 
     emb = catalog.available_embedding()
     assert emb is not None
@@ -76,10 +76,13 @@ def test_openrouter_only_routes_via_openrouter(clean_keys):
     llms = catalog.available_llms()
     assert all(m.provider == "openrouter" and m.call.startswith("openrouter/") for m in llms)
 
-    # OpenAI models are reachable through OpenRouter.
-    assert catalog.resolve_code("gpt-4.1") == "openrouter/openai/gpt-4.1"
+    # OpenAI models are reachable through OpenRouter (no :nitro for openai/anthropic).
+    assert catalog.resolve_code("gpt-5.4") == "openrouter/openai/gpt-5.4"
     # So is Claude, with no native Anthropic key.
-    assert catalog.resolve_code("claude-opus-4.6") == "openrouter/anthropic/claude-opus-4.6"
+    assert catalog.resolve_code("claude-opus-4.8") == "openrouter/anthropic/claude-opus-4.8"
+    # Non-OpenAI/Anthropic models carry the :nitro throughput variant.
+    assert catalog.resolve_code("glm-5.2") == "openrouter/z-ai/glm-5.2:nitro"
+    assert catalog.resolve_code("minimax-m2.7") == "openrouter/minimax/minimax-m2.7:nitro"
 
     # Embeddings work through OpenRouter (no OpenAI key required).
     emb = catalog.available_embedding()
@@ -89,6 +92,27 @@ def test_openrouter_only_routes_via_openrouter(clean_keys):
     assert emb.dim == 512
 
 
+def test_nitro_only_on_non_openai_anthropic_routes(clean_keys):
+    """OpenAI/Anthropic OpenRouter routes omit :nitro; others include it."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    by_id = {m.id: m for m in catalog.available_llms()}
+
+    # OpenAI + Anthropic via OpenRouter: no :nitro.
+    assert ":nitro" not in by_id["gpt-5.4"].call
+    assert ":nitro" not in by_id["claude-opus-4.8"].call
+    # Everyone else via OpenRouter: :nitro.
+    for mid in ("glm-5.2", "gemma-4-31b", "qwen3.6-plus", "deepseek-v4-pro", "kimi-k2.6", "minimax-m2.7"):
+        assert by_id[mid].call.endswith(":nitro"), mid
+
+
+def test_retired_models_are_gone(clean_keys):
+    """Models dropped in the revamp no longer resolve."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    ids = {m.id for m in catalog.available_llms()}
+    for retired in ("gpt-4.1", "gpt-4o", "gemini-2.5-pro", "glm-4.7", "kimi-k2.5", "deepseek-v3.2"):
+        assert retired not in ids
+
+
 def test_native_route_preferred_over_openrouter(clean_keys):
     """Native routes win over OpenRouter when both keys are present."""
     clean_keys.setenv("OPENAI_API_KEY", "sk-x")
@@ -96,10 +120,10 @@ def test_native_route_preferred_over_openrouter(clean_keys):
     clean_keys.setenv("ANTHROPIC_API_KEY", "an-x")
 
     # Native routes win when both a native key and OpenRouter are present.
-    assert catalog.resolve_code("gpt-4.1") == "openai/gpt-4.1"
-    assert catalog.resolve_code("claude-opus-4.6") == "anthropic/claude-opus-4-6"
+    assert catalog.resolve_code("gpt-5.4") == "openai/gpt-5.4"
+    assert catalog.resolve_code("claude-opus-4.8") == "anthropic/claude-opus-4-8"
     # A model with no native key still falls back to OpenRouter.
-    assert catalog.resolve_code("kimi-k2.5") == "openrouter/moonshotai/kimi-k2.5:nitro"
+    assert catalog.resolve_code("kimi-k2.6") == "openrouter/moonshotai/kimi-k2.6:nitro"
 
 
 def test_default_model_code_by_tier(clean_keys):
@@ -119,15 +143,15 @@ def test_default_model_code_by_tier(clean_keys):
 @pytest.mark.parametrize(
     "given",
     [
-        "gpt-4.1-mini",                       # canonical id
-        "openai/gpt-4.1-mini",               # legacy provider-prefixed code
-        "openrouter/openai/gpt-4.1-mini",    # already-resolved call code
+        "gpt-5.4-mini",                       # canonical id
+        "openai/gpt-5.4-mini",               # legacy provider-prefixed code
+        "openrouter/openai/gpt-5.4-mini",    # already-resolved call code
     ],
 )
 def test_normalize_code_accepts_ids_codes_and_legacy(clean_keys, given):
     """normalize_code maps ids, call codes, and legacy codes to a reachable call."""
     clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
-    assert catalog.normalize_code(given) == "openrouter/openai/gpt-4.1-mini"
+    assert catalog.normalize_code(given) == "openrouter/openai/gpt-5.4-mini"
 
 
 def test_normalize_code_unknown_returns_none(clean_keys):

--- a/backend/test/unit/config/test_catalog_integrity.py
+++ b/backend/test/unit/config/test_catalog_integrity.py
@@ -1,0 +1,118 @@
+"""Static integrity checks for the model catalog and its consumers.
+
+Unlike test_catalog.py (which exercises resolution against various key states),
+these load the catalog as-authored and guard the invariants that hand-edits to
+models.yml / model_enum.py / the agent YAML configs can silently break. They are
+key-independent: they read the static catalog, not the live environment.
+"""
+
+import yaml
+
+from topix.agents.config import CONFIG_DIR
+from topix.agents.datatypes.model_enum import ModelEnum, _bare
+from topix.config import catalog
+
+
+def _catalog():
+    """Return (providers, llm models, embedding models) as authored in models.yml."""
+    return catalog._load()
+
+
+def test_every_route_references_a_defined_provider():
+    """Each route's `via` must exist in the providers registry."""
+    providers, llm, embedding = _catalog()
+    unknown = [
+        (m.id, r.via)
+        for m in (*llm, *embedding)
+        for r in m.routes
+        if r.via not in providers
+    ]
+    assert unknown == [], f"routes reference undefined providers: {unknown}"
+
+
+def test_every_llm_has_a_valid_tier():
+    """Auto-model selection relies on every LLM declaring a pro/lite tier."""
+    _, llm, _ = _catalog()
+    bad = [(m.id, m.tier) for m in llm if m.tier not in ("pro", "lite")]
+    assert bad == [], f"models with invalid tier: {bad}"
+
+
+def test_catalog_has_both_tiers():
+    """auto-mode needs at least one lite and one pro model to route between."""
+    _, llm, _ = _catalog()
+    tiers = {m.tier for m in llm}
+    assert "pro" in tiers
+    assert "lite" in tiers
+
+
+def test_model_ids_are_unique():
+    """Canonical ids must be unique (id is the public handle clients send)."""
+    _, llm, embedding = _catalog()
+    ids = [m.id for m in (*llm, *embedding)]
+    assert len(ids) == len(set(ids)), "duplicate model ids in catalog"
+
+
+def test_embedding_routes_share_dim_per_id():
+    """All routes for one embedding id must share a dim (vectors aren't portable)."""
+    _, _, embedding = _catalog()
+    for m in embedding:
+        assert m.dim is not None, f"embedding {m.id} missing dim"
+
+
+def test_nitro_only_on_non_openai_anthropic_openrouter_routes():
+    """OpenRouter routes carry :nitro except for openai/anthropic single-provider models."""
+    _, llm, _ = _catalog()
+    violations = []
+    for m in llm:
+        for r in m.routes:
+            if r.via != "openrouter":
+                continue
+            single_provider = r.model.startswith(("openai/", "anthropic/"))
+            has_nitro = r.model.endswith(":nitro")
+            if single_provider and has_nitro:
+                violations.append(("unexpected :nitro", m.id, r.model))
+            if not single_provider and not has_nitro:
+                violations.append(("missing :nitro", m.id, r.model))
+    assert violations == [], f"nitro-rule violations: {violations}"
+
+
+def test_agent_config_models_exist_in_catalog():
+    """Every `model:` in the agent YAML configs must be a catalog id.
+
+    validate_model silently falls back when a model is unreachable, so a typo in
+    a config would otherwise go unnoticed; this catches it at the source.
+    """
+    _, llm, _ = _catalog()
+    ids = {m.id for m in llm}
+
+    def collect(node) -> list[str]:
+        found: list[str] = []
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "model" and isinstance(value, str):
+                    found.append(value)
+                else:
+                    found.extend(collect(value))
+        elif isinstance(node, list):
+            for item in node:
+                found.extend(collect(item))
+        return found
+
+    for name in ("assistant.yml", "deep_research.yml"):
+        cf = yaml.safe_load((CONFIG_DIR / name).read_text())
+        for model_id in collect(cf):
+            assert model_id in ids, f"{name} references unknown model '{model_id}'"
+
+
+def test_model_enum_handles_resolve_to_catalog():
+    """ModelEnum convenience handles (agent defaults) must map to catalog ids.
+
+    Guards the bulk-renamed sub-agent defaults from drifting off the catalog and
+    silently falling back. Perplexity is excluded (its Sonar handle is a search
+    summarizer, not a chat-catalog model).
+    """
+    _, llm, _ = _catalog()
+    ids = {m.id for m in llm}
+    for family in (ModelEnum.OpenAI, ModelEnum.OpenRouter):
+        for member in family:
+            assert _bare(member.value) in ids, f"{member} not in catalog"

--- a/backend/test/unit/nlp/test_embed.py
+++ b/backend/test/unit/nlp/test_embed.py
@@ -35,9 +35,8 @@ class TestEmbedderClamping:
     """The embedder must never hand the API an over-limit input."""
 
     def _embedder(self) -> tuple[OpenAIEmbedder, _FakeClient]:
-        embedder = OpenAIEmbedder(api_key="test-key")
         fake = _FakeClient()
-        embedder._client = fake
+        embedder = OpenAIEmbedder(client=fake)
         return embedder, fake
 
     async def test_oversized_input_is_clamped_before_api_call(self):

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-import os
 import time
 
 from typing import Literal
 
-from openai import AsyncOpenAI
+import litellm
+
 from pydantic import BaseModel
 
 from topix.config import catalog
 
 AUTO_MODEL_TIMEOUT_SECONDS = 2
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 logger = logging.getLogger(__name__)
 
@@ -157,52 +157,46 @@ def _build_classifier_input(messages: list[dict[str, str]]) -> str:
     return "\n\n".join(parts)
 
 
-def _classifier_client_and_model() -> tuple[AsyncOpenAI, str] | None:
-    """Build an OpenAI-compatible client + model for the cheap classifier call.
-
-    Uses the best available "lite" model; supports the OpenAI and OpenRouter
-    providers (both OpenAI-compatible). Returns None when no compatible model
-    is reachable, in which case the caller falls back to a default complexity.
-    """
-    fast = catalog.default_resolved("lite") or catalog.default_resolved()
-    if fast is None:
-        return None
-
-    if fast.provider == "openai":
-        return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY")), fast.model
-    if fast.provider == "openrouter":
-        client = AsyncOpenAI(api_key=os.getenv("OPENROUTER_API_KEY"), base_url=OPENROUTER_BASE_URL)
-        return client, fast.model
-    return None
+def _parse_complexity(content: str | None) -> ComplexityLabel:
+    """Extract the complexity label from the classifier's JSON reply (medium on miss)."""
+    if not content:
+        return "medium"
+    try:
+        label = json.loads(content).get("complexity")
+    except (json.JSONDecodeError, AttributeError):
+        return "medium"
+    if label in ("simple", "medium", "complex"):
+        return label
+    return "medium"
 
 
 async def classify_auto_model_complexity(messages: list[dict[str, str]]) -> ComplexityLabel:
-    """Classify the request complexity, falling back to medium on any failure."""
+    """Classify the request complexity, falling back to medium on any failure.
+
+    Routes through LiteLLM using the best available "lite" model, so the
+    classifier works for any configured provider (OpenAI, OpenRouter, or a
+    native Anthropic/Gemini/Mistral/DeepSeek key), not just OpenAI-compatible ones.
+    """
     started_at = time.perf_counter()
-    selected = _classifier_client_and_model()
-    if selected is None:
-        elapsed_ms = (time.perf_counter() - started_at) * 1000
-        logger.info("Auto model classifier skipped (no compatible model) in %.1fms", elapsed_ms)
+    fast = catalog.default_resolved("lite") or catalog.default_resolved()
+    if fast is None:
+        logger.info("Auto model classifier skipped (no model available)")
         return "medium"
 
-    client, classifier_model = selected
-
     async def _run() -> ComplexityLabel:
-        response = await client.beta.chat.completions.parse(
-            model=classifier_model,
+        response = await litellm.acompletion(
+            model=fast.call,
             messages=[
                 {"role": "system", "content": AUTO_MODEL_SYSTEM_PROMPT},
                 {"role": "user", "content": _build_classifier_input(messages)},
             ],
             response_format=AutoModelDecision,
             temperature=0,
-            max_completion_tokens=1000,
+            max_tokens=1000,
+            timeout=AUTO_MODEL_TIMEOUT_SECONDS,
+            drop_params=True,
         )
-
-        parsed = response.choices[0].message.parsed
-        if parsed is None:
-            return "medium"
-        return parsed.complexity
+        return _parse_complexity(response.choices[0].message.content)
 
     try:
         complexity = await asyncio.wait_for(_run(), timeout=AUTO_MODEL_TIMEOUT_SECONDS)

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -12,9 +12,10 @@ from typing import Literal
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 
+from topix.config import catalog
+
 AUTO_MODEL_TIMEOUT_SECONDS = 2
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-OPENROUTER_AUTO_MODEL = "openai/gpt-oss-120b:nitro"
 
 logger = logging.getLogger(__name__)
 
@@ -156,23 +157,39 @@ def _build_classifier_input(messages: list[dict[str, str]]) -> str:
     return "\n\n".join(parts)
 
 
+def _classifier_client_and_model() -> tuple[AsyncOpenAI, str] | None:
+    """Build an OpenAI-compatible client + model for the cheap classifier call.
+
+    Uses the best available "lite" model; supports the OpenAI and OpenRouter
+    providers (both OpenAI-compatible). Returns None when no compatible model
+    is reachable, in which case the caller falls back to a default complexity.
+    """
+    fast = catalog.default_resolved("lite") or catalog.default_resolved()
+    if fast is None:
+        return None
+
+    if fast.provider == "openai":
+        return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY")), fast.model
+    if fast.provider == "openrouter":
+        client = AsyncOpenAI(api_key=os.getenv("OPENROUTER_API_KEY"), base_url=OPENROUTER_BASE_URL)
+        return client, fast.model
+    return None
+
+
 async def classify_auto_model_complexity(messages: list[dict[str, str]]) -> ComplexityLabel:
     """Classify the request complexity, falling back to medium on any failure."""
     started_at = time.perf_counter()
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
+    selected = _classifier_client_and_model()
+    if selected is None:
         elapsed_ms = (time.perf_counter() - started_at) * 1000
-        logger.info("Auto model classifier skipped (missing OPENROUTER_API_KEY) in %.1fms", elapsed_ms)
+        logger.info("Auto model classifier skipped (no compatible model) in %.1fms", elapsed_ms)
         return "medium"
 
-    client = AsyncOpenAI(
-        api_key=api_key,
-        base_url=OPENROUTER_BASE_URL,
-    )
+    client, classifier_model = selected
 
     async def _run() -> ComplexityLabel:
         response = await client.beta.chat.completions.parse(
-            model=OPENROUTER_AUTO_MODEL,
+            model=classifier_model,
             messages=[
                 {"role": "system", "content": AUTO_MODEL_SYSTEM_PROMPT},
                 {"role": "user", "content": _build_classifier_input(messages)},

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -10,7 +10,6 @@ from topix.agents.assistant.auto_model import classify_auto_model_complexity
 from topix.agents.assistant.plan import Plan
 from topix.agents.config import AssistantManagerConfig
 from topix.agents.datatypes.context import ReasoningContext
-from topix.agents.datatypes.model_enum import ModelEnum
 from topix.agents.datatypes.outputs import CreateNoteOutput, LinkNotesOutput, WriteNoteOutput
 from topix.agents.datatypes.reasoning_step import ReasoningStep
 from topix.agents.datatypes.stream import (
@@ -25,6 +24,7 @@ from topix.agents.run import AgentRunner
 from topix.agents.sessions import AssistantSession
 from topix.agents.utils.text import post_process_url_citations
 from topix.collab.agent_bridge import AgentBoardBridge
+from topix.config import catalog
 from topix.datatypes.chat.chat import Message
 from topix.datatypes.property import ReasoningProperty, TextProperty
 from topix.datatypes.resource import RichText
@@ -34,8 +34,15 @@ from topix.utils.common import gen_uid
 
 logger = logging.getLogger(__name__)
 
-AUTO_MODEL_BASE_PLAN = "openrouter/deepseek/deepseek-v4-flash:nitro"
-AUTO_MODEL_COMPLEX_PLAN = ModelEnum.OpenAI.GPT_5_4
+def _auto_base_model() -> str | None:
+    """Cheapest/fastest available model for the auto-mode base plan."""
+    return catalog.default_model_code("lite") or catalog.default_model_code()
+
+
+def _auto_complex_model() -> str | None:
+    """Most capable available model for complex auto-mode requests."""
+    return catalog.default_model_code("pro") or catalog.default_model_code()
+
 
 # Hard ceiling on plan-agent turns (one turn = one LLM invocation, which may
 # fire several parallel tool calls). This is a runaway-loop backstop, not a
@@ -80,7 +87,7 @@ class AssistantManager:
         """Create an instance of AssistantManager from configuration."""
         config_ = config.model_copy(deep=True)
         if auto_mode:
-            config_.plan.model = AUTO_MODEL_BASE_PLAN
+            config_.plan.model = _auto_base_model()
 
         plan_agent = Plan.from_config(
             content_store,
@@ -115,8 +122,8 @@ class AssistantManager:
         logger.info(f"Auto model classified complexity as {complexity}")
 
         if complexity == "complex":
-            return AUTO_MODEL_COMPLEX_PLAN
-        return AUTO_MODEL_BASE_PLAN
+            return _auto_complex_model()
+        return _auto_base_model()
 
     async def _compose_input(
         self,

--- a/backend/topix/agents/assistant/manager.py
+++ b/backend/topix/agents/assistant/manager.py
@@ -34,14 +34,14 @@ from topix.utils.common import gen_uid
 
 logger = logging.getLogger(__name__)
 
-def _auto_base_model() -> str | None:
+def _auto_base_model() -> str:
     """Cheapest/fastest available model for the auto-mode base plan."""
-    return catalog.default_model_code("lite") or catalog.default_model_code()
+    return catalog.require_model_code("lite")
 
 
-def _auto_complex_model() -> str | None:
+def _auto_complex_model() -> str:
     """Most capable available model for complex auto-mode requests."""
-    return catalog.default_model_code("pro") or catalog.default_model_code()
+    return catalog.require_model_code("pro")
 
 
 # Hard ceiling on plan-agent turns (one turn = one LLM invocation, which may

--- a/backend/topix/agents/assistant/plan.py
+++ b/backend/topix/agents/assistant/plan.py
@@ -44,7 +44,7 @@ class Plan(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "plan.system.jinja",
         model_settings: ModelSettings | None = None,
         tools: list[FunctionTool] | None = None,

--- a/backend/topix/agents/base.py
+++ b/backend/topix/agents/base.py
@@ -41,6 +41,7 @@ from topix.agents.datatypes.stream import (
 )
 from topix.agents.datatypes.tools import AgentToolName
 from topix.agents.tool_handler import ToolHandler
+from topix.config import catalog
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +57,15 @@ class BaseAgent(Agent[Context]):
     """Base class for agents. Inherit from Openai Agent."""
 
     def __post_init__(self):
-        """Automatically load Litellm Model if not openai's."""
+        """Resolve the model against available keys, then load LiteLLM if not OpenAI."""
         if isinstance(self.model, str):
+            # Normalize any id / legacy code to a concrete route for the current
+            # keys; fall back to the best available model if it is unreachable.
+            self.model = (
+                catalog.normalize_code(self.model)
+                or catalog.default_model_code()
+                or self.model
+            )
             model_type = self.model.split("/")[0]
             if model_type != "openai":
                 self.model = LitellmModel(self.model)

--- a/backend/topix/agents/base.py
+++ b/backend/topix/agents/base.py
@@ -60,12 +60,9 @@ class BaseAgent(Agent[Context]):
         """Resolve the model against available keys, then load LiteLLM if not OpenAI."""
         if isinstance(self.model, str):
             # Normalize any id / legacy code to a concrete route for the current
-            # keys; fall back to the best available model if it is unreachable.
-            self.model = (
-                catalog.normalize_code(self.model)
-                or catalog.default_model_code()
-                or self.model
-            )
+            # keys; fall back to the best available model, or raise a clear error
+            # when no provider key is configured at all.
+            self.model = catalog.normalize_code(self.model) or catalog.require_model_code()
             model_type = self.model.split("/")[0]
             if model_type != "openai":
                 self.model = LitellmModel(self.model)

--- a/backend/topix/agents/config.py
+++ b/backend/topix/agents/config.py
@@ -11,6 +11,7 @@ from agents import ModelSettings
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from topix.agents.datatypes.web_search import WebSearchContextSize, WebSearchOption
+from topix.config import catalog
 from topix.config.services import service_config
 from topix.datatypes.recurrence import Recurrence
 
@@ -37,16 +38,18 @@ class BaseAgentConfig(BaseConfig):
     @field_validator("model")
     @classmethod
     def validate_model(cls, v: str) -> str:
-        """Check if the model is valid."""
-        valid_model_codes = [service.code for service in service_config.llm]
+        """Resolve a model id (or legacy call code) to a concrete, reachable call code."""
+        resolved = catalog.normalize_code(v)
+        if resolved is not None:
+            return resolved
 
-        if len(valid_model_codes) == 0:
-            raise ValueError("No LLM API available. Please add at least one LLM API by adding its api key to the config.")
-
-        if v in valid_model_codes:
-            return v
-        logger.info(f"Model '{v}' is not available, replaced with {valid_model_codes[0]}")
-        return valid_model_codes[0]
+        fallback = catalog.default_model_code()
+        if fallback is None:
+            raise ValueError(
+                "No LLM API available. Please add at least one LLM API by adding its api key to the config."
+            )
+        logger.info(f"Model '{v}' is not available, replaced with {fallback}")
+        return fallback
 
 
 class WebSearchConfig(BaseAgentConfig):

--- a/backend/topix/agents/configs/assistant.yml
+++ b/backend/topix/agents/configs/assistant.yml
@@ -1,5 +1,5 @@
 plan:
-  model: openai/gpt-4.1
+  model: gpt-4.1
   instructions_template: plan.system.jinja
   model_settings:
     temperature: 0.01
@@ -7,7 +7,7 @@ plan:
 
   web_search:
     search_engine: linkup
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: web_search.jinja
     search_context_size: medium
     model_settings:
@@ -16,17 +16,17 @@ plan:
     streaming: false
 
   navigate:
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: navigate.system.jinja
 
   memory_search:
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: memory_search.jinja
     model_settings:
       temperature: 0.01
 
   code_interpreter:
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: code_interpreter.jinja
     model_settings:
       temperature: 0.01

--- a/backend/topix/agents/configs/assistant.yml
+++ b/backend/topix/agents/configs/assistant.yml
@@ -1,5 +1,5 @@
 plan:
-  model: gpt-4.1
+  model: gpt-5.4
   instructions_template: plan.system.jinja
   model_settings:
     temperature: 0.01
@@ -7,7 +7,7 @@ plan:
 
   web_search:
     search_engine: linkup
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: web_search.jinja
     search_context_size: medium
     model_settings:
@@ -16,17 +16,17 @@ plan:
     streaming: false
 
   navigate:
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: navigate.system.jinja
 
   memory_search:
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: memory_search.jinja
     model_settings:
       temperature: 0.01
 
   code_interpreter:
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: code_interpreter.jinja
     model_settings:
       temperature: 0.01

--- a/backend/topix/agents/configs/deep_research.yml
+++ b/backend/topix/agents/configs/deep_research.yml
@@ -1,11 +1,11 @@
 outline_generator:
-  model: gpt-5
+  model: gpt-5.4
   instructions_template: deep_research/outline_generator.jinja
   model_settings:
     temperature: 0.01
 
   web_search:
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: decoupled_web_search.jinja
     search_engine: linkup
     search_context_size: medium
@@ -15,13 +15,13 @@ outline_generator:
     streaming: false
 
 web_collector:
-  model: gpt-4.1
+  model: gpt-5.4
   instructions_template: deep_research/web_collector.jinja
   model_settings:
     temperature: 0.01
 
   web_search:
-    model: gpt-4.1-mini
+    model: gpt-5.4-mini
     instructions_template: decoupled_web_search.jinja
     search_engine: linkup
     search_context_size: medium
@@ -31,7 +31,7 @@ web_collector:
     streaming: false
 
 synthesis:
-  model: gpt-4.1
+  model: gpt-5.4
   instructions_template: deep_research/synthesis.system.jinja
   model_settings:
     temperature: 0.05

--- a/backend/topix/agents/configs/deep_research.yml
+++ b/backend/topix/agents/configs/deep_research.yml
@@ -1,11 +1,11 @@
 outline_generator:
-  model: openai/gpt-5
+  model: gpt-5
   instructions_template: deep_research/outline_generator.jinja
   model_settings:
     temperature: 0.01
 
   web_search:
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: decoupled_web_search.jinja
     search_engine: linkup
     search_context_size: medium
@@ -15,13 +15,13 @@ outline_generator:
     streaming: false
 
 web_collector:
-  model: openai/gpt-4.1
+  model: gpt-4.1
   instructions_template: deep_research/web_collector.jinja
   model_settings:
     temperature: 0.01
 
   web_search:
-    model: openai/gpt-4.1-mini
+    model: gpt-4.1-mini
     instructions_template: decoupled_web_search.jinja
     search_engine: linkup
     search_context_size: medium
@@ -31,7 +31,7 @@ web_collector:
     streaming: false
 
 synthesis:
-  model: "openai/gpt-4.1"
+  model: gpt-4.1
   instructions_template: deep_research/synthesis.system.jinja
   model_settings:
     temperature: 0.05

--- a/backend/topix/agents/datatypes/model_enum.py
+++ b/backend/topix/agents/datatypes/model_enum.py
@@ -61,85 +61,104 @@ class ModelEnum:
     OpenRouter = OpenRouterModel
 
 
-def support_temperature(model: str) -> bool:
+def _bare(model: object) -> str:
+    """Return a model's bare name (final path segment), ignoring any route prefix.
+
+    Capability checks must hold whether a model is addressed natively
+    ("openai/gpt-5.4"), routed through OpenRouter ("openrouter/openai/gpt-5.4"),
+    or wrapped in a LitellmModel — all share the same bare name "gpt-5.4".
+    """
+    name = model.model if hasattr(model, "model") else model
+    if isinstance(name, Enum):
+        name = name.value  # str(Enum) yields "OpenAIModel.X", not the model string
+    return str(name).rsplit("/", 1)[-1]
+
+
+# Capability sets keyed on bare model names so they match regardless of route.
+_NO_TEMPERATURE_MODELS = frozenset(_bare(m) for m in (
+    OpenAIModel.GPT_5,
+    OpenAIModel.GPT_5_MINI,
+    OpenAIModel.GPT_5_NANO,
+    OpenAIModel.GPT_5_4,
+    OpenAIModel.GPT_5_4_MINI,
+    OpenAIModel.GPT_5_4_NANO,
+    OpenAIModel.GPT_5_1_CHAT,
+))
+
+_REASONING_MODELS = frozenset(_bare(m) for m in (
+    # OpenAI reasoning-capable
+    OpenAIModel.GPT_5_1,
+    OpenAIModel.GPT_5_1_CHAT,
+    OpenAIModel.GPT_5,
+    OpenAIModel.GPT_5_MINI,
+    OpenAIModel.GPT_5_NANO,
+    OpenAIModel.GPT_5_2,
+    OpenAIModel.GPT_5_2_CHAT,
+    OpenAIModel.GPT_5_4,
+    OpenAIModel.GPT_5_4_MINI,
+    OpenAIModel.GPT_5_4_NANO,
+    # Gemini reasoning-capable
+    GeminiModel.GEMINI_2_5_FLASH,
+    GeminiModel.GEMINI_2_5_PRO,
+    # Perplexity reasoning-capable
+    PerplexityModel.PERPLEXITY_SONAR,
+))
+
+_REASONING_EFFORT_INSTANT_MODELS = frozenset(_bare(m) for m in (
+    OpenAIModel.GPT_5_1_CHAT,
+))
+
+_REASONING_EFFORT_NONE_MODELS = frozenset(_bare(m) for m in (
+    OpenAIModel.GPT_5_1,
+    OpenAIModel.GPT_5_4,
+    OpenAIModel.GPT_5_4_MINI,
+    OpenAIModel.GPT_5_4_NANO,
+    OpenAIModel.GPT_5_2,
+    OpenAIModel.GPT_5_2_CHAT,
+))
+
+_NO_PENALTIES_MODELS = frozenset(_bare(m) for m in (
+    OpenAIModel.GPT_4O,
+    OpenAIModel.GPT_4O_MINI,
+    OpenAIModel.GPT_4_1,
+    OpenAIModel.GPT_4_1_MINI,
+    OpenAIModel.GPT_4_1_NANO,
+    OpenAIModel.GPT_5_1_CHAT,
+    OpenAIModel.GPT_5,
+    OpenAIModel.GPT_5_MINI,
+    OpenAIModel.GPT_5_NANO,
+    OpenAIModel.GPT_5_4,
+    OpenAIModel.GPT_5_4_MINI,
+    OpenAIModel.GPT_5_4_NANO,
+    GeminiModel.GEMINI_2_5_FLASH,
+    GeminiModel.GEMINI_2_5_PRO,
+))
+
+
+def support_temperature(model: object) -> bool:
     """Check if the model supports temperature.
 
     Temperature is possibly not supported in reasoning models due to
     introduced newer parameters like `verbosity` or `reasoning_effort`.
     """
-    if model in [
-        OpenAIModel.GPT_5,
-        OpenAIModel.GPT_5_MINI,
-        OpenAIModel.GPT_5_NANO,
-        OpenAIModel.GPT_5_4,
-        OpenAIModel.GPT_5_4_MINI,
-        OpenAIModel.GPT_5_4_NANO,
-        OpenAIModel.GPT_5_1_CHAT,
-    ]:
-        return False
-    return True
+    return _bare(model) not in _NO_TEMPERATURE_MODELS
 
 
-def support_reasoning(model: str) -> bool:
+def support_reasoning(model: object) -> bool:
     """Check if the model supports reasoning."""
-    reasoning_models = {
-        # OpenAI reasoning-capable
-        OpenAIModel.GPT_5_1,
-        OpenAIModel.GPT_5_1_CHAT,
-        OpenAIModel.GPT_5,
-        OpenAIModel.GPT_5_MINI,
-        OpenAIModel.GPT_5_NANO,
-        OpenAIModel.GPT_5_2,
-        OpenAIModel.GPT_5_2_CHAT,
-        OpenAIModel.GPT_5_4,
-        OpenAIModel.GPT_5_4_MINI,
-        OpenAIModel.GPT_5_4_NANO,
-
-        # Gemini reasoning-capable
-        GeminiModel.GEMINI_2_5_FLASH,
-        GeminiModel.GEMINI_2_5_PRO,
-
-        # Perplexity reasoning-capable
-        PerplexityModel.PERPLEXITY_SONAR
-    }
-
-    return model in reasoning_models
+    return _bare(model) in _REASONING_MODELS
 
 
-def support_reasoning_effort_instant_mode(model: str) -> bool:
+def support_reasoning_effort_instant_mode(model: object) -> bool:
     """Check if the model supports instant reasoning effort."""
-    return model in [OpenAIModel.GPT_5_1_CHAT]
+    return _bare(model) in _REASONING_EFFORT_INSTANT_MODELS
 
 
-def support_reasoning_effort_none(model: str) -> bool:
+def support_reasoning_effort_none(model: object) -> bool:
     """Check if the model supports 'none' reasoning effort."""
-    return model in [
-        OpenAIModel.GPT_5_1,
-        OpenAIModel.GPT_5_4,
-        OpenAIModel.GPT_5_4_MINI,
-        OpenAIModel.GPT_5_4_NANO,
-        OpenAIModel.GPT_5_2,
-        OpenAIModel.GPT_5_2_CHAT
-    ]
+    return _bare(model) in _REASONING_EFFORT_NONE_MODELS
 
 
-def support_penalties(model: str) -> bool:
+def support_penalties(model: object) -> bool:
     """Check if the model supports frequency and presence penalty."""
-    if model in [
-        OpenAIModel.GPT_4O,
-        OpenAIModel.GPT_4O_MINI,
-        OpenAIModel.GPT_4_1,
-        OpenAIModel.GPT_4_1_MINI,
-        OpenAIModel.GPT_4_1_NANO,
-        OpenAIModel.GPT_5_1_CHAT,
-        OpenAIModel.GPT_5,
-        OpenAIModel.GPT_5_MINI,
-        OpenAIModel.GPT_5_NANO,
-        OpenAIModel.GPT_5_4,
-        OpenAIModel.GPT_5_4_MINI,
-        OpenAIModel.GPT_5_4_NANO,
-        GeminiModel.GEMINI_2_5_FLASH,
-        GeminiModel.GEMINI_2_5_PRO,
-    ]:
-        return False
-    return True
+    return _bare(model) not in _NO_PENALTIES_MODELS

--- a/backend/topix/agents/datatypes/model_enum.py
+++ b/backend/topix/agents/datatypes/model_enum.py
@@ -1,49 +1,28 @@
-"""Model Enum."""
+"""Model Enum.
+
+Convenience handles for the current models, plus capability checks. Capability
+sets are keyed on bare model names (final path segment, no route prefix or
+OpenRouter `:variant`) so they hold no matter how a model is addressed.
+"""
 from enum import Enum
 
 
 class OpenAIModel(str, Enum):
     """OpenAI Models."""
 
-    GPT_4O = "openai/gpt-4o"
-    GPT_4O_MINI = "openai/gpt-4o-mini"
-    GPT_4_1 = "openai/gpt-4.1"
-    GPT_4_1_MINI = "openai/gpt-4.1-mini"
-    GPT_4_1_NANO = "openai/gpt-4.1-nano"
-    GPT_5 = "openai/gpt-5"
-    GPT_5_MINI = "openai/gpt-5-mini"
-    GPT_5_NANO = "openai/gpt-5-nano"
+    GPT_5_5 = "openai/gpt-5.5"
+    GPT_5_5_PRO = "openai/gpt-5.5-pro"
     GPT_5_4 = "openai/gpt-5.4"
     GPT_5_4_MINI = "openai/gpt-5.4-mini"
     GPT_5_4_NANO = "openai/gpt-5.4-nano"
-    GPT_5_1_CHAT = "openai/gpt-5.1-chat-latest"
-    GPT_5_1 = "openai/gpt-5.1"
-    GPT_5_2 = "openai/gpt-5.2"
-    GPT_5_2_CHAT = "openai/gpt-5.2-chat-latest"
-
-
-class GeminiModel(str, Enum):
-    """Gemini Models."""
-
-    GEMINI_2_FLASH = "gemini/gemini-2.0-flash"
-    GEMINI_2_5_FLASH = "gemini/gemini-2.5-flash"
-    GEMINI_2_5_PRO = "gemini/gemini-2.5-pro"
 
 
 class OpenRouterModel(str, Enum):
-    """Anthropic Models."""
+    """OpenRouter-routed convenience handles."""
 
-    CLAUDE_OPUS_4_6 = "openrouter/anthropic/claude-opus-4.6"
-    CLAUDE_OPUS_4_5 = "openrouter/anthropic/claude-opus-4.5"
-    CLAUDE_SONNET_4_6 = "openrouter/anthropic/claude-sonnet-4.6"
-    CLAUDE_OPUS_4_1 = "openrouter/anthropic/claude-opus-4.1"
-    CLAUDE_HAIKU = "openrouter/anthropic/claude-3.5-haiku"
-    DEEPSEEK_CHAT = "openrouter/deepseek/deepseek-chat-v3.1"
-    MISTRAL_MEDIUM = "openrouter/mistralai/mistral-medium-3.1"
-    GEMINI_2_5_FLASH = "openrouter/google/gemini-2.5-flash"
-    GLM_4_7 = "openrouter/z-ai/glm-4.7:nitro"
-    QWEN_3_5_PLUS = "openrouter/qwen/qwen3.5-plus-02-15"
-    QWEN_3_6_PLUS = "openrouter/qwen/qwen3.6-plus-preview:free"
+    CLAUDE_OPUS = "openrouter/anthropic/claude-opus-4.8"
+    CLAUDE_SONNET = "openrouter/anthropic/claude-sonnet-4.6"
+    CLAUDE_HAIKU = "openrouter/anthropic/claude-haiku-4.5"
 
 
 class PerplexityModel(str, Enum):
@@ -56,83 +35,45 @@ class ModelEnum:
     """Model Enum."""
 
     OpenAI = OpenAIModel
-    Gemini = GeminiModel
     Perplexity = PerplexityModel
     OpenRouter = OpenRouterModel
 
 
 def _bare(model: object) -> str:
-    """Return a model's bare name (final path segment), ignoring any route prefix.
+    """Return a model's bare name, ignoring any route prefix or OpenRouter variant.
 
     Capability checks must hold whether a model is addressed natively
     ("openai/gpt-5.4"), routed through OpenRouter ("openrouter/openai/gpt-5.4"),
-    or wrapped in a LitellmModel — all share the same bare name "gpt-5.4".
+    carries a throughput variant ("z-ai/glm-5.2:nitro"), or is wrapped in a
+    LitellmModel — all collapse to the same bare name (e.g. "gpt-5.4", "glm-5.2").
     """
     name = model.model if hasattr(model, "model") else model
     if isinstance(name, Enum):
         name = name.value  # str(Enum) yields "OpenAIModel.X", not the model string
-    return str(name).rsplit("/", 1)[-1]
+    return str(name).rsplit("/", 1)[-1].split(":", 1)[0]
 
 
-# Capability sets keyed on bare model names so they match regardless of route.
-_NO_TEMPERATURE_MODELS = frozenset(_bare(m) for m in (
-    OpenAIModel.GPT_5,
-    OpenAIModel.GPT_5_MINI,
-    OpenAIModel.GPT_5_NANO,
-    OpenAIModel.GPT_5_4,
-    OpenAIModel.GPT_5_4_MINI,
-    OpenAIModel.GPT_5_4_NANO,
-    OpenAIModel.GPT_5_1_CHAT,
-))
+# The current OpenAI lineup: reasoning-capable, no temperature, no penalties,
+# and supports the "none" reasoning-effort. Capability sets are bare names so
+# they match native and OpenRouter-routed forms alike.
+_CURRENT_OPENAI_MODELS = frozenset({
+    "gpt-5.5",
+    "gpt-5.5-pro",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+})
 
-_REASONING_MODELS = frozenset(_bare(m) for m in (
-    # OpenAI reasoning-capable
-    OpenAIModel.GPT_5_1,
-    OpenAIModel.GPT_5_1_CHAT,
-    OpenAIModel.GPT_5,
-    OpenAIModel.GPT_5_MINI,
-    OpenAIModel.GPT_5_NANO,
-    OpenAIModel.GPT_5_2,
-    OpenAIModel.GPT_5_2_CHAT,
-    OpenAIModel.GPT_5_4,
-    OpenAIModel.GPT_5_4_MINI,
-    OpenAIModel.GPT_5_4_NANO,
-    # Gemini reasoning-capable
-    GeminiModel.GEMINI_2_5_FLASH,
-    GeminiModel.GEMINI_2_5_PRO,
-    # Perplexity reasoning-capable
-    PerplexityModel.PERPLEXITY_SONAR,
-))
+# Additional reasoning-capable models served through other providers.
+_OTHER_REASONING_MODELS = frozenset({
+    "sonar",  # perplexity/sonar
+})
 
-_REASONING_EFFORT_INSTANT_MODELS = frozenset(_bare(m) for m in (
-    OpenAIModel.GPT_5_1_CHAT,
-))
-
-_REASONING_EFFORT_NONE_MODELS = frozenset(_bare(m) for m in (
-    OpenAIModel.GPT_5_1,
-    OpenAIModel.GPT_5_4,
-    OpenAIModel.GPT_5_4_MINI,
-    OpenAIModel.GPT_5_4_NANO,
-    OpenAIModel.GPT_5_2,
-    OpenAIModel.GPT_5_2_CHAT,
-))
-
-_NO_PENALTIES_MODELS = frozenset(_bare(m) for m in (
-    OpenAIModel.GPT_4O,
-    OpenAIModel.GPT_4O_MINI,
-    OpenAIModel.GPT_4_1,
-    OpenAIModel.GPT_4_1_MINI,
-    OpenAIModel.GPT_4_1_NANO,
-    OpenAIModel.GPT_5_1_CHAT,
-    OpenAIModel.GPT_5,
-    OpenAIModel.GPT_5_MINI,
-    OpenAIModel.GPT_5_NANO,
-    OpenAIModel.GPT_5_4,
-    OpenAIModel.GPT_5_4_MINI,
-    OpenAIModel.GPT_5_4_NANO,
-    GeminiModel.GEMINI_2_5_FLASH,
-    GeminiModel.GEMINI_2_5_PRO,
-))
+_NO_TEMPERATURE_MODELS = _CURRENT_OPENAI_MODELS
+_REASONING_MODELS = _CURRENT_OPENAI_MODELS | _OTHER_REASONING_MODELS
+_REASONING_EFFORT_NONE_MODELS = _CURRENT_OPENAI_MODELS
+_REASONING_EFFORT_INSTANT_MODELS: frozenset[str] = frozenset()
+_NO_PENALTIES_MODELS = _CURRENT_OPENAI_MODELS
 
 
 def support_temperature(model: object) -> bool:

--- a/backend/topix/agents/deep_research.py
+++ b/backend/topix/agents/deep_research.py
@@ -30,7 +30,7 @@ class WebCollector(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_5,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "deep_research/web_collector.jinja",
         model_settings: ModelSettings | None = None,
         web_search_tool: FunctionTool | None = None,
@@ -77,20 +77,11 @@ class Synthesizer(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "deep_research/synthesis.system.jinja",
         model_settings: ModelSettings | None = None,
     ):
         """Init method."""
-        # TODO: GPT-5.1-chat-latest is not compatible with deep research long detailed report synthesis, to
-        # replace it with GPT-5.1 for now. But need better configuration management later.
-        if model == ModelEnum.OpenAI.GPT_5_1_CHAT:
-            logger.warning(
-                "gpt-5.1-chat-latest is not compatible with deep research long detailed report synthesis "
-                "due to verbosity/formatting restrictions in hidden system prompt. Falling back to gpt-5.1."
-            )
-            model = ModelEnum.OpenAI.GPT_5_1
-
         name = "Synthesizer"
         instructions = self._render_prompt(instructions_template)
 

--- a/backend/topix/agents/describe_board.py
+++ b/backend/topix/agents/describe_board.py
@@ -23,7 +23,7 @@ class DescribeBoard(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1_NANO,
+        model: str = ModelEnum.OpenAI.GPT_5_4_NANO,
         instructions_template: str = "describe_board.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/describe_chat.py
+++ b/backend/topix/agents/describe_chat.py
@@ -23,7 +23,7 @@ class DescribeChat(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1_NANO,
+        model: str = ModelEnum.OpenAI.GPT_5_4_NANO,
         instructions_template: str = "describe_chat.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/document/mindmap.py
+++ b/backend/topix/agents/document/mindmap.py
@@ -12,7 +12,7 @@ class DocumentMindmapAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "document/document_mindmap.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/drawify/drawify.py
+++ b/backend/topix/agents/drawify/drawify.py
@@ -19,7 +19,7 @@ class DrawifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenRouter.CLAUDE_OPUS_4_6,
+        model: str = ModelEnum.OpenRouter.CLAUDE_OPUS,
         instructions_template: str = "drawify/drawify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/image/describe.py
+++ b/backend/topix/agents/image/describe.py
@@ -43,7 +43,7 @@ class ImageDescriptionAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4O_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "image/image_description.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/image/illustrate.py
+++ b/backend/topix/agents/image/illustrate.py
@@ -15,7 +15,7 @@ class TopicIllustrator(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4O_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "image/topic_illustrator.jinja",
         model_settings: ModelSettings | None = None,
         image_search_engine: ImageSearchOption = ImageSearchOption.SERPER,

--- a/backend/topix/agents/mindmap/mapify.py
+++ b/backend/topix/agents/mindmap/mapify.py
@@ -19,7 +19,7 @@ class MapifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4O_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "mapify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/mindmap/notify.py
+++ b/backend/topix/agents/mindmap/notify.py
@@ -17,7 +17,7 @@ class NotifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4O_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "notify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/mindmap/quizify/quizify.py
+++ b/backend/topix/agents/mindmap/quizify/quizify.py
@@ -14,7 +14,7 @@ class QuizifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_5_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "quizify/quizify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/mindmap/schemify/schemify.py
+++ b/backend/topix/agents/mindmap/schemify/schemify.py
@@ -72,7 +72,7 @@ class SchemifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "schemify/schemify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/mindmap/summify/summify.py
+++ b/backend/topix/agents/mindmap/summify/summify.py
@@ -14,7 +14,7 @@ class SummifyAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_5_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "summify/summify.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/newsfeed/collector.py
+++ b/backend/topix/agents/newsfeed/collector.py
@@ -28,7 +28,7 @@ class NewsfeedCollector(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "newsfeed/collector.system.jinja",
         model_settings: ModelSettings | None = None,
         web_search: Tool | None = None
@@ -95,7 +95,7 @@ class NewsfeedSynthesizer(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "newsfeed/synthesizer.system.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/agents/newsfeed/topic_tracker.py
+++ b/backend/topix/agents/newsfeed/topic_tracker.py
@@ -27,7 +27,7 @@ class TopicSetup(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "newsfeed/topic_setup.system.jinja",
         model_settings: ModelSettings | None = None,
         web_search: Tool | None = None

--- a/backend/topix/agents/translate/translate.py
+++ b/backend/topix/agents/translate/translate.py
@@ -14,7 +14,7 @@ class TranslateAgent(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_5_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "translate/translate.system.jinja",
         model_settings: ModelSettings | None = None,
         target_language: str = "English",

--- a/backend/topix/agents/websearch/handler.py
+++ b/backend/topix/agents/websearch/handler.py
@@ -64,7 +64,7 @@ class WebSearchHandler:
     @classmethod
     def get_openai_web_tool(
         cls,
-        model: str = ModelEnum.OpenAI.GPT_5_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "web_search.jinja",
         model_settings: ModelSettings | None = None,
         search_context_size: WebSearchContextSize = WebSearchContextSize.MEDIUM,

--- a/backend/topix/agents/websearch/openai.py
+++ b/backend/topix/agents/websearch/openai.py
@@ -21,7 +21,7 @@ class OpenAIWebSearch(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_5_MINI,
+        model: str = ModelEnum.OpenAI.GPT_5_4_MINI,
         instructions_template: str = "web_search.jinja",
         model_settings: ModelSettings | None = None,
         search_context_size: WebSearchContextSize = WebSearchContextSize.MEDIUM,

--- a/backend/topix/agents/websearch/web_summarize.py
+++ b/backend/topix/agents/websearch/web_summarize.py
@@ -12,7 +12,7 @@ class WebSummarize(BaseAgent):
 
     def __init__(
         self,
-        model: str = ModelEnum.OpenAI.GPT_4_1,
+        model: str = ModelEnum.OpenAI.GPT_5_4,
         instructions_template: str = "web_summarize.jinja",
         model_settings: ModelSettings | None = None,
     ):

--- a/backend/topix/api/router/chats.py
+++ b/backend/topix/api/router/chats.py
@@ -23,6 +23,7 @@ from topix.api.utils.decorators import with_standard_response
 from topix.api.utils.rate_limit.dependency import rate_limiter
 from topix.api.utils.resilient_streaming import with_streaming_resilient_ndjson
 from topix.api.utils.security import get_current_user_uid, verify_chat_user
+from topix.config import catalog
 from topix.datatypes.chat.chat import Chat
 from topix.store.chat import ChatStore
 from topix.store.graph import GraphStore
@@ -167,7 +168,7 @@ async def send_message(
 
     if body.use_deep_research:
         deepsearch_config = DeepResearchConfig.from_yaml()
-        deepsearch_model = body.model if body.model != "auto" else "openai/gpt-5.4-mini"
+        deepsearch_model = body.model if body.model != "auto" else catalog.default_model_code("lite")
         deepsearch_config.set_model(deepsearch_model)
 
         deepsearch = DeepResearch.from_config(deepsearch_config)

--- a/backend/topix/api/router/chats.py
+++ b/backend/topix/api/router/chats.py
@@ -168,7 +168,7 @@ async def send_message(
 
     if body.use_deep_research:
         deepsearch_config = DeepResearchConfig.from_yaml()
-        deepsearch_model = body.model if body.model != "auto" else catalog.default_model_code("lite")
+        deepsearch_model = body.model if body.model != "auto" else catalog.require_model_code("lite")
         deepsearch_config.set_model(deepsearch_model)
 
         deepsearch = DeepResearch.from_config(deepsearch_config)

--- a/backend/topix/api/router/utils.py
+++ b/backend/topix/api/router/utils.py
@@ -70,9 +70,23 @@ async def search_images(
 @router.get("/services")
 @with_standard_response
 async def get_services() -> dict:
-    """Get available services."""
+    """Get available services.
+
+    `llm` is the catalog of reachable models (keyed by canonical id) with the
+    display metadata the frontend needs to render the picker; the id is what the
+    client sends back as the chosen model.
+    """
     return {
-        "llm": [llm.code for llm in service_config.llm],
+        "llm": [
+            {
+                "id": m.id,
+                "label": m.label,
+                "family": m.family,
+                "tier": m.tier,
+                "provider": m.provider,
+            }
+            for m in service_config.llm
+        ],
         "search": [search.name for search in service_config.search],
         "navigate": [navigate.name for navigate in service_config.navigate],
         "code": [code.name for code in service_config.code],

--- a/backend/topix/config/catalog.py
+++ b/backend/topix/config/catalog.py
@@ -1,0 +1,186 @@
+"""Model catalog: canonical models -> provider routes, resolved against present keys.
+
+The catalog (`models.yml`) declares providers and an ordered list of routes per
+model. `resolve()` walks a model's routes and returns the first one whose
+provider key is configured, producing a flat `Resolved` object that every
+consumer (agents, embeddings, the services endpoint) can use. Static file
+parsing is cached; key presence is read live so `ServiceConfig.update()` and
+post-startup env changes are picked up.
+"""
+
+import logging
+import os
+
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+MODELS_FILEPATH = Path(__file__).parent.parent / "models.yml"
+
+
+class Provider(BaseModel):
+    """A model provider: its API-key env var and (for LLMs) its call prefix."""
+
+    name: str
+    key: str | None = None    # env var name; None => keyless (always available)
+    prefix: str | None = None  # prepended to the route model string for the call code
+
+
+class Route(BaseModel):
+    """One way to reach a model: a provider plus that provider's model string."""
+
+    via: str
+    model: str
+
+
+class CatalogModel(BaseModel):
+    """A canonical model: stable id, display metadata, and ordered routes."""
+
+    id: str
+    label: str
+    family: str
+    tier: str | None = None    # "pro" | "lite" (llm only)
+    dim: int | None = None     # vector size (embedding only)
+    routes: list[Route]
+
+
+class Resolved(BaseModel):
+    """A model resolved to a concrete provider route for the current keys."""
+
+    id: str
+    label: str
+    family: str
+    tier: str | None = None
+    dim: int | None = None
+    provider: str
+    model: str    # raw provider model string (e.g. "openai/text-embedding-3-small")
+    call: str     # call code for agents/base.py (e.g. "openrouter/anthropic/claude-opus-4.6")
+
+    @property
+    def code(self) -> str:
+        """Back-compat alias: the call code used as a model identifier."""
+        return self.call
+
+
+@lru_cache(maxsize=1)
+def _load() -> tuple[dict[str, Provider], list[CatalogModel], list[CatalogModel]]:
+    """Parse and cache models.yml into (providers, llm models, embedding models)."""
+    with open(MODELS_FILEPATH) as f:
+        cf = yaml.safe_load(f)
+
+    providers = {
+        name: Provider(name=name, **(spec or {}))
+        for name, spec in (cf.get("providers") or {}).items()
+    }
+    llm = [CatalogModel.model_validate(m) for m in (cf.get("llm") or [])]
+    embedding = [CatalogModel.model_validate(m) for m in (cf.get("embedding") or [])]
+    return providers, llm, embedding
+
+
+def _provider_available(p: Provider) -> bool:
+    """Return True if the provider is keyless or its API-key env var is set."""
+    return p.key is None or bool(os.getenv(p.key))
+
+
+def available_providers() -> list[str]:
+    """Names of providers whose key is present (or that need no key)."""
+    providers, _, _ = _load()
+    return [name for name, p in providers.items() if _provider_available(p)]
+
+
+def _resolve(model: CatalogModel) -> Resolved | None:
+    """Return the first route whose provider key is present; None if unreachable."""
+    providers, _, _ = _load()
+    for route in model.routes:
+        p = providers.get(route.via)
+        if p is None:
+            logger.warning("Model '%s' references unknown provider '%s'", model.id, route.via)
+            continue
+        if _provider_available(p):
+            call = f"{p.prefix}/{route.model}" if p.prefix else route.model
+            return Resolved(
+                id=model.id,
+                label=model.label,
+                family=model.family,
+                tier=model.tier,
+                dim=model.dim,
+                provider=p.name,
+                model=route.model,
+                call=call,
+            )
+    return None
+
+
+def available_llms() -> list[Resolved]:
+    """All LLM models reachable with the configured keys, in catalog order."""
+    _, llm, _ = _load()
+    return [r for m in llm if (r := _resolve(m))]
+
+
+def available_embedding() -> Resolved | None:
+    """First embedding model reachable with the configured keys (preference order)."""
+    _, _, embedding = _load()
+    for m in embedding:
+        if (r := _resolve(m)):
+            return r
+    return None
+
+
+def resolve_code(model_id_or_code: str) -> str | None:
+    """Map an incoming model id (or legacy call code) to a concrete call code.
+
+    Accepts either a canonical catalog id ("claude-opus-4.6") or a full call
+    code ("openrouter/anthropic/claude-opus-4.6") for backward compatibility.
+    Returns None when the model is not reachable with the current keys.
+    """
+    for r in available_llms():
+        if model_id_or_code in (r.id, r.call):
+            return r.call
+    return None
+
+
+def normalize_code(model: str) -> str | None:
+    """Map any model reference to a concrete, reachable call code (or None).
+
+    Handles canonical ids ("gpt-4.1-mini"), already-resolved call codes
+    ("openrouter/openai/gpt-4.1-mini"), and legacy provider-prefixed codes
+    ("openai/gpt-4.1-mini", "openrouter/openai/gpt-5.2") by progressively
+    stripping leading provider segments until a catalog model matches.
+    """
+    direct = resolve_code(model)
+    if direct is not None:
+        return direct
+
+    providers, _, _ = _load()
+    parts = model.split("/")
+    i = 0
+    while i < len(parts) - 1 and parts[i] in providers:
+        i += 1
+        hit = resolve_code("/".join(parts[i:]))
+        if hit is not None:
+            return hit
+    return None
+
+
+def default_resolved(tier: str | None = None) -> Resolved | None:
+    """Best available model, optionally constrained to a tier (falls back to any)."""
+    models = available_llms()
+    if tier:
+        for m in models:
+            if m.tier == tier:
+                return m
+    return models[0] if models else None
+
+
+def default_model_code(tier: str | None = None) -> str | None:
+    """Best available model call code, optionally constrained to a tier.
+
+    Falls back to any available model when no model matches the requested tier.
+    """
+    r = default_resolved(tier)
+    return r.call if r else None

--- a/backend/topix/config/catalog.py
+++ b/backend/topix/config/catalog.py
@@ -21,6 +21,10 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 MODELS_FILEPATH = Path(__file__).parent.parent / "models.yml"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+NO_LLM_ERROR = (
+    "No LLM API available. Set a provider key (e.g. OPENAI_API_KEY or OPENROUTER_API_KEY)."
+)
 
 
 class Provider(BaseModel):
@@ -93,15 +97,14 @@ def available_providers() -> list[str]:
     return [name for name, p in providers.items() if _provider_available(p)]
 
 
-def _resolve(model: CatalogModel) -> Resolved | None:
-    """Return the first route whose provider key is present; None if unreachable."""
-    providers, _, _ = _load()
+def _resolve(model: CatalogModel, providers: dict[str, Provider], present: frozenset[str]) -> Resolved | None:
+    """Return the first route served by an available provider; None if unreachable."""
     for route in model.routes:
         p = providers.get(route.via)
         if p is None:
             logger.warning("Model '%s' references unknown provider '%s'", model.id, route.via)
             continue
-        if _provider_available(p):
+        if p.name in present:
             call = f"{p.prefix}/{route.model}" if p.prefix else route.model
             return Resolved(
                 id=model.id,
@@ -116,19 +119,29 @@ def _resolve(model: CatalogModel) -> Resolved | None:
     return None
 
 
+@lru_cache(maxsize=8)
+def _resolved_for(present: frozenset[str]) -> tuple[tuple[Resolved, ...], Resolved | None]:
+    """Resolve the whole catalog for a given set of available providers (memoized).
+
+    Keyed on the present-provider snapshot so it recomputes only when configured
+    keys change (startup sync, tests); stable env => cache hit on the hot path.
+    """
+    providers, llm, embedding = _load()
+    llms = tuple(r for m in llm if (r := _resolve(m, providers, present)))
+    emb = next((r for m in embedding if (r := _resolve(m, providers, present))), None)
+    return llms, emb
+
+
 def available_llms() -> list[Resolved]:
     """All LLM models reachable with the configured keys, in catalog order."""
-    _, llm, _ = _load()
-    return [r for m in llm if (r := _resolve(m))]
+    llms, _ = _resolved_for(frozenset(available_providers()))
+    return list(llms)
 
 
 def available_embedding() -> Resolved | None:
     """First embedding model reachable with the configured keys (preference order)."""
-    _, _, embedding = _load()
-    for m in embedding:
-        if (r := _resolve(m)):
-            return r
-    return None
+    _, emb = _resolved_for(frozenset(available_providers()))
+    return emb
 
 
 def resolve_code(model_id_or_code: str) -> str | None:
@@ -138,6 +151,8 @@ def resolve_code(model_id_or_code: str) -> str | None:
     code ("openrouter/anthropic/claude-opus-4.6") for backward compatibility.
     Returns None when the model is not reachable with the current keys.
     """
+    if not isinstance(model_id_or_code, str):
+        return None
     for r in available_llms():
         if model_id_or_code in (r.id, r.call):
             return r.call
@@ -152,6 +167,9 @@ def normalize_code(model: str) -> str | None:
     ("openai/gpt-4.1-mini", "openrouter/openai/gpt-5.2") by progressively
     stripping leading provider segments until a catalog model matches.
     """
+    if not isinstance(model, str):
+        return None
+
     direct = resolve_code(model)
     if direct is not None:
         return direct
@@ -184,3 +202,26 @@ def default_model_code(tier: str | None = None) -> str | None:
     """
     r = default_resolved(tier)
     return r.call if r else None
+
+
+def require_model_code(tier: str | None = None) -> str:
+    """Like default_model_code but raise a clear error when no model is reachable."""
+    code = default_model_code(tier)
+    if code is None:
+        raise ValueError(NO_LLM_ERROR)
+    return code
+
+
+def openai_compatible_client(resolved: Resolved):
+    """Build an OpenAI-compatible AsyncOpenAI client for a resolved route.
+
+    Supports the OpenAI and OpenRouter providers (both speak the OpenAI API);
+    returns None for providers that are not OpenAI-API-compatible.
+    """
+    from openai import AsyncOpenAI
+
+    if resolved.provider == "openai":
+        return AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    if resolved.provider == "openrouter":
+        return AsyncOpenAI(api_key=os.getenv("OPENROUTER_API_KEY"), base_url=OPENROUTER_BASE_URL)
+    return None

--- a/backend/topix/config/services.py
+++ b/backend/topix/config/services.py
@@ -1,7 +1,12 @@
-"""All services info."""
+"""All services info.
+
+LLM and embedding availability come from the model catalog (`models.yml` via
+`config.catalog`), which resolves canonical models to concrete provider routes
+based on which API keys are present. Search / navigate / code / image_generation
+stay declared in `services.yml` and are gated by the same provider availability.
+"""
 
 import logging
-import os
 
 from enum import StrEnum
 from pathlib import Path
@@ -11,9 +16,11 @@ import yaml
 
 from pydantic import BaseModel
 
+from topix.config import catalog
+from topix.config.catalog import Resolved
+
 logger = logging.getLogger(__name__)
 
-LLM_FILEPATH = Path(__file__).parent.parent / "llm_models.yml"
 SERVICES_FILEPATH = Path(__file__).parent.parent / "services.yml"
 
 
@@ -27,38 +34,12 @@ class ServiceEnum(StrEnum):
     IMAGE_GENERATION = "image_generation"
 
 
-class LLMTier(StrEnum):
-    """LLM Model tiers."""
-
-    PRO = "pro"
-    LITE = "lite"
-
-
 class BaseService(BaseModel):
     """Base Service info."""
 
     type: ServiceEnum
     name: str
     provider: str
-
-
-class LLMService(BaseService):
-    """LLM Service info."""
-
-    type: Literal[ServiceEnum.LLM] = ServiceEnum.LLM
-    model: str
-    tier: LLMTier
-    openrouter_model: str | None = None
-    use_openrouter: bool = False
-
-    @property
-    def code(self) -> str:
-        """Get the code representation of the LLM service."""
-        if not self.use_openrouter:
-            return f"{self.provider}/{self.model}"
-        else:
-            model_name = self.openrouter_model or f"{self.provider}/{self.model}"
-            return f"openrouter/{model_name}"
 
 
 class SearchService(BaseService):
@@ -89,7 +70,7 @@ class ServiceConfig(BaseModel):
     """Valid Services info."""
 
     providers: list[str]
-    llm: list[LLMService]
+    llm: list[Resolved]
     search: list[SearchService]
     navigate: list[NavigateService]
     code: list[CodeService]
@@ -97,40 +78,30 @@ class ServiceConfig(BaseModel):
 
     @classmethod
     def _sync(cls) -> dict:
-        """Sync the services config with environment variables."""
+        """Sync the services config with the currently configured API keys."""
         with open(SERVICES_FILEPATH) as f:
             cf = yaml.safe_load(f)
 
-        # Get valid providers:
-        providers: list[str] = []
-        for provider, env_var in cf["providers"].items():
-            # Check if the env var is set and is not empty
-            if os.getenv(env_var["env_var"]):
-                providers.append(provider)
+        # Provider availability + LLM models come from the model catalog.
+        providers = catalog.available_providers()
 
-        # Get valid services
         services = cf["services"]
 
-        dct = {}
-        dct["providers"] = providers
-        dct["llm"] = cls._get_llm_services(services[ServiceEnum.LLM], providers)
-        dct["search"] = [
-            SearchService.model_validate(service)
-            for service in services[ServiceEnum.SEARCH] if service["provider"] in providers
-        ]
-        dct["navigate"] = [
-            NavigateService.model_validate(service)
-            for service in services[ServiceEnum.NAVIGATE] if service["provider"] in providers
-        ]
-        dct["code"] = [
-            CodeService.model_validate(service)
-            for service in services[ServiceEnum.CODE] if service["provider"] in providers
-        ]
-        dct["image_generation"] = [
-            ImageGenerationService.model_validate(service)
-            for service in services[ServiceEnum.IMAGE_GENERATION] if service["provider"] in providers
-        ]
-        return dct
+        def gated(service_key: ServiceEnum, model_cls):
+            return [
+                model_cls.model_validate(service)
+                for service in services.get(service_key, [])
+                if service["provider"] in providers
+            ]
+
+        return {
+            "providers": providers,
+            "llm": catalog.available_llms(),
+            "search": gated(ServiceEnum.SEARCH, SearchService),
+            "navigate": gated(ServiceEnum.NAVIGATE, NavigateService),
+            "code": gated(ServiceEnum.CODE, CodeService),
+            "image_generation": gated(ServiceEnum.IMAGE_GENERATION, ImageGenerationService),
+        }
 
     def update(self):
         """Update the service config."""
@@ -142,44 +113,8 @@ class ServiceConfig(BaseModel):
 
     @classmethod
     def from_yaml(cls) -> "ServiceConfig":
-        """Create an instance of ServiceManager from a YAML file."""
-        synced_data = cls._sync()
-
-        return cls(**synced_data)
-
-    @classmethod
-    def _get_llm_services(
-        cls,
-        llm_services: list[str],
-        providers: list[str],
-    ) -> list[LLMService]:
-        """Get a list of valid LLM services from a given list of LLM names and providers.
-
-        Args:
-            llm_services (list[str]): A list of LLM names.
-            providers (list[str]): A list of valid providers.
-
-        Returns:
-            list[LLMService]: A list of valid LLM services.
-
-        """
-        with open(LLM_FILEPATH) as f:
-            cf: list[dict] = yaml.safe_load(f)
-
-        res = []
-        for llm_name in llm_services:
-            if llm_name in cf:
-                if cf[llm_name]["provider"] in providers:
-                    res.append(LLMService.model_validate({'name': llm_name, **cf[llm_name]}))
-                elif "openrouter" in providers:
-                    res.append(
-                        LLMService.model_validate(dict(
-                            name=llm_name,
-                            **cf[llm_name],
-                            use_openrouter=True,
-                        ))
-                    )
-        return res
+        """Create an instance of ServiceConfig from current config."""
+        return cls(**cls._sync())
 
 
 """

--- a/backend/topix/models.yml
+++ b/backend/topix/models.yml
@@ -7,6 +7,9 @@
 # route whose provider key is present (see config/catalog.py).
 #
 # Adding a model = one entry here. No code change.
+#
+# OpenRouter routes use the `:nitro` throughput variant EXCEPT for OpenAI and
+# Anthropic models (single-provider on OpenRouter; nitro adds nothing there).
 
 providers:
   # LLM providers. `prefix` is prepended to the route's model string to form the
@@ -27,63 +30,21 @@ providers:
   exa:        { key: EXA_API_KEY }
 
 llm:
-  # --- OpenAI ---
-  - id: gpt-5.2
-    label: GPT-5.2
+  # --- OpenAI (native preferred, OpenRouter fallback without :nitro) ---
+  - id: gpt-5.5
+    label: GPT-5.5
     family: openai
     tier: pro
     routes:
-      - { via: openai,     model: gpt-5.2 }
-      - { via: openrouter, model: openai/gpt-5.2 }
-  - id: gpt-5.2-chat-latest
-    label: GPT-5.2 Chat
+      - { via: openai,     model: gpt-5.5 }
+      - { via: openrouter, model: openai/gpt-5.5 }
+  - id: gpt-5.5-pro
+    label: GPT-5.5 Pro
     family: openai
     tier: pro
     routes:
-      - { via: openai,     model: gpt-5.2-chat-latest }
-      - { via: openrouter, model: openai/gpt-5.2-chat }
-  - id: gpt-5.1
-    label: GPT-5.1
-    family: openai
-    tier: pro
-    routes:
-      - { via: openai,     model: gpt-5.1 }
-      - { via: openrouter, model: openai/gpt-5.1 }
-  - id: gpt-5.1-chat-latest
-    label: GPT-5.1 Chat
-    family: openai
-    tier: pro
-    routes:
-      - { via: openai,     model: gpt-5.1-chat-latest }
-      - { via: openrouter, model: openai/gpt-5.1-chat }
-  - id: gpt-4.1
-    label: GPT-4.1
-    family: openai
-    tier: pro
-    routes:
-      - { via: openai,     model: gpt-4.1 }
-      - { via: openrouter, model: openai/gpt-4.1 }
-  - id: gpt-4.1-mini
-    label: GPT-4.1 Mini
-    family: openai
-    tier: lite
-    routes:
-      - { via: openai,     model: gpt-4.1-mini }
-      - { via: openrouter, model: openai/gpt-4.1-mini }
-  - id: gpt-4.1-nano
-    label: GPT-4.1 Nano
-    family: openai
-    tier: lite
-    routes:
-      - { via: openai,     model: gpt-4.1-nano }
-      - { via: openrouter, model: openai/gpt-4.1-nano }
-  - id: gpt-5
-    label: GPT-5
-    family: openai
-    tier: pro
-    routes:
-      - { via: openai,     model: gpt-5 }
-      - { via: openrouter, model: openai/gpt-5 }
+      - { via: openai,     model: gpt-5.5-pro }
+      - { via: openrouter, model: openai/gpt-5.5-pro }
   - id: gpt-5.4
     label: GPT-5.4
     family: openai
@@ -105,43 +66,15 @@ llm:
     routes:
       - { via: openai,     model: gpt-5.4-nano }
       - { via: openrouter, model: openai/gpt-5.4-nano }
-  - id: gpt-5-mini
-    label: GPT-5 Mini
-    family: openai
-    tier: lite
-    routes:
-      - { via: openai,     model: gpt-5-mini }
-      - { via: openrouter, model: openai/gpt-5-mini }
-  - id: gpt-4o
-    label: GPT-4o
-    family: openai
-    tier: pro
-    routes:
-      - { via: openai,     model: gpt-4o }
-      - { via: openrouter, model: openai/gpt-4o }
-  - id: gpt-4o-mini
-    label: GPT-4o Mini
-    family: openai
-    tier: lite
-    routes:
-      - { via: openai,     model: gpt-4o-mini }
-      - { via: openrouter, model: openai/gpt-4o-mini }
 
-  # --- Anthropic ---
-  - id: claude-opus-4.6
-    label: Claude Opus 4.6
+  # --- Anthropic (native preferred, OpenRouter fallback without :nitro) ---
+  - id: claude-opus-4.8
+    label: Claude Opus 4.8
     family: anthropic
     tier: pro
     routes:
-      - { via: anthropic,  model: claude-opus-4-6 }
-      - { via: openrouter, model: anthropic/claude-opus-4.6 }
-  - id: claude-opus-4.5
-    label: Claude Opus 4.5
-    family: anthropic
-    tier: pro
-    routes:
-      - { via: anthropic,  model: claude-opus-4-5 }
-      - { via: openrouter, model: anthropic/claude-opus-4.5 }
+      - { via: anthropic,  model: claude-opus-4-8 }
+      - { via: openrouter, model: anthropic/claude-opus-4.8 }
   - id: claude-sonnet-4.6
     label: Claude Sonnet 4.6
     family: anthropic
@@ -152,91 +85,92 @@ llm:
   - id: claude-haiku-4.5
     label: Claude Haiku 4.5
     family: anthropic
-    tier: pro
+    tier: lite
     routes:
       - { via: anthropic,  model: claude-haiku-4-5 }
       - { via: openrouter, model: anthropic/claude-haiku-4.5 }
-  - id: claude-opus-4.1
-    label: Claude Opus 4.1
-    family: anthropic
-    tier: lite
-    routes:
-      - { via: anthropic,  model: claude-opus-4-20250514 }
-      - { via: openrouter, model: anthropic/claude-opus-4.1 }
 
-  # --- Google Gemini ---
-  - id: gemini-2.5-pro
-    label: Gemini 2.5 Pro
-    family: google
+  # --- z-ai GLM (OpenRouter only) ---
+  - id: glm-5.2
+    label: GLM 5.2
+    family: z-ai
     tier: pro
     routes:
-      - { via: gemini,     model: gemini-2.5-pro }
-      - { via: openrouter, model: google/gemini-2.5-pro }
-  - id: gemini-2.5-flash
-    label: Gemini 2.5 Flash
-    family: google
-    tier: lite
-    routes:
-      - { via: gemini,     model: gemini-2.5-flash }
-      - { via: openrouter, model: google/gemini-2.5-flash }
-
-  # --- Mistral ---
-  - id: mistral-large-3
-    label: Mistral Large 3
-    family: mistralai
-    tier: pro
-    routes:
-      - { via: mistral,    model: mistral-large-latest }
-      - { via: openrouter, model: mistralai/mistral-large-2512 }
-  - id: mistral-medium-3.1
-    label: Mistral Medium 3.1
-    family: mistralai
-    tier: lite
-    routes:
-      - { via: mistral,    model: mistral-medium-latest }
-      - { via: openrouter, model: mistralai/mistral-medium-3.1 }
-
-  # --- DeepSeek ---
-  - id: deepseek-v3.2
-    label: DeepSeek V3.2
-    family: deepseek
-    tier: pro
-    routes:
-      - { via: deepseek,   model: deepseek-v3.2 }
-      - { via: openrouter, model: deepseek/deepseek-v3.2 }
-  - id: deepseek-chat-v3.1
-    label: DeepSeek Chat V3.1
-    family: deepseek
-    tier: pro
-    routes:
-      - { via: deepseek,   model: deepseek-chat-v3.1 }
-      - { via: openrouter, model: deepseek/deepseek-chat-v3.1 }
-
-  # --- OpenRouter-only models (no native key wired) ---
-  - id: glm-4.7
-    label: GLM 4.7
+      - { via: openrouter, model: z-ai/glm-5.2:nitro }
+  - id: glm-5.1
+    label: GLM 5.1
     family: z-ai
     tier: lite
     routes:
-      - { via: openrouter, model: z-ai/glm-4.7:nitro }
-  - id: qwen3.5-plus-02-15
-    label: Qwen3.5 Plus
-    family: qwen
-    tier: pro
+      - { via: openrouter, model: z-ai/glm-5.1:nitro }
+
+  # --- Google Gemma (OpenRouter only) ---
+  - id: gemma-4-31b
+    label: Gemma 4 31B
+    family: google
+    tier: lite
     routes:
-      - { via: openrouter, model: qwen/qwen3.5-plus-02-15 }
+      - { via: openrouter, model: google/gemma-4-31b-it:nitro }
+  - id: gemma-4-26b
+    label: Gemma 4 26B
+    family: google
+    tier: lite
+    routes:
+      - { via: openrouter, model: google/gemma-4-26b-a4b-it:nitro }
+
+  # --- Qwen (OpenRouter only) ---
   - id: qwen3.6-plus
     label: Qwen3.6 Plus
     family: qwen
     tier: pro
     routes:
-      - { via: openrouter, model: qwen/qwen3.6-plus-preview:free }
-  - id: kimi-k2.5
-    label: Kimi K2.5
+      - { via: openrouter, model: qwen/qwen3.6-plus:nitro }
+
+  # --- DeepSeek V4 (OpenRouter only) ---
+  - id: deepseek-v4-pro
+    label: DeepSeek V4 Pro
+    family: deepseek
+    tier: pro
+    routes:
+      - { via: openrouter, model: deepseek/deepseek-v4-pro:nitro }
+  - id: deepseek-v4-flash
+    label: DeepSeek V4 Flash
+    family: deepseek
+    tier: lite
+    routes:
+      - { via: openrouter, model: deepseek/deepseek-v4-flash:nitro }
+
+  # --- Mistral (native preferred, OpenRouter fallback with :nitro) ---
+  - id: mistral-large
+    label: Mistral Large
+    family: mistralai
+    tier: pro
+    routes:
+      - { via: mistral,    model: mistral-large-latest }
+      - { via: openrouter, model: mistralai/mistral-large-2512:nitro }
+  - id: mistral-medium-3.5
+    label: Mistral Medium 3.5
+    family: mistralai
+    tier: lite
+    routes:
+      - { via: mistral,    model: mistral-medium-latest }
+      - { via: openrouter, model: mistralai/mistral-medium-3-5:nitro }
+
+  # --- Moonshot Kimi (OpenRouter only) ---
+  - id: kimi-k2.6
+    label: Kimi K2.6
     family: moonshotai
     tier: pro
     routes:
-      - { via: openrouter, model: moonshotai/kimi-k2.5:nitro }
+      - { via: openrouter, model: moonshotai/kimi-k2.6:nitro }
+
+  # --- MiniMax (OpenRouter only) ---
+  - id: minimax-m2.7
+    label: MiniMax M2.7
+    family: minimax
+    tier: pro
+    routes:
+      - { via: openrouter, model: minimax/minimax-m2.7:nitro }
 
 embedding:
   # Routes under one id MUST share `dim` (vectors are not cross-compatible).

--- a/backend/topix/models.yml
+++ b/backend/topix/models.yml
@@ -1,0 +1,250 @@
+# Model catalog.
+#
+# Two registries: `providers` (who serves a model + how it's called) and the
+# model lists (`llm`, `embedding`). Each model is a canonical `id` plus an
+# ordered list of `routes`; a route says which provider serves it and under
+# what provider-specific model string. At runtime the resolver picks the first
+# route whose provider key is present (see config/catalog.py).
+#
+# Adding a model = one entry here. No code change.
+
+providers:
+  # LLM providers. `prefix` is prepended to the route's model string to form the
+  # call code consumed by agents/base.py ("openai/..." -> native client,
+  # anything else -> LiteLLM).
+  openai:     { key: OPENAI_API_KEY,     prefix: openai }
+  openrouter: { key: OPENROUTER_API_KEY, prefix: openrouter }
+  anthropic:  { key: ANTHROPIC_API_KEY,  prefix: anthropic }
+  gemini:     { key: GEMINI_API_KEY,     prefix: gemini }
+  mistral:    { key: MISTRAL_API_KEY,    prefix: mistral }
+  deepseek:   { key: DEEPSEEK_API_KEY,   prefix: deepseek }
+
+  # Search / fetch providers. No `prefix` (never used as an LLM route); listed
+  # here so the single resolver can also gate search/navigate availability.
+  linkup:     { key: LINKUP_API_KEY }
+  tavily:     { key: TAVILY_API_KEY }
+  perplexity: { key: PERPLEXITY_API_KEY }
+  exa:        { key: EXA_API_KEY }
+
+llm:
+  # --- OpenAI ---
+  - id: gpt-5.2
+    label: GPT-5.2
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5.2 }
+      - { via: openrouter, model: openai/gpt-5.2 }
+  - id: gpt-5.2-chat-latest
+    label: GPT-5.2 Chat
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5.2-chat-latest }
+      - { via: openrouter, model: openai/gpt-5.2-chat }
+  - id: gpt-5.1
+    label: GPT-5.1
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5.1 }
+      - { via: openrouter, model: openai/gpt-5.1 }
+  - id: gpt-5.1-chat-latest
+    label: GPT-5.1 Chat
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5.1-chat-latest }
+      - { via: openrouter, model: openai/gpt-5.1-chat }
+  - id: gpt-4.1
+    label: GPT-4.1
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-4.1 }
+      - { via: openrouter, model: openai/gpt-4.1 }
+  - id: gpt-4.1-mini
+    label: GPT-4.1 Mini
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-4.1-mini }
+      - { via: openrouter, model: openai/gpt-4.1-mini }
+  - id: gpt-4.1-nano
+    label: GPT-4.1 Nano
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-4.1-nano }
+      - { via: openrouter, model: openai/gpt-4.1-nano }
+  - id: gpt-5
+    label: GPT-5
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5 }
+      - { via: openrouter, model: openai/gpt-5 }
+  - id: gpt-5.4
+    label: GPT-5.4
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-5.4 }
+      - { via: openrouter, model: openai/gpt-5.4 }
+  - id: gpt-5.4-mini
+    label: GPT-5.4 Mini
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-5.4-mini }
+      - { via: openrouter, model: openai/gpt-5.4-mini }
+  - id: gpt-5.4-nano
+    label: GPT-5.4 Nano
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-5.4-nano }
+      - { via: openrouter, model: openai/gpt-5.4-nano }
+  - id: gpt-5-mini
+    label: GPT-5 Mini
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-5-mini }
+      - { via: openrouter, model: openai/gpt-5-mini }
+  - id: gpt-4o
+    label: GPT-4o
+    family: openai
+    tier: pro
+    routes:
+      - { via: openai,     model: gpt-4o }
+      - { via: openrouter, model: openai/gpt-4o }
+  - id: gpt-4o-mini
+    label: GPT-4o Mini
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     model: gpt-4o-mini }
+      - { via: openrouter, model: openai/gpt-4o-mini }
+
+  # --- Anthropic ---
+  - id: claude-opus-4.6
+    label: Claude Opus 4.6
+    family: anthropic
+    tier: pro
+    routes:
+      - { via: anthropic,  model: claude-opus-4-6 }
+      - { via: openrouter, model: anthropic/claude-opus-4.6 }
+  - id: claude-opus-4.5
+    label: Claude Opus 4.5
+    family: anthropic
+    tier: pro
+    routes:
+      - { via: anthropic,  model: claude-opus-4-5 }
+      - { via: openrouter, model: anthropic/claude-opus-4.5 }
+  - id: claude-sonnet-4.6
+    label: Claude Sonnet 4.6
+    family: anthropic
+    tier: pro
+    routes:
+      - { via: anthropic,  model: claude-sonnet-4-6 }
+      - { via: openrouter, model: anthropic/claude-sonnet-4.6 }
+  - id: claude-haiku-4.5
+    label: Claude Haiku 4.5
+    family: anthropic
+    tier: pro
+    routes:
+      - { via: anthropic,  model: claude-haiku-4-5 }
+      - { via: openrouter, model: anthropic/claude-haiku-4.5 }
+  - id: claude-opus-4.1
+    label: Claude Opus 4.1
+    family: anthropic
+    tier: lite
+    routes:
+      - { via: anthropic,  model: claude-opus-4-20250514 }
+      - { via: openrouter, model: anthropic/claude-opus-4.1 }
+
+  # --- Google Gemini ---
+  - id: gemini-2.5-pro
+    label: Gemini 2.5 Pro
+    family: google
+    tier: pro
+    routes:
+      - { via: gemini,     model: gemini-2.5-pro }
+      - { via: openrouter, model: google/gemini-2.5-pro }
+  - id: gemini-2.5-flash
+    label: Gemini 2.5 Flash
+    family: google
+    tier: lite
+    routes:
+      - { via: gemini,     model: gemini-2.5-flash }
+      - { via: openrouter, model: google/gemini-2.5-flash }
+
+  # --- Mistral ---
+  - id: mistral-large-3
+    label: Mistral Large 3
+    family: mistralai
+    tier: pro
+    routes:
+      - { via: mistral,    model: mistral-large-latest }
+      - { via: openrouter, model: mistralai/mistral-large-2512 }
+  - id: mistral-medium-3.1
+    label: Mistral Medium 3.1
+    family: mistralai
+    tier: lite
+    routes:
+      - { via: mistral,    model: mistral-medium-latest }
+      - { via: openrouter, model: mistralai/mistral-medium-3.1 }
+
+  # --- DeepSeek ---
+  - id: deepseek-v3.2
+    label: DeepSeek V3.2
+    family: deepseek
+    tier: pro
+    routes:
+      - { via: deepseek,   model: deepseek-v3.2 }
+      - { via: openrouter, model: deepseek/deepseek-v3.2 }
+  - id: deepseek-chat-v3.1
+    label: DeepSeek Chat V3.1
+    family: deepseek
+    tier: pro
+    routes:
+      - { via: deepseek,   model: deepseek-chat-v3.1 }
+      - { via: openrouter, model: deepseek/deepseek-chat-v3.1 }
+
+  # --- OpenRouter-only models (no native key wired) ---
+  - id: glm-4.7
+    label: GLM 4.7
+    family: z-ai
+    tier: lite
+    routes:
+      - { via: openrouter, model: z-ai/glm-4.7:nitro }
+  - id: qwen3.5-plus-02-15
+    label: Qwen3.5 Plus
+    family: qwen
+    tier: pro
+    routes:
+      - { via: openrouter, model: qwen/qwen3.5-plus-02-15 }
+  - id: qwen3.6-plus
+    label: Qwen3.6 Plus
+    family: qwen
+    tier: pro
+    routes:
+      - { via: openrouter, model: qwen/qwen3.6-plus-preview:free }
+  - id: kimi-k2.5
+    label: Kimi K2.5
+    family: moonshotai
+    tier: pro
+    routes:
+      - { via: openrouter, model: moonshotai/kimi-k2.5:nitro }
+
+embedding:
+  # Routes under one id MUST share `dim` (vectors are not cross-compatible).
+  # openai-native and openrouter both serve text-embedding-3-small at dim 512.
+  - id: text-embedding-3-small
+    label: OpenAI text-embedding-3-small
+    family: openai
+    dim: 512
+    routes:
+      - { via: openai,     model: text-embedding-3-small }
+      - { via: openrouter, model: openai/text-embedding-3-small }

--- a/backend/topix/nlp/embed.py
+++ b/backend/topix/nlp/embed.py
@@ -2,10 +2,11 @@
 
 import asyncio
 import logging
+import os
 
 from openai import AsyncOpenAI
 
-from topix.config.config import Config
+from topix.config import catalog
 from topix.nlp.tokens import truncate_to_tokens
 from topix.utils.timeit import async_timeit
 
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_NAME = "text-embedding-3-small"
 DIMENSIONS = 512
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 # Hard per-input limit for `text-embedding-3-small` is 8191 tokens; cap a touch
 # below it so any counting drift still lands inside the limit. Oversized inputs
@@ -22,16 +24,48 @@ MAX_EMBED_TOKENS = 8000
 
 
 class OpenAIEmbedder:
-    """A class to handle OpenAI embeddings using the OpenAI API."""
+    """Embeds text via an OpenAI-compatible endpoint (OpenAI or OpenRouter).
 
-    def __init__(self, api_key: str | None = None):
-        """Initialize the OpenAIEmbedder."""
-        self._client = AsyncOpenAI(api_key=api_key)
+    The concrete provider, model string, and vector size are resolved from the
+    model catalog based on which API keys are present.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model: str = MODEL_NAME,
+        dimensions: int = DIMENSIONS,
+    ):
+        """Initialize the embedder with a provider client, model, and vector size."""
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self.model = model
+        self.dimensions = dimensions
 
     @classmethod
     def from_config(cls):
-        """Create an instance of OpenAIEmbedder from configuration."""
-        return cls(api_key=Config.instance().run.apis.openai.api_key.get_secret_value())
+        """Create an embedder routed to the first available embedding provider."""
+        resolved = catalog.available_embedding()
+        if resolved is None:
+            raise RuntimeError(
+                "No embedding model available. Set OPENAI_API_KEY or OPENROUTER_API_KEY."
+            )
+
+        dimensions = resolved.dim or DIMENSIONS
+        if resolved.provider == "openai":
+            return cls(
+                api_key=os.getenv("OPENAI_API_KEY"),
+                model=resolved.model,
+                dimensions=dimensions,
+            )
+        if resolved.provider == "openrouter":
+            return cls(
+                api_key=os.getenv("OPENROUTER_API_KEY"),
+                base_url=OPENROUTER_BASE_URL,
+                model=resolved.model,
+                dimensions=dimensions,
+            )
+        raise RuntimeError(f"Unsupported embedding provider: {resolved.provider}")
 
     def _fit(self, text: str) -> str:
         """Clamp one text to the embedding model's per-input token limit.
@@ -64,9 +98,9 @@ class OpenAIEmbedder:
         texts = await asyncio.to_thread(self._fit_batch, texts) if needs_encode else self._fit_batch(texts)
         # Call the embeddings endpoint asynchronously
         response = await self._client.embeddings.create(
-            model=MODEL_NAME,
+            model=self.model,
             input=texts,
-            dimensions=DIMENSIONS
+            dimensions=self.dimensions
         )
         # The embeddings are in response.data, ordered same as input
         return [e.embedding for e in response.data]

--- a/backend/topix/nlp/embed.py
+++ b/backend/topix/nlp/embed.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 
 from openai import AsyncOpenAI
 
@@ -14,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 MODEL_NAME = "text-embedding-3-small"
 DIMENSIONS = 512
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 # Hard per-input limit for `text-embedding-3-small` is 8191 tokens; cap a touch
 # below it so any counting drift still lands inside the limit. Oversized inputs
@@ -32,13 +30,12 @@ class OpenAIEmbedder:
 
     def __init__(
         self,
-        api_key: str | None = None,
-        base_url: str | None = None,
+        client: AsyncOpenAI,
         model: str = MODEL_NAME,
         dimensions: int = DIMENSIONS,
     ):
         """Initialize the embedder with a provider client, model, and vector size."""
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self._client = client
         self.model = model
         self.dimensions = dimensions
 
@@ -51,21 +48,15 @@ class OpenAIEmbedder:
                 "No embedding model available. Set OPENAI_API_KEY or OPENROUTER_API_KEY."
             )
 
-        dimensions = resolved.dim or DIMENSIONS
-        if resolved.provider == "openai":
-            return cls(
-                api_key=os.getenv("OPENAI_API_KEY"),
-                model=resolved.model,
-                dimensions=dimensions,
-            )
-        if resolved.provider == "openrouter":
-            return cls(
-                api_key=os.getenv("OPENROUTER_API_KEY"),
-                base_url=OPENROUTER_BASE_URL,
-                model=resolved.model,
-                dimensions=dimensions,
-            )
-        raise RuntimeError(f"Unsupported embedding provider: {resolved.provider}")
+        client = catalog.openai_compatible_client(resolved)
+        if client is None:
+            raise RuntimeError(f"Unsupported embedding provider: {resolved.provider}")
+
+        return cls(
+            client=client,
+            model=resolved.model,
+            dimensions=resolved.dim or DIMENSIONS,
+        )
 
     def _fit(self, text: str) -> str:
         """Clamp one text to the embedding model's per-input token limit.

--- a/backend/topix/services.yml
+++ b/backend/topix/services.yml
@@ -1,56 +1,8 @@
-providers:
-  openai:
-    env_var: OPENAI_API_KEY
-  gemini:
-    env_var: GEMINI_API_KEY
-  anthropic:
-    env_var: ANTHROPIC_API_KEY
-  deepseek:
-    env_var: DEEPSEEK_API_KEY
-  openrouter:
-    env_var: OPENROUTER_API_KEY
-  linkup:
-    env_var: LINKUP_API_KEY
-  tavily:
-    env_var: TAVILY_API_KEY
-  mistralai:
-    env_var: MISTRALAI_API_KEY
-  perplexity:
-    env_var: PERPLEXITY_API_KEY
-  exa:
-    env_var: EXA_API_KEY
+# LLM models and provider keys now live in models.yml (the model catalog).
+# This file declares the non-LLM services (search / navigate / code / image),
+# gated by the same provider availability the catalog computes.
 
 services:
-  llm:
-    - gpt-5.2
-    - gpt-5.2-chat-latest
-    - gpt-5.1
-    - gpt-5.1-chat-latest
-    - gpt-4.1
-    - gpt-4.1-mini
-    - gpt-5
-    - gpt-5.4
-    - gpt-5.4-mini
-    - gpt-5.4-nano
-    - gpt-5-mini
-    - gpt-4o
-    - gpt-4o-mini
-    - claude-opus-4.6
-    - claude-opus-4.5
-    - claude-sonnet-4.6
-    - claude-haiku-4.5
-    - claude-opus-4.1
-    - gemini-2.5-pro
-    - gemini-2.5-flash
-    - mistral-large-3
-    - mistral-medium-3.1
-    - deepseek-v3.2
-    - deepseek-chat-v3.1
-    - glm-4.7
-    - qwen3.5-plus-02-15
-    - qwen3.6-plus
-    - kimi-k2.5
-
   search:
     - name: linkup
       provider: linkup

--- a/backend/topix/store/qdrant/base.py
+++ b/backend/topix/store/qdrant/base.py
@@ -21,6 +21,7 @@ from qdrant_client.models import (
     VectorParams,
 )
 
+from topix.config import catalog
 from topix.config.config import Config
 from topix.nlp.embed import DIMENSIONS
 from topix.store.qdrant.utils import payload_dict_to_field_list
@@ -76,15 +77,20 @@ class QdrantStore:
 
     async def create_collection(
         self,
-        vector_size: int = DIMENSIONS,
+        vector_size: int | None = None,
         distance: Distance = Distance.COSINE,
         force_recreate: bool = False,
         quantized: bool = True
     ) -> None:
         """Create a Qdrant collection with the specified parameters.
 
-        Supporting multiple vector storage
+        Vector size defaults to the active embedding model's dimension (from the
+        catalog) so the collection matches whatever provider serves embeddings.
         """
+        if vector_size is None:
+            emb = catalog.available_embedding()
+            vector_size = (emb.dim if emb else None) or DIMENSIONS
+
         exists = await self.client.collection_exists(self.collection)
         if force_recreate and exists:
             await self.client.delete_collection(self.collection)

--- a/backend/topix/store/qdrant/store.py
+++ b/backend/topix/store/qdrant/store.py
@@ -24,7 +24,7 @@ from qdrant_client.models import (
 
 from topix.config.config import Config, QdrantConfig
 from topix.datatypes.resource import Resource, dict_to_embeddable
-from topix.nlp.embed import DIMENSIONS, OpenAIEmbedder
+from topix.nlp.embed import OpenAIEmbedder
 from topix.store.qdrant.utils import (
     RetrieveOutput,
     convert_point,
@@ -92,15 +92,19 @@ class ContentStore:
 
     async def create_collection(
         self,
-        vector_size: int = DIMENSIONS,
+        vector_size: int | None = None,
         distance: Distance = Distance.COSINE,
         force_recreate: bool = False,
         quantized: bool = True,
     ) -> None:
         """Create a Qdrant collection with the specified parameters.
 
-        Supporting multiple vector storage
+        Vector size defaults to the active embedder's dimension so the collection
+        always matches the embeddings it will store.
         """
+        if vector_size is None:
+            vector_size = self.embedder.dimensions
+
         exists = await self.client.collection_exists(self.collection)
 
         if force_recreate and exists:
@@ -219,7 +223,7 @@ class ContentStore:
         # Fill in None embeddings with zero vectors
         for i, emb in enumerate(embeddings):
             if emb is None:
-                embeddings[i] = [[0.0] * DIMENSIONS]
+                embeddings[i] = [[0.0] * self.embedder.dimensions]
 
         return embeddings
 

--- a/model-catalog-proposal.md
+++ b/model-catalog-proposal.md
@@ -1,0 +1,265 @@
+# Proposal: Simplified model catalog so Dim0 runs on minimal API keys
+
+**Status:** implemented (branch `feat/model-catalog-minimal-keys`), for review
+
+## Implementation status (what landed)
+
+- **Step 1 — catalog + resolver:** `backend/topix/models.yml` (providers + `llm` + `embedding`, route-based) and `backend/topix/config/catalog.py` (`resolve` / `available_llms` / `available_embedding` / `resolve_code` / `normalize_code` / `default_model_code` / `default_resolved`). `config/services.py` now sources LLMs + provider availability from the catalog; `services.yml` keeps only search/navigate/code/image. Unit tests in `test/unit/config/test_catalog.py` (9, passing).
+- **Step 2 — auto-model + no hardcoded providers:** `manager.py` picks tier-based models from the catalog; `auto_model.py` classifier uses the best available lite model (OpenAI or OpenRouter client); `agents/config.py:validate_model` and `BaseAgent.__post_init__` route every model string through `normalize_code` (this transparently fixes the ~7 aux agents that defaulted to `ModelEnum.OpenAI.*`). YAML configs switched to canonical ids; deep-research auto default de-hardcoded in `chats.py`.
+- **Step 3 — embeddings via routes:** `nlp/embed.py` resolves its provider (OpenAI native or OpenRouter base_url) from `catalog.available_embedding()`. Vector dim stays 512 (same model on both routes), so Qdrant wiring is untouched.
+- **Step 4 — navigate no hard-fail:** already satisfied — `AssistantManagerConfig.from_yaml` guards disable navigate/code/image to `None` when no provider, so nothing raises. The keyless/Linkup fetch remains a separate follow-up PR.
+- **Step 5 — key-aware default tools:** `chat-store.ts:syncDefaults` already gated default `enabledTools` on availability; the only gap fixed was the image-gen toggle, now disabled when OpenRouter is absent (matching code-interpreter).
+- **Step 6 — dynamic model list:** `/utils/services` returns full model objects (`id`/`label`/`family`/`tier`/`provider`); frontend `llm.ts` dropped the hardcoded `LlmModels`/`LlmName`/`LlmFamilyMap`/… in favor of backend-driven rendering (`familyIcon`/`familyLabel` with fallbacks), `LlmModel` relaxed to `string`, picker groups by backend `family`.
+
+Verified: catalog resolves correctly for OpenAI-only / OpenRouter-only / multi-key / no-key; backend `529 + 9` unit tests pass; frontend `tsc` + `eslint` clean.
+
+---
+
+
+**Goal:** Let a self-hoster run Dim0 with just **OpenAI + Linkup** *or* **OpenRouter + Linkup** and have everything "just work" — chat, embeddings/memory, auto-model, web search, and URL fetch — with the model list auto-syncing to whatever keys are present.
+
+This proposal covers **only the API-key painpoint**. The infra painpoint (Postgres + Qdrant + Redis) is out of scope.
+
+---
+
+## 1. Problem
+
+Today a working deploy effectively needs **OpenAI + OpenRouter + Linkup**, because three things are wired to specific providers:
+
+1. **Embeddings are hard-pinned to OpenAI.** `nlp/embed.py` has one embedder (`OpenAIEmbedder`, `text-embedding-3-small`, 512-dim), instantiated unconditionally. Every note write and chat message embeds (via `store/graph.py`, `store/chat.py` → Qdrant); `memory_search` embeds the query. There is no fallback. → "OpenRouter + Linkup, no OpenAI" breaks on the **first note write**.
+
+2. **Auto-model is hardcoded to specific providers.** `agents/assistant/manager.py`:
+   ```python
+   AUTO_MODEL_BASE_PLAN    = "openrouter/deepseek/deepseek-v4-flash:nitro"   # needs OpenRouter
+   AUTO_MODEL_COMPLEX_PLAN = ModelEnum.OpenAI.GPT_5_4                        # needs OpenAI
+   ```
+   The complexity classifier (`agents/assistant/auto_model.py`) also calls a hardcoded OpenRouter model. → Auto-model silently assumes **both** keys exist. OpenAI-only breaks the base plan; OpenRouter-only breaks the complex plan.
+
+3. **Navigate (fetch URL) hard-requires Tavily.** `agents/websearch/fetch.py` → `tools.py` calls `https://api.tavily.com/extract`, and the config validator (`agents/config.py:~86`) raises if no navigate provider is present. Neither target key-set includes Tavily. → Even "OpenAI + Linkup" trips this.
+
+A secondary issue: the **data structure** for models is flat and bakes in exactly two routes per model (`model` = native, `openrouter_model` = the single fallback). It can't cleanly express "this model is reachable through N providers, each with a slightly different string name," and it makes OpenRouter a special case rather than just another provider.
+
+### What already works (don't rebuild)
+
+- `config/services.py:_sync()` already filters providers by `os.getenv(env_var)` — only providers with a key load.
+- The OpenRouter fallback already exists (`_get_llm_services`, ~line 174): missing native key + present `OPENROUTER_API_KEY` ⇒ model kept with `use_openrouter=True`, `code` becomes `openrouter/<openrouter_model>`.
+- `GET /utils/services` (`api/router/utils.py:69-80`) already returns the key-filtered list.
+- The frontend already overlays availability and gates unavailable models with a lock icon.
+- **OpenRouter now supports embeddings** (2026): `POST /api/v1/embeddings`, OpenAI-compatible, exposing `text-embedding-3-*`, Gemini Embedding, Qwen, etc. ⇒ embeddings can use the same routing as chat; no local embedder required.
+
+---
+
+## 2. Core idea: separate the *model* from the *route*
+
+Model the catalog as **canonical model → ordered list of routes**, with a small **provider registry** that owns the key + call convention. One resolver turns `(catalog, keys-present)` into a flat list of available models. That single list feeds every consumer.
+
+This directly answers "which provider, and what string on that provider": the per-provider string lives in the route; the resolver just prepends the provider prefix.
+
+### New file: `backend/topix/models.yml`
+
+Replaces `llm_models.yml` and folds the provider→env-var map in from `services.yml`.
+
+```yaml
+providers:
+  openai:     { key: OPENAI_API_KEY,     prefix: openai }
+  openrouter: { key: OPENROUTER_API_KEY, prefix: openrouter }
+  anthropic:  { key: ANTHROPIC_API_KEY,  prefix: anthropic }
+  gemini:     { key: GEMINI_API_KEY,     prefix: gemini }
+  mistral:    { key: MISTRAL_API_KEY,    prefix: mistral }
+  deepseek:   { key: DEEPSEEK_API_KEY,   prefix: deepseek }
+
+llm:
+  - id: gpt-5.4              # stable id used by API + frontend; never changes
+    name: GPT-5.4
+    family: openai           # icon / grouping
+    tier: pro                # consumed by auto-model
+    routes:                  # preferred first
+      - { via: openai,     name: gpt-5.4 }
+      - { via: openrouter, name: openai/gpt-5.4 }
+
+  - id: gpt-5.4-mini
+    name: GPT-5.4 Mini
+    family: openai
+    tier: lite
+    routes:
+      - { via: openai,     name: gpt-5.4-mini }
+      - { via: openrouter, name: openai/gpt-5.4-mini }
+
+  - id: claude-opus-4.6
+    name: Claude Opus 4.6
+    family: anthropic
+    tier: pro
+    routes:
+      - { via: anthropic,  name: claude-opus-4-6 }
+      - { via: openrouter, name: anthropic/claude-opus-4.6 }
+
+embedding:
+  - id: text-embedding-3-small
+    dim: 512                 # routes under one id MUST share dim (vector compatibility)
+    routes:
+      - { via: openai,     name: text-embedding-3-small }
+      - { via: openrouter, name: openai/text-embedding-3-small }
+```
+
+Adding/removing a model = one YAML entry. No code change.
+
+### New file: `backend/topix/config/catalog.py` (~40 lines)
+
+```python
+@dataclass
+class Resolved:
+    id: str
+    name: str
+    family: str
+    tier: str            # "pro" | "lite" (llm only)
+    provider: str        # the chosen route's provider
+    call: str            # what base.py/embedder uses: "openrouter/anthropic/claude-opus-4.6"
+    dim: int | None = None   # embedding only
+    available: bool = True
+
+
+def resolve(model) -> Resolved | None:
+    """First route whose provider key is present wins; None means hidden."""
+    for r in model.routes:
+        p = providers[r.via]
+        if os.getenv(p.key):
+            return Resolved(**model.meta, provider=r.via,
+                            call=f"{p.prefix}/{r.name}", dim=getattr(model, "dim", None))
+    return None
+
+
+def available_llms() -> list[Resolved]:
+    return [r for m in catalog.llm if (r := resolve(m))]
+
+
+def available_embedding() -> Resolved | None:
+    for m in catalog.embedding:
+        if (r := resolve(m)):
+            return r
+    return None
+```
+
+`call` is exactly the format `agents/base.py:58-63` already consumes (`openai/...` → native OpenAI client; anything else → `LitellmModel`). The OpenRouter embeddings route uses the same OpenAI SDK with `base_url=https://openrouter.ai/api/v1`.
+
+**Resolved object shape returned to all consumers:**
+```jsonc
+{ "id": "claude-opus-4.6", "name": "Claude Opus 4.6", "family": "anthropic",
+  "tier": "pro", "provider": "openrouter",
+  "call": "openrouter/anthropic/claude-opus-4.6", "available": true }
+```
+
+---
+
+## 3. Changes — 6 small, sequenced steps
+
+### Step 1 — Catalog + resolver (foundation)
+- **Add** `backend/topix/models.yml`, `backend/topix/config/catalog.py`.
+- **Migrate** `llm_models.yml` → `models.yml` mechanically (see §4).
+- **Rewire** `config/services.py` so `service_config.llm` is backed by `available_llms()`. Keep `services.yml`'s `search` / `navigate` / `code` / `image_generation` sections as-is — **do not** unify those (not worth the churn).
+- `agents/config.py:validate_model` keeps working: it validates against `service_config.llm` and falls back to the first available — unchanged behavior, new backing list.
+
+### Step 2 — Auto-model stops hardcoding (`agents/assistant/manager.py`)
+- Replace the two `AUTO_MODEL_*` constants with selection from `available_llms()`:
+  - `smart = first model with tier == "pro"`
+  - `fast  = first model with tier == "lite"`  (catalog order = preference)
+  - classifier (`auto_model.py`) reuses `fast` instead of its hardcoded OpenRouter model; if no lite model exists, skip classification and default to `smart`.
+- Result: auto-model works on OpenAI-only **or** OpenRouter-only.
+
+### Step 3 — Embeddings via routes (`nlp/embed.py`, Qdrant setup)
+- `Embedder` resolves its route from `available_embedding()`:
+  - provider `openai` → native `AsyncOpenAI`.
+  - provider `openrouter` → `AsyncOpenAI(base_url="https://openrouter.ai/api/v1", api_key=OPENROUTER_API_KEY)` (OpenAI-compatible embeddings endpoint).
+- Drive the Qdrant collection vector size from the resolved `dim` (`store/qdrant/setup.py` / `store.py`) instead of the hardcoded 512.
+- **Constraint to document:** the embedding model is fixed per deployment. Switching providers for the *same* id (openai ↔ openrouter, both 512) is safe; switching to a different id/dim requires a re-index. This is fine for fresh OSS deploys.
+- **Unlocks "OpenRouter + Linkup, no OpenAI."**
+
+### Step 4 — Navigate: stop hard-failing (`agents/config.py`)
+Scope here is **only** removing the hard requirement; the actual fetch revamp is a separate PR (see §5).
+- Relax the navigate validator (`agents/config.py:~86`) so a missing Tavily key no longer raises. With no navigate provider, `navigate` resolves as unavailable and the tool is simply disabled — exactly like `code` / `image_generation` already degrade.
+- Net effect for minimal-key deploys: the app **runs**; URL-fetch is just off until the follow-up PR adds a keyless / Linkup fetch.
+
+### Step 5 — Key-aware default tools (`features/agent/store/chat-store.ts`)
+Today the frontend seeds a fixed `enabledTools` list (`chat-store.ts:47-63`) with *every* tool on, regardless of whether its backing service has a key; some toggles (e.g. image-gen) don't even check availability. Make defaults follow availability, reusing the same `/utils/services` data the model picker already consumes.
+- In `syncDefaults` (`chat-store.ts:87-142`), a tool is **default-enabled only if its service resolves**:
+  - `web_search` → only if `services.search` non-empty (engine defaults to first available)
+  - `code_interpreter` → only if `services.code[0].available` (Daytona)
+  - `image_generation` → only if `services.image_generation[0].available` (OpenRouter)
+  - `navigate` → only if `services.navigate` non-empty
+  - `memory_search` → board-scoped (already)
+  - board tools (`write_note` / `edit_note` / `get_note` / `link_notes`) and keyless widgets (`display_*`, `learn_*`) → always on
+- Every tool toggle shows a lock/disabled state when unavailable (the model picker already does this; bring the image-gen toggle in line — it currently skips the check, per the TODO in `image-gen.tsx`).
+- Backend already wires tools conditionally; this just stops the UI from defaulting-on tools that can't run.
+
+### Step 6 — Frontend dynamic model list (`features/agent`)
+- **Backend:** extend `GET /utils/services` (or add `/models`) to return the full Resolved objects (`id`, `name`, `family`, `tier`, `available`) rather than just `code` strings.
+- **Frontend:**
+  - Drop the hardcoded `LlmModels` union (`types/llm.ts:14-44`) and the parallel `LlmName` / `LlmDescription` maps; render whatever the backend returns, grouped by `family`.
+  - Relax `LlmModel` type from a string-literal union → `string`.
+  - Keep `LlmFamilyIcon` (`types/llm.ts:~196-206`) as a brand-icon lookup with a **generic fallback** for unknown families.
+  - Availability gating (lock icons), provider grouping, storage, and request transmission already work — no change.
+  - Optional: activate the already-defined-but-unused tier badges.
+
+---
+
+## 4. Migration (mechanical)
+
+For each entry in `llm_models.yml`:
+- native route ← `{ via: <provider>, name: <model> }`
+- if `openrouter_model` present ← add `{ via: openrouter, name: <openrouter_model> }`
+- if absent but OR fallback desired ← `{ via: openrouter, name: "<provider>/<model>" }` (mirrors today's `self.openrouter_model or f"{provider}/{model}"`).
+
+`tier` already exists on every entry — it just starts being *used* (Step 2). Provider→env-var map moves from `services.yml` into `models.yml`'s `providers` block.
+
+---
+
+## 5. Explicitly out of scope (keep it simple)
+
+- **Web-search / fetch revamp** — a keyless `httpx` + readability fetch *and* a Linkup-based fetch are a **separate follow-up PR** that reworks the web-search/fetch tools. This PR only stops `navigate` from hard-failing (Step 4) so minimal-key deploys boot; it does not implement a new fetch path.
+- **Local/ONNX embedder** — unnecessary now that OpenRouter serves embeddings. Add later only if someone wants fully keyless RAG.
+- **Unifying search/navigate/code/image into the routes catalog** — they stay on their current simpler config; only `llm` + `embedding` use routes.
+- **Live provider `/models` auto-discovery** — curated catalog stays the source of truth. A `make models-sync` dev script that validates each route's `name` against provider `/models` endpoints (and LiteLLM's built-in name map) can come later as a maintenance aid, not a runtime mechanism.
+
+---
+
+## 6. Result
+
+| Keys present | Chat | Embeddings / memory | Auto-model | Web search | Navigate |
+|---|---|---|---|---|---|
+| **OpenAI + Linkup** | OpenAI native | OpenAI | OpenAI tiers | Linkup | off unless Tavily set¹ |
+| **OpenRouter + Linkup** | all via OpenRouter | via OpenRouter | OpenRouter tiers | Linkup | off unless Tavily set¹ |
+| OpenAI + OpenRouter + Linkup (today) | both | OpenAI | both | Linkup | Tavily |
+
+¹ `navigate` no longer hard-fails; it's just disabled when no fetch provider is configured. The follow-up web-search/fetch PR adds a keyless / Linkup fetch so it works with zero extra keys.
+
+Steps 1–3 make it **run** on minimal keys (the core goal). Step 4 removes the last hard-fail. Step 5 makes tool defaults honest about what's actually available. Step 6 delivers the auto-sync model UX.
+
+---
+
+## 7. Open questions
+
+1. **Embedding default** — confirm: route through `openai` then `openrouter`, no local fallback for v1? (Recommended: yes.)
+2. **Provider env-var names** — `.env.sample` currently has `MISTRAL_API_KEY` but `services.yml` references `MISTRALAI_API_KEY`; standardize when moving into `models.yml`.
+3. **`/models` vs extend `/utils/services`** — add a dedicated endpoint or widen the existing one? (Recommended: widen existing to avoid a new route + frontend fetch.)
+4. **Image generation** with OpenAI-only — leave disabled (OpenRouter-only feature), or add an OpenAI image route? (Recommended: leave disabled for v1.)
+
+---
+
+## 8. Key file references
+
+| Concern | File | Notes |
+|---|---|---|
+| Static model list | `backend/topix/llm_models.yml` | → replaced by `models.yml` |
+| Provider env-var map, llm filtering, OR fallback | `backend/topix/config/services.py` (`_sync` ~98–148, `_get_llm_services` ~150–182, `LLMService.code` ~54–61) | rewire to `catalog.py` |
+| Model → agent instantiation | `backend/topix/agents/base.py:58-63` | consumes `call` unchanged |
+| Model validation/fallback | `backend/topix/agents/config.py:37-49` | unchanged behavior |
+| Auto-model hardcoded picks | `backend/topix/agents/assistant/manager.py` (~37–38, ~109–119) | Step 2 |
+| Complexity classifier | `backend/topix/agents/assistant/auto_model.py` | Step 2 |
+| Embedder (OpenAI-pinned) | `backend/topix/nlp/embed.py:14-24` | Step 3 |
+| Qdrant collection dim | `backend/topix/store/qdrant/setup.py`, `store/qdrant/store.py` (~87) | Step 3 |
+| Navigate hard-fail validator | `agents/config.py:~86` | Step 4 (fetch impl deferred to follow-up PR) |
+| Frontend tool defaults | `webui/src/features/agent/store/chat-store.ts` (defaults ~47–63, `syncDefaults` ~87–142) | Step 5 |
+| Per-tool toggles (incl. image-gen TODO) | `webui/src/features/agent/components/chat/input-settings/` | Step 5 |
+| Services endpoint | `backend/topix/api/router/utils.py:69-80` | Step 6 |
+| Frontend hardcoded model list | `webui/src/features/agent/types/llm.ts:14-44`, family icons ~196–206 | Step 6 |
+| Frontend availability overlay | `webui/src/features/agent/api/list-available-services.ts:26-70` | Step 6 |
+| Model picker UI | `webui/src/features/agent/components/chat/input-settings/model-card.tsx:68-178` | Step 6 |

--- a/webui/src/components/icons/index.ts
+++ b/webui/src/components/icons/index.ts
@@ -90,6 +90,7 @@ export {
   MapPinIcon,
   MemorySearchIcon,
   MistralBrandIcon,
+  MinimaxBrandIcon,
   MinusIcon,
   MonitorIcon,
   MoonIcon,

--- a/webui/src/components/icons/registry.ts
+++ b/webui/src/components/icons/registry.ts
@@ -1,4 +1,4 @@
-import { Claude, DeepSeek, Exa, Gemini, Mistral, Moonshot, OpenAI, Perplexity, Qwen, Tavily, ZAI } from "@lobehub/icons"
+import { Claude, DeepSeek, Exa, Gemini, Minimax, Mistral, Moonshot, OpenAI, Perplexity, Qwen, Tavily, ZAI } from "@lobehub/icons"
 import {
   ArrowUpIcon,
   ArticleIcon,
@@ -200,6 +200,7 @@ export const MailIcon = createPhosphorIcon(EnvelopeIcon)
 export const MapPinIcon = createPhosphorIcon(MapPinGlyphIcon)
 export const MemorySearchIcon = createPhosphorIcon(CircuitryIcon)
 export const MistralBrandIcon = createReactIcon(Mistral.Color)
+export const MinimaxBrandIcon = createReactIcon(Minimax.Color)
 export const MinusIcon = createPhosphorIcon(MinusGlyphIcon)
 export const MonitorIcon = createPhosphorIcon(MonitorGlyphIcon)
 export const MoonIcon = createPhosphorIcon(MoonGlyphIcon)

--- a/webui/src/features/agent/api/list-available-services.ts
+++ b/webui/src/features/agent/api/list-available-services.ts
@@ -1,15 +1,27 @@
 import { apiFetch } from "@/api"
 import { useQuery } from "@tanstack/react-query"
-import { defaultServices, type Services } from "../types/services"
+import { AUTO_LLM_OPTION, defaultServices, type Services } from "../types/services"
 import { useChatStore } from "../store/chat-store"
 import { useEffect } from "react"
+
+
+/**
+ * One reachable model as served by the backend catalog.
+ */
+export interface AvailableLlm {
+  id: string
+  label: string
+  family: string
+  tier?: string
+  provider?: string
+}
 
 
 /**
  * Response structure for listing available services.
  */
 export interface ListAvailableServicesResponse {
-  llm: string[]
+  llm: AvailableLlm[]
   search: string[]
   navigate: string[]
   code: string[]
@@ -30,10 +42,19 @@ const updateDefaultServices = ({
 }): Services => {
   // This function can be used to update the DefaultServices constant
   const services: Services = defaultServices()
-  services.llm = services.llm.map((service) => ({
-    ...service,
-    available: availableServices.llm.includes(service.name),
-  }))
+  // The backend returns exactly the reachable models; render them as-is, with
+  // the synthetic "auto" option always first.
+  services.llm = [
+    AUTO_LLM_OPTION,
+    ...availableServices.llm.map((model) => ({
+      name: model.id,
+      label: model.label,
+      family: model.family,
+      tier: model.tier,
+      provider: model.provider,
+      available: true,
+    })),
+  ]
   services.search = services.search.map((service) => ({
     ...service,
     available: availableServices.search.includes(service.name),

--- a/webui/src/features/agent/components/chat/input-settings/image-gen.tsx
+++ b/webui/src/features/agent/components/chat/input-settings/image-gen.tsx
@@ -2,14 +2,21 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ImageGenerationIcon } from "@/components/icons"
 import { useChatStore } from "@/features/agent/store/chat-store"
 import { clsx } from "clsx"
+import { useShallow } from "zustand/shallow"
 
-// Component that allows users to enable or disable the memory search tool
+// Component that allows users to enable or disable the image generation tool
 export const ImageGenMenu = () => {
-  const { enabledTools, setEnabledTools } = useChatStore()
+  const imageService = useChatStore(
+    useShallow((state) => state.services.imageGeneration.find((s) => s.name === "openrouter")),
+  )
+  const enabledTools = useChatStore(useShallow((state) => state.enabledTools))
+  const setEnabledTools = useChatStore((state) => state.setEnabledTools)
 
   const isEnabled = enabledTools.includes("image_generation")
+  const isAvailable = imageService?.available || false
 
   const handleToggle = () => {
+    if (!isAvailable) return
     if (isEnabled) {
       setEnabledTools(enabledTools.filter(tool => tool !== "image_generation"))
     } else {
@@ -17,10 +24,13 @@ export const ImageGenMenu = () => {
     }
   }
 
-  const tooltipText = isEnabled ? "Disable Image Generation" : "Enable Image Generation"
+  const tooltipText = isAvailable
+    ? (isEnabled ? "Disable Image Generation" : "Enable Image Generation")
+    : "Image Generation Unavailable"
 
   const buttonClass = clsx(
-    "transition-all w-full my-icon px-2 py-1.5 rounded-md hover:bg-accent dark:hover:bg-accent/50 border border-transparent hover:border-border transition-colors flex flex-row items-center gap-2 text-left text-muted-foreground"
+    "transition-all w-full my-icon px-2 py-1.5 rounded-md hover:bg-accent dark:hover:bg-accent/50 border border-transparent hover:border-border transition-colors flex flex-row items-center gap-2 text-left text-muted-foreground",
+    !isAvailable && "opacity-50 cursor-not-allowed pointer-events-none",
   )
   const iconClass = clsx(
     "size-4 shrink-0",
@@ -34,6 +44,7 @@ export const ImageGenMenu = () => {
           <button
             className={buttonClass}
             onClick={handleToggle}
+            disabled={!isAvailable}
           >
             <ImageGenerationIcon className={iconClass} strokeWidth={2} />
             <span className="text-xs">Image generation</span>

--- a/webui/src/features/agent/components/chat/input-settings/model-card.tsx
+++ b/webui/src/features/agent/components/chat/input-settings/model-card.tsx
@@ -1,62 +1,38 @@
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger } from "@/components/ui/select"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useChatStore } from "@/features/agent/store/chat-store"
 import {
-  LlmDescription,
-  LlmName,
-  type LlmModel,
-  LlmFamilyMap,
-  LlmFamilyIcon,
-  type LlmFamily,
+  familyIcon,
+  familyLabel,
 } from "@/features/agent/types/llm"
+import type { LlmOption } from "@/features/agent/types/services"
 import { LockIcon } from "@/components/icons"
 import { clsx } from "clsx"
 import { useShallow } from "zustand/shallow"
-
-/**
- * Optional: pretty labels for families
- */
-const LlmFamilyLabel: Record<LlmFamily, string> = {
-  dim0: "Dim0",
-  openai: "OpenAI",
-  google: "Google Gemini",
-  anthropic: "Anthropic Claude",
-  mistralai: "Mistral",
-  deepseek: "DeepSeek",
-  "z-ai": "Z.ai",
-  qwen: "Qwen",
-  moonshotai: "Moonshot",
-}
 
 type ModelChoiceMenuProps = {
   display?: "icon" | "row"
 }
 
 /**
- * ModelCard is a component that displays the name and description of a LLM model
- * in a hover card format. It is used within the ModelChoiceMenu to provide
- * additional information about each model.
+ * ModelCard renders a model's label, with an optional tier hint, and dims it
+ * when the model is unavailable.
  */
-const ModelCard: React.FC<{ model: LlmModel; available?: boolean }> = ({ model, available }) => {
+const ModelCard: React.FC<{ model: LlmOption }> = ({ model }) => {
   const clss = clsx(
     "flex-1 flex flex-row items-center gap-2 justify-between truncate",
-    available === false ? "text-muted-foreground cursor-not-allowed pointer-events-none" : "",
+    model.available === false ? "text-muted-foreground cursor-not-allowed pointer-events-none" : "",
   )
 
   return (
-    <HoverCard openDelay={200}>
-      <HoverCardTrigger className={clss}>
-        <span className="truncate">{LlmName[model]}</span>
-      </HoverCardTrigger>
-      <HoverCardContent
-        className="w-48 rounded-lg border border-border bg-popover text-popover-foreground shadow text-sm"
-        side="left"
-        sideOffset={15}
-      >
-        <div>{LlmDescription[model]}</div>
-      </HoverCardContent>
-    </HoverCard>
+    <div className={clss}>
+      <span className="truncate">{model.label}</span>
+      {model.tier && (
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {model.tier}
+        </span>
+      )}
+    </div>
   )
 }
 
@@ -73,22 +49,23 @@ export const ModelChoiceMenu = ({ display = "icon" }: ModelChoiceMenuProps) => {
   )
 
   const handleModelChange = (value: string) => {
-    setLlmModel(value as LlmModel)
+    setLlmModel(value)
   }
 
-  // Group models by family
-  const modelsByFamily: Partial<Record<LlmFamily, typeof availableModels>> = {}
+  // Group models by family (order preserved from the backend catalog)
+  const modelsByFamily: Record<string, typeof availableModels> = {}
   for (const model of availableModels) {
-    const family = LlmFamilyMap[model.name]
-    if (!family) continue
+    const family = model.family || "dim0"
     if (!modelsByFamily[family]) {
       modelsByFamily[family] = []
     }
-    modelsByFamily[family]!.push(model)
+    modelsByFamily[family].push(model)
   }
 
-  const currentFamily = LlmFamilyMap[llmModel]
-  const CurrentFamilyIcon = LlmFamilyIcon[currentFamily]
+  const currentModel = availableModels.find((model) => model.name === llmModel)
+  const currentFamily = currentModel?.family ?? "dim0"
+  const CurrentFamilyIcon = familyIcon(currentFamily)
+  const currentLabel = currentModel?.label ?? llmModel
   const isRow = display === "row"
   const triggerClassName = isRow
     ? "w-full rounded-md text-xs px-2 py-1.5 shadow-none hover:bg-accent [&>svg:not(.my-icon)]:hidden border border-transparent hover:border-border transition-colors justify-start gap-2 text-muted-foreground"
@@ -107,7 +84,7 @@ export const ModelChoiceMenu = ({ display = "icon" }: ModelChoiceMenuProps) => {
                   isRow ? (
                     <>
                       <CurrentFamilyIcon size={16} />
-                      <span className="text-xs truncate">Core LLM ({LlmName[llmModel]})</span>
+                      <span className="text-xs truncate">Core LLM ({currentLabel})</span>
                     </>
                   ) : (
                     <CurrentFamilyIcon size={16} />
@@ -128,19 +105,17 @@ export const ModelChoiceMenu = ({ display = "icon" }: ModelChoiceMenuProps) => {
             </SelectLabel>
           </SelectGroup>
 
-          {(
-            Object.keys(modelsByFamily) as LlmFamily[]
-          ).map((family) => {
+          {Object.keys(modelsByFamily).map((family) => {
             const familyModels = modelsByFamily[family]
             if (!familyModels || familyModels.length === 0) return null
 
-            const FamilyIcon = LlmFamilyIcon[family]
+            const FamilyIcon = familyIcon(family)
 
             return (
               <SelectGroup key={family} className="mt-1">
                 <SelectLabel className="flex flex-row items-center gap-2 text-xs font-medium">
                   <FamilyIcon size={16} />
-                  <span>{LlmFamilyLabel[family]}</span>
+                  <span>{familyLabel(family)}</span>
                 </SelectLabel>
 
                 {familyModels.map((model) => {
@@ -158,7 +133,7 @@ export const ModelChoiceMenu = ({ display = "icon" }: ModelChoiceMenuProps) => {
                       className={clName}
                       disabled={!model.available}
                     >
-                      <ModelCard model={model.name} available={model.available} />
+                      <ModelCard model={model} />
                       {!model.available && (
                         <LockIcon
                           className="size-4 absolute right-2 top-1/2 -translate-y-1/2"

--- a/webui/src/features/agent/store/chat-store.ts
+++ b/webui/src/features/agent/store/chat-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand"
 import type { ToolName } from "../types/stream"
 import type { LlmModel } from "../types/llm"
 import type { WebSearchEngine } from "../types/web"
-import { defaultServices, type Services } from "../types/services"
+import { AUTO_LLM_OPTION, defaultServices, type Services } from "../types/services"
 
 const DEFAULT_LLM_MODEL: LlmModel = "auto"
 
@@ -88,7 +88,7 @@ export const useChatStore = create<ChatStore>((set) => ({
     const servicesWithAuto: Services = {
       ...services,
       llm: [
-        { name: "auto", available: true, provider: "dim0" },
+        AUTO_LLM_OPTION,
         ...services.llm.filter((service) => service.name !== "auto"),
       ],
     }

--- a/webui/src/features/agent/types/llm.ts
+++ b/webui/src/features/agent/types/llm.ts
@@ -4,6 +4,7 @@ import {
   DeepSeekBrandIcon,
   Dim0Icon,
   GeminiBrandIcon,
+  MinimaxBrandIcon,
   MistralBrandIcon,
   MoonshotBrandIcon,
   OpenAIBrandIcon,
@@ -34,6 +35,7 @@ export const LlmFamilyIcon: Record<string, AppIconComponent> = {
   "z-ai": ZAiBrandIcon,
   qwen: QwenBrandIcon,
   moonshotai: MoonshotBrandIcon,
+  minimax: MinimaxBrandIcon,
 }
 
 
@@ -41,13 +43,14 @@ export const LlmFamilyIcon: Record<string, AppIconComponent> = {
 export const LlmFamilyLabel: Record<string, string> = {
   dim0: "Dim0",
   openai: "OpenAI",
-  google: "Google Gemini",
+  google: "Google Gemma",
   anthropic: "Anthropic Claude",
   mistralai: "Mistral",
   deepseek: "DeepSeek",
   "z-ai": "Z.ai",
   qwen: "Qwen",
   moonshotai: "Moonshot",
+  minimax: "MiniMax",
 }
 
 

--- a/webui/src/features/agent/types/llm.ts
+++ b/webui/src/features/agent/types/llm.ts
@@ -11,189 +11,20 @@ import {
   ZAiBrandIcon,
 } from "@/components/icons"
 
-export const LlmModels = [
-  "auto",
-  "openai/gpt-5.2",
-  "openai/gpt-5.2-chat-latest",
-  "openai/gpt-5.1",
-  "openai/gpt-5.1-chat-latest",
-  "openai/gpt-4o",
-  "openai/gpt-4.1",
-  "openai/gpt-5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.4-mini",
-  "openai/gpt-5.4-nano",
-  "openai/gpt-5-mini",
-  "openai/gpt-5-nano",
-  "openrouter/anthropic/claude-opus-4.6",
-  "openrouter/anthropic/claude-opus-4.5",
-  "openrouter/anthropic/claude-opus-4.1",
-  "openrouter/anthropic/claude-sonnet-4.6",
-  "openrouter/anthropic/claude-haiku-4.5",
-  "openrouter/google/gemini-3-pro-preview",
-  "openrouter/google/gemini-2.5-pro",
-  "openrouter/google/gemini-2.5-flash",
-  "openrouter/mistralai/mistral-large-2512",
-  "openrouter/mistralai/mistral-medium-3.1",
-  "openrouter/deepseek/deepseek-v3.2",
-  "openrouter/deepseek/deepseek-chat-v3.1",
-  "openrouter/z-ai/glm-4.7:nitro",
-  "openrouter/qwen/qwen3.5-plus-02-15",
-  "openrouter/qwen/qwen3.6-plus-preview:free",
-  "openrouter/moonshotai/kimi-k2.5:nitro"
-] as const
-
-export type LlmModel = typeof LlmModels[number]
-
-export const LlmName: Record<LlmModel, string> = {
-  "auto": "Auto",
-  "openai/gpt-5.2": "GPT-5.2",
-  "openai/gpt-5.2-chat-latest": "GPT-5.2 Chat",
-  "openai/gpt-5.1-chat-latest": "GPT-5.1 Chat",
-  "openai/gpt-5.1": "GPT-5.1",
-  "openai/gpt-4o": "GPT-4o",
-  "openai/gpt-4.1": "GPT-4.1",
-  "openai/gpt-5": "GPT-5",
-  "openai/gpt-5.4": "GPT-5.4",
-  "openai/gpt-5.4-mini": "GPT-5.4 Mini",
-  "openai/gpt-5.4-nano": "GPT-5.4 Nano",
-  "openai/gpt-5-mini": "GPT-5 Mini",
-  "openai/gpt-5-nano": "GPT-5 Nano",
-  "openrouter/google/gemini-3-pro-preview": "Gemini 3 Pro Preview",
-  "openrouter/google/gemini-2.5-pro": "Gemini 2.5 Pro",
-  "openrouter/google/gemini-2.5-flash": "Gemini 2.5 Flash",
-  "openrouter/anthropic/claude-opus-4.6": "Claude Opus 4.6",
-  "openrouter/anthropic/claude-opus-4.5": "Claude Opus 4.5",
-  "openrouter/anthropic/claude-opus-4.1": "Claude Opus 4.1",
-  "openrouter/anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
-  "openrouter/anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
-  "openrouter/mistralai/mistral-large-2512": "Mistral Large",
-  "openrouter/mistralai/mistral-medium-3.1": "Mistral Medium",
-  "openrouter/deepseek/deepseek-v3.2": "DeepSeek",
-  "openrouter/deepseek/deepseek-chat-v3.1": "DeepSeek Chat",
-  "openrouter/z-ai/glm-4.7:nitro": "GLM-4.7",
-  "openrouter/qwen/qwen3.5-plus-02-15": "Qwen 3.5 Plus",
-  "openrouter/qwen/qwen3.6-plus-preview:free": "Qwen 3.6 Plus Preview",
-  "openrouter/moonshotai/kimi-k2.5:nitro": "Kimi K2.5"
-}
-
-export const LlmDescription: Record<LlmModel, string> = {
-  "auto": "Choose the best model per task complexity",
-  "openai/gpt-5.2": "Next-generation model offering advanced reasoning and broader skill coverage",
-  "openai/gpt-5.2-chat-latest": "Latest GPT-5.2 model optimized for chat applications with enhanced capabilities",
-  "openai/gpt-5.1": "Next-generation model offering advanced reasoning and broader skill coverage",
-  "openai/gpt-5.1-chat-latest": "Latest GPT-5.1 model optimized for chat applications with enhanced capabilities",
-  "openai/gpt-4o": "High-quality, fast, and capable model with strong reasoning and low latency",
-  "openai/gpt-4.1": "Enhanced GPT-4 model with balanced performance across reasoning and creativity",
-  "openai/gpt-5": "Next-generation model offering advanced reasoning and broader skill coverage",
-  "openai/gpt-5.4": "Latest GPT-5.4 model offering advanced reasoning and broader skill coverage",
-  "openai/gpt-5.4-mini": "Compact GPT-5.4 variant optimized for efficiency and responsiveness",
-  "openai/gpt-5.4-nano": "Ultra-light GPT-5.4 variant ideal for quick or edge tasks",
-  "openai/gpt-5-mini": "Compact GPT-5 version optimized for efficiency and responsiveness",
-  "openai/gpt-5-nano": "Ultra-light GPT-5 variant ideal for quick or edge tasks",
-  "openrouter/google/gemini-3-pro-preview": "Cutting-edge Gemini model with advanced reasoning and multimodal capabilities",
-  "openrouter/google/gemini-2.5-pro": "Powerful Gemini model designed for professional applications with enhanced understanding",
-  "openrouter/google/gemini-2.5-flash": "Lightweight Gemini variant optimized for speed and efficiency",
-  "openrouter/anthropic/claude-opus-4.6": "Top-tier Claude model known for its long-context reasoning and safety alignment",
-  "openrouter/anthropic/claude-opus-4.5": "Top-tier Claude model known for its long-context reasoning and safety alignment",
-  "openrouter/anthropic/claude-opus-4.1": "Top-tier Claude model known for its long-context reasoning and safety alignment",
-  "openrouter/anthropic/claude-sonnet-4.6": "Balanced Claude model combining speed with nuanced understanding",
-  "openrouter/anthropic/claude-haiku-4.5": "Lightweight and responsive Claude variant suited for everyday tasks",
-  "openrouter/mistralai/mistral-large-2512": "Powerful Mistral model excelling in complex reasoning and creativity",
-  "openrouter/mistralai/mistral-medium-3.1": "Efficient Mistral model offering strong multilingual and structured reasoning",
-  "openrouter/deepseek/deepseek-v3.2": "Advanced open-source model with strong performance across various tasks",
-  "openrouter/deepseek/deepseek-chat-v3.1": "High-performance open-source model with advanced reasoning and adaptability",
-  "openrouter/z-ai/glm-4.7:nitro": "Fast general-purpose model from Z.ai with strong reasoning and coding ability",
-  "openrouter/qwen/qwen3.5-plus-02-15": "Versatile Qwen model tuned for strong multilingual reasoning and tool use",
-  "openrouter/qwen/qwen3.6-plus-preview:free": "Preview of Qwen 3.6 with stronger reasoning, agentic behavior, and coding performance",
-  "openrouter/moonshotai/kimi-k2.5:nitro": "Fast Moonshot model tuned for stronger reasoning, coding, and agentic tasks"
-}
+// A model is identified by its canonical catalog id (e.g. "claude-opus-4.6"),
+// plus the synthetic "auto" option. The available models and their metadata are
+// served by the backend (GET /utils/services), so this is an open string rather
+// than a hardcoded union.
+export type LlmModel = string
 
 
-export const LlmTiers = ["Rapid", "Balanced", "Elite"] as const
-export type LlmTier = typeof LlmTiers[number]
+// Provider family, used for grouping and brand icons. Open string: unknown
+// families coming from the backend fall back to a generic icon/label.
+export type LlmFamily = string
 
 
-export const LlmBadge: Record<LlmModel, LlmTier> = {
-  "auto": "Balanced",
-  "openai/gpt-5.2": "Elite",
-  "openai/gpt-5.2-chat-latest": "Elite",
-  "openai/gpt-5.1-chat-latest": "Elite",
-  "openai/gpt-5.1": "Elite",
-  "openai/gpt-4o": "Balanced",
-  "openai/gpt-4.1": "Balanced",
-  "openai/gpt-5": "Elite",
-  "openai/gpt-5.4": "Elite",
-  "openai/gpt-5.4-mini": "Rapid",
-  "openai/gpt-5.4-nano": "Rapid",
-  "openai/gpt-5-mini": "Rapid",
-  "openai/gpt-5-nano": "Rapid",
-  "openrouter/google/gemini-3-pro-preview": "Elite",
-  "openrouter/google/gemini-2.5-pro": "Elite",
-  "openrouter/google/gemini-2.5-flash": "Rapid",
-  "openrouter/anthropic/claude-opus-4.6": "Elite",
-  "openrouter/anthropic/claude-opus-4.5": "Elite",
-  "openrouter/anthropic/claude-opus-4.1": "Elite",
-  "openrouter/anthropic/claude-sonnet-4.6": "Balanced",
-  "openrouter/anthropic/claude-haiku-4.5": "Rapid",
-  "openrouter/mistralai/mistral-large-2512": "Elite",
-  "openrouter/mistralai/mistral-medium-3.1": "Balanced",
-  "openrouter/deepseek/deepseek-v3.2": "Balanced",
-  "openrouter/deepseek/deepseek-chat-v3.1": "Balanced",
-  "openrouter/z-ai/glm-4.7:nitro": "Balanced",
-  "openrouter/qwen/qwen3.5-plus-02-15": "Balanced",
-  "openrouter/qwen/qwen3.6-plus-preview:free": "Balanced",
-  "openrouter/moonshotai/kimi-k2.5:nitro": "Balanced"
-}
-
-export const LlmFamilies = [
-  "dim0",
-  "openai",
-  "google",
-  "anthropic",
-  "mistralai",
-  "deepseek",
-  "z-ai",
-  "qwen",
-  "moonshotai"
-]
-
-export type LlmFamily = typeof LlmFamilies[number]
-
-export const LlmFamilyMap: Record<LlmModel, LlmFamily> = {
-  "auto": "dim0",
-  "openai/gpt-5.2": "openai",
-  "openai/gpt-5.2-chat-latest": "openai",
-  "openai/gpt-5.1-chat-latest": "openai",
-  "openai/gpt-5.1": "openai",
-  "openai/gpt-4o": "openai",
-  "openai/gpt-4.1": "openai",
-  "openai/gpt-5": "openai",
-  "openai/gpt-5.4": "openai",
-  "openai/gpt-5.4-mini": "openai",
-  "openai/gpt-5.4-nano": "openai",
-  "openai/gpt-5-mini": "openai",
-  "openai/gpt-5-nano": "openai",
-  "openrouter/google/gemini-3-pro-preview": "google",
-  "openrouter/google/gemini-2.5-pro": "google",
-  "openrouter/google/gemini-2.5-flash": "google",
-  "openrouter/anthropic/claude-opus-4.6": "anthropic",
-  "openrouter/anthropic/claude-opus-4.5": "anthropic",
-  "openrouter/anthropic/claude-opus-4.1": "anthropic",
-  "openrouter/anthropic/claude-sonnet-4.6": "anthropic",
-  "openrouter/anthropic/claude-haiku-4.5": "anthropic",
-  "openrouter/mistralai/mistral-large-2512": "mistralai",
-  "openrouter/mistralai/mistral-medium-3.1": "mistralai",
-  "openrouter/deepseek/deepseek-v3.2": "deepseek",
-  "openrouter/deepseek/deepseek-chat-v3.1": "deepseek",
-  "openrouter/z-ai/glm-4.7:nitro": "z-ai",
-  "openrouter/qwen/qwen3.5-plus-02-15": "qwen",
-  "openrouter/qwen/qwen3.6-plus-preview:free": "qwen",
-  "openrouter/moonshotai/kimi-k2.5:nitro": "moonshotai"
-}
-
-
-export const LlmFamilyIcon: Record<LlmFamily, AppIconComponent> = {
+// Known brand icons by family. Unknown families fall back via familyIcon().
+export const LlmFamilyIcon: Record<string, AppIconComponent> = {
   dim0: Dim0Icon,
   openai: OpenAIBrandIcon,
   google: GeminiBrandIcon,
@@ -202,5 +33,35 @@ export const LlmFamilyIcon: Record<LlmFamily, AppIconComponent> = {
   deepseek: DeepSeekBrandIcon,
   "z-ai": ZAiBrandIcon,
   qwen: QwenBrandIcon,
-  moonshotai: MoonshotBrandIcon
+  moonshotai: MoonshotBrandIcon,
+}
+
+
+// Pretty labels by family; unknown families fall back to the raw family string.
+export const LlmFamilyLabel: Record<string, string> = {
+  dim0: "Dim0",
+  openai: "OpenAI",
+  google: "Google Gemini",
+  anthropic: "Anthropic Claude",
+  mistralai: "Mistral",
+  deepseek: "DeepSeek",
+  "z-ai": "Z.ai",
+  qwen: "Qwen",
+  moonshotai: "Moonshot",
+}
+
+
+/**
+ * Resolve a family's brand icon, falling back to the Dim0 icon when unknown.
+ */
+export function familyIcon(family: string): AppIconComponent {
+  return LlmFamilyIcon[family] ?? Dim0Icon
+}
+
+
+/**
+ * Resolve a family's display label, falling back to the raw family string.
+ */
+export function familyLabel(family: string): string {
+  return LlmFamilyLabel[family] ?? family
 }

--- a/webui/src/features/agent/types/services.ts
+++ b/webui/src/features/agent/types/services.ts
@@ -1,5 +1,3 @@
-import type { LlmModel } from "./llm"
-
 /**
  * Represents a service option with its availability and provider.
  */
@@ -9,8 +7,14 @@ export interface ServiceOption {
   provider?: string
 }
 
+/**
+ * A selectable LLM, carrying the display metadata the picker needs. `name` is
+ * the canonical model id sent back to the backend (or "auto").
+ */
 export interface LlmOption extends ServiceOption {
-  name: LlmModel
+  label: string
+  family: string
+  tier?: string
 }
 
 
@@ -37,38 +41,19 @@ export type ServiceName = typeof SERVICE_NAMES[number]
  *
  * Note: All services are marked as unavailable by default.
  */
+export const AUTO_LLM_OPTION: LlmOption = {
+  name: "auto",
+  label: "Auto",
+  family: "dim0",
+  provider: "dim0",
+  available: true,
+}
+
+
 export const defaultServices: () => Services = () => ({
-  llm: [
-    { name: "auto", available: true, provider: "dim0" },
-    { name: "openai/gpt-5.2", available: false, provider: "openai" },
-    { name: "openai/gpt-5.2-chat-latest", available: false, provider: "openai" },
-    { name: "openai/gpt-5.1", available: false, provider: "openai" },
-    { name: "openai/gpt-5.1-chat-latest", available: false, provider: "openai" },
-    { name: "openai/gpt-5.4", available: false, provider: "openai" },
-    { name: "openai/gpt-5.4-mini", available: false, provider: "openai" },
-    { name: "openai/gpt-5.4-nano", available: false, provider: "openai" },
-    // { name: "openai/gpt-5", available: false, provider: "openai" },
-    // { name: "openai/gpt-5-mini", available: false, provider: "openai" },
-    // { name: "openai/gpt-5-nano", available: false, provider: "openai" },
-    // { name: "openai/gpt-4.1", available: false, provider: "openai" },
-    // { name: "openai/gpt-4o", available: false, provider: "openai" },
-    { name: "openrouter/anthropic/claude-opus-4.6", available: false, provider: "openrouter" },
-    // { name: "openrouter/anthropic/claude-opus-4.5", available: false, provider: "openrouter" },
-    // { name: "openrouter/anthropic/claude-opus-4.1", available: false, provider: "openrouter" },
-    { name: "openrouter/anthropic/claude-sonnet-4.6", available: false, provider: "openrouter" },
-    { name: "openrouter/anthropic/claude-haiku-4.5", available: false, provider: "openrouter" },
-    { name: "openrouter/google/gemini-3-pro-preview", available: false, provider: "openrouter" },
-    { name: "openrouter/google/gemini-2.5-pro", available: false, provider: "openrouter" },
-    { name: "openrouter/google/gemini-2.5-flash", available: false, provider: "openrouter" },
-    { name: "openrouter/mistralai/mistral-large-2512", available: false, provider: "openrouter" },
-    { name: "openrouter/mistralai/mistral-medium-3.1", available: false, provider: "openrouter" },
-    { name: "openrouter/deepseek/deepseek-v3.2", available: false, provider: "openrouter" },
-    // { name: "openrouter/deepseek/deepseek-chat-v3.1", available: false, provider: "openrouter" },
-    { name: "openrouter/z-ai/glm-4.7:nitro", available: false, provider: "openrouter" },
-    { name: "openrouter/qwen/qwen3.5-plus-02-15", available: false, provider: "openrouter" },
-    // { name: "openrouter/qwen/qwen3.6-plus-preview:free", available: false, provider: "openrouter" },
-    { name: "openrouter/moonshotai/kimi-k2.5:nitro", available: false, provider: "openrouter" },
-  ],
+  // The real model list is filled in from the backend (keys-aware); only the
+  // synthetic "auto" option is known client-side.
+  llm: [AUTO_LLM_OPTION],
   search: [
     { name: "linkup", available: false, provider: "linkup" },
     { name: "exa", available: false, provider: "exa" },


### PR DESCRIPTION
## Why

Self-hosting Dim0 today effectively needs **three** keys — OpenAI **and** OpenRouter **and** Linkup — because embeddings, auto-model, and several agents are wired to specific providers. This makes the app run on **minimal keys**: **OpenAI + Linkup** *or* **OpenRouter + Linkup**, auto-syncing the available models to whichever keys are present.

(Infra simplification — Postgres + Qdrant + Redis — is out of scope; this PR is only the API-key painpoint.)

## Approach

Introduce one abstraction — a **route-based model catalog**. Each canonical model declares an ordered list of routes (`{ via: provider, model: "<provider-specific id>" }`); a resolver returns the first route whose provider key is present. The same mechanism powers LLMs, embeddings, auto-model, and the frontend picker.

```yaml
- id: claude-opus-4.6
  label: Claude Opus 4.6
  family: anthropic
  tier: pro
  routes:
    - { via: anthropic,  model: claude-opus-4-6 }      # preferred when key present
    - { via: openrouter, model: anthropic/claude-opus-4.6 }
```

## What changed

- **Catalog + resolver** — `backend/topix/models.yml` (providers + `llm` + `embedding`) and `config/catalog.py` (`resolve` / `normalize_code` / `available_llms` / `available_embedding` / `default_resolved`). `config/services.py` sources LLMs + provider availability from the catalog; `services.yml` trimmed to search/navigate/code/image.
- **No hardcoded providers** — `validate_model` and `BaseAgent.__post_init__` route every model string through `normalize_code`, so ids, call codes, and legacy `provider/model` codes all map to a reachable route (transparently fixes the ~7 aux agents that defaulted to OpenAI-only models). Auto-model + the complexity classifier select by tier from available models instead of hardcoded ids.
- **Embeddings via routes** — `nlp/embed.py` resolves the embedding provider (OpenAI native or OpenRouter `base_url`). Vector dim stays 512 (same model on both routes), so Qdrant is untouched. **This is what unlocks "OpenRouter + Linkup, no OpenAI".**
- **Dynamic model picker** — `/utils/services` returns full model metadata (`id`/`label`/`family`/`tier`/`provider`); the frontend drops the hardcoded `LlmModels`/`LlmName`/`LlmFamilyMap` and renders the picker from the backend (`familyIcon`/`familyLabel` with fallbacks). Image-gen toggle now gated on availability.
- **Fixes** `MISTRAL_API_KEY` vs `MISTRALAI_API_KEY` mismatch (native Mistral never resolved before); clarifies `.env.sample` minimal-key guidance.

## Out of scope (follow-up)

- **Web-search / fetch revamp** — a keyless `httpx`+readability fetch and a Linkup fetch. This PR only ensures `navigate` degrades gracefully when no fetch provider is set (already the case); it doesn't add a new fetch path.

## Result

| Keys present | Chat | Embeddings | Auto-model | Search | Navigate |
| --- | --- | --- | --- | --- | --- |
| **OpenAI + Linkup** | OpenAI | OpenAI | OpenAI tiers | Linkup | off unless Tavily¹ |
| **OpenRouter + Linkup** | all via OpenRouter | via OpenRouter | OpenRouter tiers | Linkup | off unless Tavily¹ |

¹ `navigate` no longer hard-fails; disabled when no fetch provider is configured. The follow-up adds a keyless / Linkup fetch.

## Testing

- New `backend/test/unit/config/test_catalog.py` (9 tests): no-keys / OpenAI-only / OpenRouter-only / native-preferred / tier defaults / `normalize_code` id+code+legacy.
- Updated `test_manager.py` for tier-based auto-model.
- Full backend unit suite green (**529 passed**); frontend `tsc` + `eslint` clean.
- Manually verified embedder routing for OpenAI-only / OpenRouter-only / no-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
