### PR TITLE
feat(board): make code node language-aware with runnable-gated sandbox

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,6 +24,16 @@ OPENROUTER_API_KEY=
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=
+# Optional per-runtime-family sandbox images (selected by note language).
+# python runs on the python family; javascript + typescript on the node
+# family. If unset, a declarative default image is built on first use
+# (node family installs ts-node globally). Point these at pre-warmed
+# snapshots in production for faster cold starts. <FAMILY> = PYTHON | NODE.
+# Legacy DAYTONA_SNAPSHOT / DAYTONA_IMAGE still work and apply to python.
+# DAYTONA_SNAPSHOT_PYTHON=
+# DAYTONA_SNAPSHOT_NODE=
+# DAYTONA_IMAGE_PYTHON=
+# DAYTONA_IMAGE_NODE=
 # for websearch
 # one of the keys for image search should be set
 LINKUP_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -25,11 +25,11 @@ DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=
 # Optional per-runtime-family sandbox images (selected by note language).
-# python runs on the python family; javascript + typescript on the node
-# family. If unset, a declarative default image is built on first use
-# (node family installs ts-node globally). Point these at pre-warmed
-# snapshots in production for faster cold starts. <FAMILY> = PYTHON | NODE.
-# Legacy DAYTONA_SNAPSHOT / DAYTONA_IMAGE still work and apply to python.
+# python runs on the python family; javascript on the node family. If unset,
+# a declarative default image is built on first use (node:20-slim for the
+# node family). Point these at pre-warmed snapshots in production for faster
+# cold starts. <FAMILY> = PYTHON | NODE. Legacy DAYTONA_SNAPSHOT /
+# DAYTONA_IMAGE still work and apply to python.
 # DAYTONA_SNAPSHOT_PYTHON=
 # DAYTONA_SNAPSHOT_NODE=
 # DAYTONA_IMAGE_PYTHON=

--- a/backend/test/unit/agents/assistant/test_code.py
+++ b/backend/test/unit/agents/assistant/test_code.py
@@ -239,3 +239,103 @@ async def test_execute_code_rejects_non_runnable_language(monkeypatch):
 
     assert result.status == "error"
     assert "not runnable" in result.stderr
+
+
+# === Runtime-family image resolution =====================================
+
+
+_IMAGE_ENV_VARS = (
+    "DAYTONA_SNAPSHOT",
+    "DAYTONA_IMAGE",
+    "DAYTONA_SNAPSHOT_PYTHON",
+    "DAYTONA_IMAGE_PYTHON",
+    "DAYTONA_SNAPSHOT_NODE",
+    "DAYTONA_IMAGE_NODE",
+)
+
+
+def _make_manager(monkeypatch) -> "code_module.DaytonaSandboxManager":
+    """Build a manager with a stubbed Daytona client and clean image env."""
+    monkeypatch.setenv("DAYTONA_API_KEY", "configured")
+    monkeypatch.setenv("DAYTONA_API_URL", "https://example.test")
+    monkeypatch.setenv("DAYTONA_TARGET", "eu")
+    for env_var in _IMAGE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(code_module, "AsyncDaytona", lambda config: object())
+    return code_module.DaytonaSandboxManager()
+
+
+def test_language_family_mapping():
+    """js/ts share the node family; python maps to python; unknown defaults."""
+    assert code_module._family_for("python") == "python"
+    assert code_module._family_for("javascript") == "node"
+    assert code_module._family_for("typescript") == "node"
+    assert code_module._family_for("rust") == code_module.DEFAULT_FAMILY
+
+
+def test_node_default_image_installs_ts_node():
+    """The node family's default image bundles node + a global ts-node."""
+    dockerfile = code_module._default_family_image("node").dockerfile()
+    assert "node:20-slim" in dockerfile
+    assert "ts-node" in dockerfile
+
+    python_dockerfile = code_module._default_family_image("python").dockerfile()
+    assert "ts-node" not in python_dockerfile
+
+
+def test_resolve_source_prefers_family_snapshot_env(monkeypatch):
+    """A family-specific snapshot env wins for that family."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setenv("DAYTONA_SNAPSHOT_NODE", "node-snap")
+
+    assert manager._resolve_source("node") == ("snapshot", "node-snap")
+
+
+def test_resolve_source_falls_back_to_family_image_env(monkeypatch):
+    """A family-specific image env is used when no snapshot env is set."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setenv("DAYTONA_IMAGE_NODE", "registry/node-img:latest")
+
+    assert manager._resolve_source("node") == ("image", "registry/node-img:latest")
+
+
+def test_resolve_source_legacy_global_scoped_to_python(monkeypatch):
+    """Legacy global vars feed python only; node falls to its default image."""
+    _make_manager(monkeypatch)
+    monkeypatch.setenv("DAYTONA_SNAPSHOT", "legacy-snap")
+    # Construct after setting the legacy var (cached in __init__).
+    manager = code_module.DaytonaSandboxManager()
+
+    assert manager._resolve_source("python") == ("snapshot", "legacy-snap")
+
+    node_kind, node_source = manager._resolve_source("node")
+    assert node_kind == "image"
+    assert not isinstance(node_source, str)  # declarative Image, not the snapshot
+
+
+def test_resolve_source_defaults_to_declarative_image(monkeypatch):
+    """With nothing configured, each family resolves to its default image."""
+    manager = _make_manager(monkeypatch)
+
+    kind, source = manager._resolve_source("python")
+    assert kind == "image"
+    assert not isinstance(source, str)
+
+
+@pytest.mark.asyncio
+async def test_create_typescript_uses_node_family_image(monkeypatch):
+    """create('typescript') runs the ts toolbox on a node-family image."""
+    client = RecordingDaytonaClient()
+    monkeypatch.setenv("DAYTONA_API_KEY", "configured")
+    monkeypatch.setenv("DAYTONA_API_URL", "https://example.test")
+    monkeypatch.setenv("DAYTONA_TARGET", "eu")
+    for env_var in _IMAGE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(code_module, "AsyncDaytona", lambda config: client)
+
+    manager = code_module.DaytonaSandboxManager()
+    await manager.create("typescript")
+
+    params = client.params[0]
+    assert params.language == "typescript"
+    assert "ts-node" in params.image.dockerfile()

--- a/backend/test/unit/agents/assistant/test_code.py
+++ b/backend/test/unit/agents/assistant/test_code.py
@@ -266,21 +266,19 @@ def _make_manager(monkeypatch) -> "code_module.DaytonaSandboxManager":
 
 
 def test_language_family_mapping():
-    """js/ts share the node family; python maps to python; unknown defaults."""
+    """Javascript maps to the node family; python to python; unknown defaults."""
     assert code_module._family_for("python") == "python"
     assert code_module._family_for("javascript") == "node"
-    assert code_module._family_for("typescript") == "node"
     assert code_module._family_for("rust") == code_module.DEFAULT_FAMILY
 
 
-def test_node_default_image_installs_ts_node():
-    """The node family's default image bundles node + a global ts-node."""
+def test_node_default_image_is_node_base():
+    """The node family's default image is a plain node base (runs javascript)."""
     dockerfile = code_module._default_family_image("node").dockerfile()
     assert "node:20-slim" in dockerfile
-    assert "ts-node" in dockerfile
 
     python_dockerfile = code_module._default_family_image("python").dockerfile()
-    assert "ts-node" not in python_dockerfile
+    assert "node" not in python_dockerfile
 
 
 def test_resolve_source_prefers_family_snapshot_env(monkeypatch):
@@ -323,8 +321,8 @@ def test_resolve_source_defaults_to_declarative_image(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_typescript_uses_node_family_image(monkeypatch):
-    """create('typescript') runs the ts toolbox on a node-family image."""
+async def test_create_javascript_uses_node_family_image(monkeypatch):
+    """create('javascript') runs the js toolbox on a node-family image."""
     client = RecordingDaytonaClient()
     monkeypatch.setenv("DAYTONA_API_KEY", "configured")
     monkeypatch.setenv("DAYTONA_API_URL", "https://example.test")
@@ -334,8 +332,8 @@ async def test_create_typescript_uses_node_family_image(monkeypatch):
     monkeypatch.setattr(code_module, "AsyncDaytona", lambda config: client)
 
     manager = code_module.DaytonaSandboxManager()
-    await manager.create("typescript")
+    await manager.create("javascript")
 
     params = client.params[0]
-    assert params.language == "typescript"
-    assert "ts-node" in params.image.dockerfile()
+    assert params.language == "javascript"
+    assert "node:20-slim" in params.image.dockerfile()

--- a/backend/test/unit/agents/assistant/test_code.py
+++ b/backend/test/unit/agents/assistant/test_code.py
@@ -59,10 +59,12 @@ class FakeSandboxManager:
         """Prepare the sandbox returned by create calls."""
         self.sandbox = FakeSandbox(response)
         self.create_calls = 0
+        self.create_languages: list[str] = []
 
-    async def create(self) -> FakeSandbox:
-        """Create and return the fake sandbox."""
+    async def create(self, language: str = "python") -> FakeSandbox:
+        """Create and return the fake sandbox, recording the requested language."""
         self.create_calls += 1
+        self.create_languages.append(language)
         return self.sandbox
 
     async def destroy(self, sandbox: FakeSandbox) -> None:
@@ -189,3 +191,51 @@ async def test_daytona_sandbox_manager_applies_short_lived_sandbox_defaults(monk
     assert params.ephemeral is True
     assert params.auto_delete_interval == 0
     assert client.timeouts == [code_module.SANDBOX_CREATE_TIMEOUT_SECONDS]
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_uses_requested_language(monkeypatch):
+    """The requested language should select the matching Daytona toolbox."""
+    client = RecordingDaytonaClient()
+    monkeypatch.setenv("DAYTONA_API_KEY", "configured")
+    monkeypatch.setenv("DAYTONA_API_URL", "https://example.test")
+    monkeypatch.setenv("DAYTONA_TARGET", "eu")
+    monkeypatch.setattr(code_module, "AsyncDaytona", lambda config: client)
+
+    manager = code_module.DaytonaSandboxManager()
+    await manager.create("javascript")
+
+    assert client.params[0].language == "javascript"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_runs_in_requested_language(monkeypatch):
+    """A runnable language should reach the sandbox via create(language)."""
+    for env_var in code_module.REQUIRED_DAYTONA_ENV_VARS:
+        monkeypatch.setenv(env_var, "configured")
+
+    manager = FakeSandboxManager(FakeResponse(stdout="3\n", exit_code=0))
+    monkeypatch.setattr(code_module, "DaytonaSandboxManager", lambda: manager)
+
+    result = await code_module.execute_code("console.log(1 + 2)", "javascript")
+
+    assert result.status == "success"
+    assert result.stdout == "3\n"
+    assert manager.create_languages == ["javascript"]
+
+
+@pytest.mark.asyncio
+async def test_execute_code_rejects_non_runnable_language(monkeypatch):
+    """Languages without a Daytona toolbox should error before any sandbox."""
+    for env_var in code_module.REQUIRED_DAYTONA_ENV_VARS:
+        monkeypatch.setenv(env_var, "configured")
+
+    def _fail():
+        raise AssertionError("sandbox should not be created for non-runnable language")
+
+    monkeypatch.setattr(code_module, "DaytonaSandboxManager", _fail)
+
+    result = await code_module.execute_code("int main(){}", "c")
+
+    assert result.status == "error"
+    assert "not runnable" in result.stderr

--- a/backend/topix/agents/assistant/code.py
+++ b/backend/topix/agents/assistant/code.py
@@ -44,6 +44,41 @@ REQUIRED_DAYTONA_ENV_VARS = (
 RUNNABLE_LANGUAGES = frozenset({"python", "javascript", "typescript"})
 DEFAULT_LANGUAGE = "python"
 
+# Each runnable language maps to a *runtime family* — the toolchain its
+# sandbox image must carry. Several languages can share one family (and so
+# one image): javascript + typescript both run on Node. The image is
+# selected per family, not per language, so adding a language that reuses an
+# existing runtime is free.
+LANGUAGE_FAMILY: dict[str, str] = {
+    "python": "python",
+    "javascript": "node",
+    "typescript": "node",
+}
+DEFAULT_FAMILY = "python"
+
+
+def _family_for(language: str) -> str:
+    """Return the runtime family (shared image) for a runnable language."""
+    return LANGUAGE_FAMILY.get(language, DEFAULT_FAMILY)
+
+
+def _default_family_image(family: str) -> Image:
+    """Build the declarative fallback image for a runtime family.
+
+    Daytona content-addresses and caches the built image, so it's built once
+    then reused. Only used when no ``DAYTONA_SNAPSHOT_<FAMILY>`` /
+    ``DAYTONA_IMAGE_<FAMILY>`` (or, for python, the legacy global vars) is
+    configured — production should point those at pre-warmed snapshots.
+    """
+    if family == "node":
+        # Node serves both javascript and typescript. ts-node + typescript
+        # are installed globally because the runtime sandbox has no network
+        # (`network_block_all`), so `npx` cannot fetch them at run time.
+        return Image.base("node:20-slim").run_commands(
+            "npm install -g ts-node typescript",
+        )
+    return Image.debian_slim("3.13")
+
 
 class DaytonaSandboxManager:
     """Create and tear down a Daytona sandbox for a single code execution."""
@@ -74,26 +109,50 @@ class DaytonaSandboxManager:
             "ephemeral": True,
         }
 
+    def _resolve_source(self, family: str) -> tuple[str, object]:
+        """Resolve the sandbox source for a runtime family.
+
+        Returns ``("snapshot", name)`` or ``("image", image)`` where image is
+        a registry name or a declarative ``Image``. Precedence:
+          1. ``DAYTONA_SNAPSHOT_<FAMILY>`` (pre-warmed snapshot)
+          2. ``DAYTONA_IMAGE_<FAMILY>`` (registry image name)
+          3. legacy global ``DAYTONA_SNAPSHOT`` / ``DAYTONA_IMAGE`` — scoped to
+             the python family only, since they predate per-language support
+             and only ever ran python (keeps existing deploys unchanged)
+          4. the declarative default image for the family
+        """
+        suffix = family.upper()
+        snapshot = os.getenv(f"DAYTONA_SNAPSHOT_{suffix}")
+        if snapshot:
+            return "snapshot", snapshot
+
+        image = os.getenv(f"DAYTONA_IMAGE_{suffix}")
+        if image:
+            return "image", image
+
+        if family == DEFAULT_FAMILY:
+            if self._snapshot:
+                return "snapshot", self._snapshot
+            if self._image:
+                return "image", self._image
+
+        return "image", _default_family_image(family)
+
     async def create(self, language: str = DEFAULT_LANGUAGE) -> AsyncSandbox:
-        """Create a sandbox configured for ``language``'s code toolbox."""
-        if self._snapshot:
-            params = CreateSandboxFromSnapshotParams(
-                snapshot=self._snapshot,
-                **self._sandbox_kwargs(language),
-            )
-            return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
+        """Create a sandbox configured for ``language``'s code toolbox.
 
-        if self._image:
-            params = CreateSandboxFromImageParams(
-                image=self._image,
-                **self._sandbox_kwargs(language),
-            )
-            return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
+        The image is selected by the language's runtime family; the
+        ``language`` kwarg still selects Daytona's per-language toolbox.
+        """
+        family = _family_for(language)
+        kind, source = self._resolve_source(family)
+        kwargs = self._sandbox_kwargs(language)
 
-        params = CreateSandboxFromImageParams(
-            image=Image.debian_slim("3.13"),
-            **self._sandbox_kwargs(language),
-        )
+        if kind == "snapshot":
+            params = CreateSandboxFromSnapshotParams(snapshot=source, **kwargs)
+        else:
+            params = CreateSandboxFromImageParams(image=source, **kwargs)
+
         return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
 
     async def destroy(self, sandbox: AsyncSandbox) -> None:

--- a/backend/topix/agents/assistant/code.py
+++ b/backend/topix/agents/assistant/code.py
@@ -36,6 +36,14 @@ REQUIRED_DAYTONA_ENV_VARS = (
     "DAYTONA_TARGET",
 )
 
+# Languages Daytona can actually execute via its built-in code toolboxes
+# (`process.code_run`). These values match Daytona's `CodeLanguage` enum
+# verbatim, so they pass straight through to sandbox creation. Any other
+# language is a display-only code note — the UI hides the run affordance
+# and this module never sees an execute request for it.
+RUNNABLE_LANGUAGES = frozenset({"python", "javascript", "typescript"})
+DEFAULT_LANGUAGE = "python"
+
 
 class DaytonaSandboxManager:
     """Create and tear down a Daytona sandbox for a single code execution."""
@@ -52,34 +60,39 @@ class DaytonaSandboxManager:
         self._image = os.getenv("DAYTONA_IMAGE")
         self._snapshot = os.getenv("DAYTONA_SNAPSHOT")
 
-    def _sandbox_kwargs(self) -> dict[str, object]:
-        """Return shared sandbox creation defaults for short-lived code runs."""
+    def _sandbox_kwargs(self, language: str) -> dict[str, object]:
+        """Return shared sandbox creation defaults for short-lived code runs.
+
+        ``language`` selects Daytona's code toolbox (the command used by
+        ``code_run``); the configured image/snapshot must carry the matching
+        runtime (e.g. Node for javascript/typescript).
+        """
         return {
-            "language": "python",
+            "language": language,
             "auto_stop_interval": SANDBOX_AUTO_STOP_INTERVAL_MINUTES,
             "network_block_all": True,
             "ephemeral": True,
         }
 
-    async def create(self) -> AsyncSandbox:
-        """Create a sandbox for the current execution."""
+    async def create(self, language: str = DEFAULT_LANGUAGE) -> AsyncSandbox:
+        """Create a sandbox configured for ``language``'s code toolbox."""
         if self._snapshot:
             params = CreateSandboxFromSnapshotParams(
                 snapshot=self._snapshot,
-                **self._sandbox_kwargs(),
+                **self._sandbox_kwargs(language),
             )
             return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
 
         if self._image:
             params = CreateSandboxFromImageParams(
                 image=self._image,
-                **self._sandbox_kwargs(),
+                **self._sandbox_kwargs(language),
             )
             return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
 
         params = CreateSandboxFromImageParams(
             image=Image.debian_slim("3.13"),
-            **self._sandbox_kwargs(),
+            **self._sandbox_kwargs(language),
         )
         return await self._client.create(params, timeout=SANDBOX_CREATE_TIMEOUT_SECONDS)
 
@@ -88,7 +101,11 @@ class DaytonaSandboxManager:
         await sandbox.delete(timeout=CODE_RUN_TIMEOUT_SECONDS)
 
     async def run_code(self, sandbox: AsyncSandbox, code: str) -> tuple[str, str]:
-        """Execute Python code inside the sandbox and capture stdio."""
+        """Execute code inside the sandbox and capture stdio.
+
+        The language was fixed at create time via the sandbox's code toolbox,
+        so this just runs whatever the agent/user wrote against it.
+        """
         response = await sandbox.process.code_run(
             code,
             timeout=CODE_RUN_TIMEOUT_SECONDS,
@@ -119,9 +136,25 @@ def _get_missing_daytona_env_vars() -> list[str]:
     return [name for name in REQUIRED_DAYTONA_ENV_VARS if not os.getenv(name)]
 
 
-async def execute_python_code(code: str) -> CodeInterpreterOutput:
-    """Run Python code in an isolated Daytona sandbox and return execution results."""
+async def execute_code(
+    code: str,
+    language: str = DEFAULT_LANGUAGE,
+) -> CodeInterpreterOutput:
+    """Run code in an isolated Daytona sandbox and return execution results.
+
+    ``language`` must be one of ``RUNNABLE_LANGUAGES``; anything else is
+    rejected up front since Daytona has no toolbox to execute it.
+    """
     started_at = time.perf_counter()
+
+    if language not in RUNNABLE_LANGUAGES:
+        return CodeInterpreterOutput(
+            status="error",
+            stdout="",
+            stderr=f"Language '{language}' is not runnable.",
+            duration_ms=int((time.perf_counter() - started_at) * 1000),
+        )
+
     missing_env_vars = _get_missing_daytona_env_vars()
 
     if missing_env_vars:
@@ -142,7 +175,7 @@ async def execute_python_code(code: str) -> CodeInterpreterOutput:
 
     async with CODE_RUN_SEMAPHORE:
         try:
-            sandbox = await sandbox_manager.create()
+            sandbox = await sandbox_manager.create(language)
             stdout, stderr = await sandbox_manager.run_code(sandbox, code)
         except TimeoutError:
             stderr = (
@@ -166,6 +199,11 @@ async def execute_python_code(code: str) -> CodeInterpreterOutput:
         stderr=stderr,
         duration_ms=duration_ms,
     )
+
+
+async def execute_python_code(code: str) -> CodeInterpreterOutput:
+    """Run Python code in an isolated Daytona sandbox (agent-tool entrypoint)."""
+    return await execute_code(code, language="python")
 
 
 async def run_code(

--- a/backend/topix/agents/assistant/code.py
+++ b/backend/topix/agents/assistant/code.py
@@ -41,18 +41,17 @@ REQUIRED_DAYTONA_ENV_VARS = (
 # verbatim, so they pass straight through to sandbox creation. Any other
 # language is a display-only code note — the UI hides the run affordance
 # and this module never sees an execute request for it.
-RUNNABLE_LANGUAGES = frozenset({"python", "javascript", "typescript"})
+RUNNABLE_LANGUAGES = frozenset({"python", "javascript"})
 DEFAULT_LANGUAGE = "python"
 
 # Each runnable language maps to a *runtime family* — the toolchain its
 # sandbox image must carry. Several languages can share one family (and so
-# one image): javascript + typescript both run on Node. The image is
-# selected per family, not per language, so adding a language that reuses an
-# existing runtime is free.
+# one image), e.g. javascript and (later) typescript both run on Node. The
+# image is selected per family, not per language, so adding a language that
+# reuses an existing runtime is free.
 LANGUAGE_FAMILY: dict[str, str] = {
     "python": "python",
     "javascript": "node",
-    "typescript": "node",
 }
 DEFAULT_FAMILY = "python"
 
@@ -71,12 +70,8 @@ def _default_family_image(family: str) -> Image:
     configured — production should point those at pre-warmed snapshots.
     """
     if family == "node":
-        # Node serves both javascript and typescript. ts-node + typescript
-        # are installed globally because the runtime sandbox has no network
-        # (`network_block_all`), so `npx` cannot fetch them at run time.
-        return Image.base("node:20-slim").run_commands(
-            "npm install -g ts-node typescript",
-        )
+        # Node runs javascript out of the box — no extra install needed.
+        return Image.base("node:20-slim")
     return Image.debian_slim("3.13")
 
 

--- a/backend/topix/api/router/boards.py
+++ b/backend/topix/api/router/boards.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.params import Body, Path
 
-from topix.agents.assistant.code import RUNNABLE_LANGUAGES, execute_code
+from topix.agents.assistant.code import DEFAULT_LANGUAGE, RUNNABLE_LANGUAGES, execute_code
 from topix.agents.datatypes.context import Context
 from topix.agents.describe_board import DescribeBoard
 from topix.agents.run import AgentRunner
@@ -300,7 +300,7 @@ async def execute_note_code(
     if note.style.type != NodeType.CODE_SANDBOX:
         raise HTTPException(status_code=400, detail="Note is not a code sandbox")
 
-    language = note.properties.programming_language.text or "python"
+    language = note.properties.programming_language.text or DEFAULT_LANGUAGE
     if language not in RUNNABLE_LANGUAGES:
         raise HTTPException(
             status_code=400,

--- a/backend/topix/api/router/boards.py
+++ b/backend/topix/api/router/boards.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.params import Body, Path
 
-from topix.agents.assistant.code import execute_python_code
+from topix.agents.assistant.code import RUNNABLE_LANGUAGES, execute_code
 from topix.agents.datatypes.context import Context
 from topix.agents.describe_board import DescribeBoard
 from topix.agents.run import AgentRunner
@@ -287,7 +287,7 @@ async def execute_note_code(
     user_id: Annotated[str, Depends(get_current_user_uid)],
     _: Annotated[None, Depends(verify_board_member)],
 ):
-    """Execute Python code stored in a code sandbox note."""
+    """Execute code stored in a code sandbox note, in its declared language."""
     store: GraphStore = request.app.graph_store
 
     notes = await store.get_nodes(node_ids=[note_id])
@@ -300,8 +300,15 @@ async def execute_note_code(
     if note.style.type != NodeType.CODE_SANDBOX:
         raise HTTPException(status_code=400, detail="Note is not a code sandbox")
 
+    language = note.properties.programming_language.text or "python"
+    if language not in RUNNABLE_LANGUAGES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Language '{language}' is not runnable",
+        )
+
     code = note.content.markdown if note.content else ""
-    result = await execute_python_code(code)
+    result = await execute_code(code, language)
     return result.model_dump(exclude_none=True)
 
 

--- a/webui/src/features/board/api/execute-code-note.ts
+++ b/webui/src/features/board/api/execute-code-note.ts
@@ -11,6 +11,22 @@ export type CodeExecutionResult = {
 }
 
 
+// Languages the Daytona backend can actually run (mirrors RUNNABLE_LANGUAGES
+// in backend/topix/agents/assistant/code.py). A code-sandbox note whose
+// language is outside this set renders as a plain code node — no Execute
+// action, no stdout/stderr panel.
+export const RUNNABLE_LANGUAGES = new Set(["python", "javascript", "typescript"])
+
+
+/** Whether a code node's language can be executed in a sandbox. */
+export function isRunnable(language: string | undefined): boolean {
+  return !!language && RUNNABLE_LANGUAGES.has(language)
+}
+
+
+export const DEFAULT_CODE_LANGUAGE = "python"
+
+
 /**
  * Execute a code sandbox note on the backend and return stdout/stderr.
  */

--- a/webui/src/features/board/api/execute-code-note.ts
+++ b/webui/src/features/board/api/execute-code-note.ts
@@ -15,7 +15,7 @@ export type CodeExecutionResult = {
 // in backend/topix/agents/assistant/code.py). A code-sandbox note whose
 // language is outside this set renders as a plain code node — no Execute
 // action, no stdout/stderr panel.
-export const RUNNABLE_LANGUAGES = new Set(["python", "javascript", "typescript"])
+export const RUNNABLE_LANGUAGES = new Set(["python", "javascript"])
 
 
 /** Whether a code node's language can be executed in a sandbox. */

--- a/webui/src/features/board/components/flow/code-area.tsx
+++ b/webui/src/features/board/components/flow/code-area.tsx
@@ -37,7 +37,7 @@ export function CodeArea({
   value,
   onChange,
   language = "python",
-  placeholder = "# Write Python here",
+  placeholder = "Write code here",
 }: CodeAreaProps) {
   const { shikiThemes } = useTheme()
   const highlightedLayerRef = useRef<HTMLDivElement | null>(null)

--- a/webui/src/features/board/components/flow/code-area.tsx
+++ b/webui/src/features/board/components/flow/code-area.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useTheme } from "@/components/theme-provider"
-import { highlightCodeSync, ensureLanguage } from "@/lib/shiki"
+import { highlightCodeSync, ensureLanguage, type LangValue } from "@/lib/shiki"
 import { cn } from "@/lib/utils"
 
 
-export type CodeAreaLanguage = "python" | "html" | "javascript" | "typescript"
+// Any language Shiki knows about. `highlightCodeSync`/`ensureLanguage`
+// already guard unknown values back to plaintext, so this is a thin alias.
+export type CodeAreaLanguage = LangValue
 
 
 type CodeAreaProps = {

--- a/webui/src/features/board/harness/chrome/node-surface-host/code-sandbox-panel.tsx
+++ b/webui/src/features/board/harness/chrome/node-surface-host/code-sandbox-panel.tsx
@@ -3,10 +3,22 @@ import { CancelPlainIcon, ConsoleIcon, LoaderIcon, PlayIcon } from "@/components
 import { Button } from "@/components/ui/button"
 import { useCanvasStore, useNode } from "@canvas-harness/react"
 import type { NodeId } from "@canvas-harness/core"
-import { CodeArea } from "@/features/board/components/flow/code-area"
+import { CodeArea, type CodeAreaLanguage } from "@/features/board/components/flow/code-area"
+import { LANGUAGE_OPTIONS } from "@/lib/shiki"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import type { CodeExecutionResult } from "@/features/board/api/execute-code-note"
-import { executeCodeNote } from "@/features/board/api/execute-code-note"
+import {
+  DEFAULT_CODE_LANGUAGE,
+  executeCodeNote,
+  isRunnable,
+} from "@/features/board/api/execute-code-note"
 import { updateNote } from "@/features/board/api/update-note"
 import type { NoteNodeData } from "../../convert/note-to-node"
 import { useBoardAppStore } from "../../store/board-app-store"
@@ -44,6 +56,9 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
   const node = useNode(nodeId as NodeId)
   const data = (node?.data ?? {}) as Partial<NoteNodeData>
   const boardId = useBoardAppStore((s) => s.boardId)
+
+  const language = data.properties?.programmingLanguage?.text || DEFAULT_CODE_LANGUAGE
+  const runnable = isRunnable(language)
 
   const [codeDraft, setCodeDraft] = useState(node?.content ?? "")
   const [isExecuting, setIsExecuting] = useState(false)
@@ -111,8 +126,29 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
     [commitTitle, titleDraft, data.label?.markdown],
   )
 
+  // Persist the chosen language onto the note (round-trips via
+  // data.properties.programmingLanguage). Drives whether the sandbox UI
+  // shows and which Shiki grammar highlights the editor.
+  const setLanguage = useCallback(
+    (next: string) => {
+      if (!node || next === language) return
+      const prevData = (node.data ?? {}) as Record<string, unknown>
+      const prevProps = (prevData.properties ?? {}) as Record<string, unknown>
+      store.updateNode(nodeId as NodeId, {
+        data: {
+          ...prevData,
+          properties: {
+            ...prevProps,
+            programmingLanguage: { type: "text", text: next },
+          },
+        },
+      })
+    },
+    [node, nodeId, store, language],
+  )
+
   const handleExecute = useCallback(async () => {
-    if (!boardId || isExecuting) return
+    if (!boardId || isExecuting || !runnable) return
 
     setIsExecuting(true)
     try {
@@ -123,7 +159,7 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
       await updateNote(boardId, nodeId, {
         content: { markdown: codeDraft },
         properties: {
-          programmingLanguage: { type: "text", text: "python" },
+          programmingLanguage: { type: "text", text: language },
         } as never,
       })
 
@@ -139,7 +175,7 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
     } finally {
       setIsExecuting(false)
     }
-  }, [boardId, codeDraft, isExecuting, nodeId, saveDraft])
+  }, [boardId, codeDraft, isExecuting, runnable, language, nodeId, saveDraft])
 
   const lastRunLabel = useMemo(
     () => (result.durationMs > 0 ? `Last run • ${result.durationMs} ms` : "Last run"),
@@ -157,7 +193,7 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
     )
   }
 
-  const displayTitle = data.label?.markdown?.trim() || "Untitled sandbox"
+  const displayTitle = data.label?.markdown?.trim() || "Untitled code"
 
   return (
     <div className={PANEL_CLASS} onClick={(e) => e.stopPropagation()}>
@@ -182,7 +218,7 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
                   }
                 }}
                 className="w-full border-0 border-b border-current/30 bg-transparent px-0 py-0.5 text-sm font-semibold text-foreground focus:border-secondary-foreground focus:outline-none"
-                placeholder="Untitled sandbox"
+                placeholder="Untitled code"
               />
             ) : (
               <button
@@ -195,28 +231,49 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
               </button>
             )}
           </div>
-          <span className="text-xs font-medium text-muted-foreground">
-            Python
-          </span>
+          <Select value={language} onValueChange={setLanguage}>
+            <SelectTrigger
+              size="sm"
+              className="h-7 w-[136px] shrink-0 text-xs"
+              aria-label="Language"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="max-h-72">
+              {LANGUAGE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex items-center gap-3">
-          <span className="text-xs text-muted-foreground">
-            Max runtime 60s
-          </span>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleExecute}
-            disabled={isExecuting || !boardId}
-            className="gap-2"
-          >
-            {isExecuting ? (
-              <LoaderIcon className="size-4 shrink-0 animate-spin" strokeWidth={2} />
-            ) : (
-              <PlayIcon className="size-4 shrink-0" strokeWidth={2} />
-            )}
-            {isExecuting ? "Running" : "Execute"}
-          </Button>
+          {runnable ? (
+            <>
+              <span className="text-xs text-muted-foreground">
+                Max runtime 60s
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleExecute}
+                disabled={isExecuting || !boardId}
+                className="gap-2"
+              >
+                {isExecuting ? (
+                  <LoaderIcon className="size-4 shrink-0 animate-spin" strokeWidth={2} />
+                ) : (
+                  <PlayIcon className="size-4 shrink-0" strokeWidth={2} />
+                )}
+                {isExecuting ? "Running" : "Execute"}
+              </Button>
+            </>
+          ) : (
+            <span className="text-xs text-muted-foreground">
+              Run not supported
+            </span>
+          )}
           <Button
             variant="ghost"
             size="icon-sm"
@@ -230,42 +287,55 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
         </div>
       </div>
 
-      <div className="grid min-h-0 flex-1 lg:grid-cols-[1.3fr_0.9fr]">
-        <div className="min-h-0 border-r border-border/70 bg-card">
+      <div
+        className={cn(
+          "grid min-h-0 flex-1",
+          runnable && "lg:grid-cols-[1.3fr_0.9fr]",
+        )}
+      >
+        <div
+          className={cn(
+            "min-h-0 bg-card",
+            runnable && "border-r border-border/70",
+          )}
+        >
           <CodeArea
             value={codeDraft}
             onChange={setCodeDraft}
+            language={language as CodeAreaLanguage}
           />
         </div>
 
-        <div className="grid min-h-0 grid-rows-[auto_1fr_1fr] bg-card">
-          <div className="px-4 py-3 text-xs font-medium text-muted-foreground">
-            {lastRunLabel}
-          </div>
-
-          <div className="min-h-0 border-t border-border/70">
-            <div className="px-4 py-2 text-xs font-semibold text-primary">
-              stdout
+        {runnable && (
+          <div className="grid min-h-0 grid-rows-[auto_1fr_1fr] bg-card">
+            <div className="px-4 py-3 text-xs font-medium text-muted-foreground">
+              {lastRunLabel}
             </div>
-            <pre className="scrollbar-thin h-full overflow-auto overflow-x-auto whitespace-pre-wrap break-all px-4 pb-4 font-mono text-xs leading-5 text-foreground">
-              {result.stdout || "No stdout"}
-            </pre>
-          </div>
 
-          <div className="min-h-0 border-t border-border/70">
-            <div className="px-4 py-2 text-xs font-semibold text-destructive">
-              stderr
+            <div className="min-h-0 border-t border-border/70">
+              <div className="px-4 py-2 text-xs font-semibold text-primary">
+                stdout
+              </div>
+              <pre className="scrollbar-thin h-full overflow-auto overflow-x-auto whitespace-pre-wrap break-all px-4 pb-4 font-mono text-xs leading-5 text-foreground">
+                {result.stdout || "No stdout"}
+              </pre>
             </div>
-            <pre
-              className={cn(
-                "scrollbar-thin h-full overflow-auto overflow-x-auto whitespace-pre-wrap break-all px-4 pb-4 font-mono text-xs leading-5",
-                result.stderr ? "text-destructive" : "text-muted-foreground",
-              )}
-            >
-              {result.stderr || "No stderr"}
-            </pre>
+
+            <div className="min-h-0 border-t border-border/70">
+              <div className="px-4 py-2 text-xs font-semibold text-destructive">
+                stderr
+              </div>
+              <pre
+                className={cn(
+                  "scrollbar-thin h-full overflow-auto overflow-x-auto whitespace-pre-wrap break-all px-4 pb-4 font-mono text-xs leading-5",
+                  result.stderr ? "text-destructive" : "text-muted-foreground",
+                )}
+              >
+                {result.stderr || "No stderr"}
+              </pre>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/webui/src/features/board/harness/chrome/node-surface-host/code-sandbox-panel.tsx
+++ b/webui/src/features/board/harness/chrome/node-surface-host/code-sandbox-panel.tsx
@@ -143,6 +143,9 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
           },
         },
       })
+      // The previous run's stdout/stderr belongs to the old language; clear
+      // it so the output panel doesn't mislabel it as this language's result.
+      setResult(EMPTY_CODE_EXECUTION_RESULT)
     },
     [node, nodeId, store, language],
   )
@@ -303,6 +306,7 @@ export const CodeSandboxPanel = memo(function CodeSandboxPanel({
             value={codeDraft}
             onChange={setCodeDraft}
             language={language as CodeAreaLanguage}
+            placeholder="Write code here"
           />
         </div>
 

--- a/webui/src/features/board/harness/node-types/code-sandbox/view.tsx
+++ b/webui/src/features/board/harness/node-types/code-sandbox/view.tsx
@@ -4,6 +4,7 @@ import { useCanvasStore, useNode } from "@canvas-harness/react"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/components/theme-provider"
 import { ensureLanguage, highlightCodeSync } from "@/lib/shiki"
+import { DEFAULT_CODE_LANGUAGE } from "@/features/board/api/execute-code-note"
 import type { NoteNodeData } from "../../convert/note-to-node"
 import {
   NodeTitleCaption,
@@ -18,15 +19,15 @@ export type CodeSandboxViewProps = {
 }
 
 
-const PLACEHOLDER = "# Write Python here"
+const PLACEHOLDER = "// Write code here"
 
 
 /**
- * Code-sandbox inline preview. The full body is the click target;
- * syntax highlighting tracks the active theme pair from `useTheme()`
- * so the preview swaps palette together with the rest of the app.
- * Falls back to plain text on the first paint while Shiki finishes
- * loading the python grammar + theme JSON.
+ * Code node inline preview. The full body is the click target; syntax
+ * highlighting uses the note's `programmingLanguage` and tracks the active
+ * theme pair from `useTheme()` so the preview swaps palette together with
+ * the rest of the app. Falls back to plain text on the first paint while
+ * Shiki finishes loading the grammar + theme JSON.
  */
 export function CodeSandboxView({ id }: CodeSandboxViewProps) {
   const node = useNode(id)
@@ -37,28 +38,30 @@ export function CodeSandboxView({ id }: CodeSandboxViewProps) {
   useStopCanvasGesture(bodyRef)
   const { shikiThemes } = useTheme()
 
+  const data = (node?.data ?? {}) as Partial<NoteNodeData>
+  const language = data.properties?.programmingLanguage?.text || DEFAULT_CODE_LANGUAGE
+
   const code = node?.content ?? ""
   const display = code || PLACEHOLDER
   const [previewHtml, setPreviewHtml] = useState<string | null>(null)
 
   useEffect(() => {
-    const html = highlightCodeSync(display, "python", shikiThemes)
+    const html = highlightCodeSync(display, language, shikiThemes)
     if (html != null) {
       setPreviewHtml(html)
       return
     }
     setPreviewHtml(null)
     let cancelled = false
-    ensureLanguage("python", shikiThemes, () => {
+    ensureLanguage(language, shikiThemes, () => {
       if (cancelled) return
-      setPreviewHtml(highlightCodeSync(display, "python", shikiThemes))
+      setPreviewHtml(highlightCodeSync(display, language, shikiThemes))
     })
     return () => { cancelled = true }
-  }, [display, shikiThemes])
+  }, [display, language, shikiThemes])
 
   if (!node) return null
 
-  const data = (node.data ?? {}) as Partial<NoteNodeData>
   const label = data.label?.markdown
 
   return (
@@ -77,7 +80,7 @@ export function CodeSandboxView({ id }: CodeSandboxViewProps) {
           "pointer-events-auto",
           canEdit ? "cursor-pointer" : "cursor-default",
         )}
-        title={canEdit ? "Open Python sandbox" : "Python sandbox preview"}
+        title={canEdit ? "Open code" : "Code preview"}
       >
         {previewHtml != null ? (
           <div
@@ -106,7 +109,7 @@ export function CodeSandboxView({ id }: CodeSandboxViewProps) {
         <NodeTitleCaption
           nodeId={id}
           label={label}
-          placeholder="Untitled sandbox"
+          placeholder="Untitled code"
           textClassName="text-center text-sm font-handwriting text-foreground"
         />
       </div>


### PR DESCRIPTION
## What

Turns the code-sandbox node into a **language-aware code node**. The node carries a programming language, and the "sandbox" affordances (Execute button + stdout/stderr panel) appear **only when the language is runnable**. Any other language renders as a plain, syntax-highlighted code node.

One node type, the **existing** `programming_language` property, runnability **derived** from a small allowlist — no new node type, no data migration.

**v1 runnable scope: Python + JavaScript.** TypeScript, C, Java, Rust, Markdown, etc. are all selectable and syntax-highlighted, just display-only (no Run). This keeps v1 free of any extra toolchain setup (see below).

## Why

Support many languages from the start for editing/display, while only the languages Daytona can execute today get paired with the sandbox runner. Scope runnable to Python + JS so **no custom image / ts-node install is required** for v1.

## Changes

**Backend**
- `agents/assistant/code.py`:
  - `RUNNABLE_LANGUAGES = {python, javascript}` (values match Daytona's `CodeLanguage`).
  - **Per-runtime-family image selection**: `LANGUAGE_FAMILY` maps language → runtime family (`python → python`, `javascript → node`); the image is chosen per *family*, not per language, so future languages that reuse a runtime are free.
  - `_resolve_source(family)` precedence: `DAYTONA_SNAPSHOT_<FAMILY>` → `DAYTONA_IMAGE_<FAMILY>` → legacy global `DAYTONA_SNAPSHOT`/`DAYTONA_IMAGE` (**scoped to python only**, so existing deploys are unchanged) → a declarative default image (`debian_slim` for python, `node:20-slim` for node — no extra installs).
  - `execute_python_code` → `execute_code(code, language)` with a non-runnable guard; `execute_python_code` kept as a wrapper so the **agent tool path is unchanged**.
- `api/router/boards.py`: `:execute` reads `note.properties.programming_language`, `400`s on non-runnable, calls `execute_code`.

**Frontend**
- `api/execute-code-note.ts`: `RUNNABLE_LANGUAGES`, `isRunnable()`, `DEFAULT_CODE_LANGUAGE` (mirrors backend).
- `code-area.tsx`: editor language widened to all Shiki grammars.
- `code-sandbox/view.tsx`: inline preview highlights in the note's language; generic labels.
- `code-sandbox-panel.tsx`: language **picker** (reuses `LANGUAGE_OPTIONS`, persists via the harness op log → collab); Execute + stdout/stderr gated on `isRunnable` (non-runnable → full-width editor, no Run).

**Config**
- `.env.sample`: documents optional `DAYTONA_{SNAPSHOT,IMAGE}_{PYTHON,NODE}` per-family overrides.

## Tests
- `test_code.py`: language→family mapping, per-family default images, per-family env override precedence, legacy global scoped to python, runnable-language execution, non-runnable rejection — **15 passed**.
- Frontend `tsc` + `eslint` on changed files — clean.

## Deploy notes
- **Python**: unchanged, runs as before.
- **JavaScript**: runs on a plain Node image. Daytona's default snapshot likely already ships Node, so this is probably zero setup; otherwise the declarative `node:20-slim` default builds once and is cached. Point `DAYTONA_SNAPSHOT_NODE` at a pre-warmed snapshot in production to avoid the first-run build.
- **Re-enabling TypeScript later**: add it back to `RUNNABLE_LANGUAGES` (both sides) and provide a node image with a global `ts-node` (Daytona's TS toolbox runs `npx ts-node`, and the runtime sandbox is network-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)