### PR TITLE
fix(billing): gate paid plan on subscription status

### DIFF
--- a/backend/test/unit/api/router/test_billing_webhook.py
+++ b/backend/test/unit/api/router/test_billing_webhook.py
@@ -1,0 +1,96 @@
+"""Tests for the Stripe webhook handler's status/ordering guards."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import topix.api.router.billing as billing
+
+
+class _FakeBillingStore:
+    """Captures upserts and returns a preset existing billing row."""
+
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.upserts: list[dict] = []
+
+    async def get_user_billing(self, user_uid: str):
+        return self.existing
+
+    async def get_user_billing_by_stripe_subscription_id(self, sub_id: str):
+        return self.existing
+
+    async def get_user_billing_by_stripe_customer_id(self, cust_id: str):
+        return self.existing
+
+    async def upsert_user_billing(self, *, user_uid: str, data: dict):
+        self.upserts.append({"user_uid": user_uid, **data})
+
+
+def _build_request(store: _FakeBillingStore):
+    async def _body():
+        return b"{}"
+
+    return SimpleNamespace(
+        app=SimpleNamespace(user_billing_store=store),
+        headers=SimpleNamespace(get=lambda _k: "sig"),
+        body=_body,
+    )
+
+
+def _subscription_event(*, status: str, sub_id: str = "sub_123", event_type: str = "customer.subscription.updated"):
+    return {
+        "type": event_type,
+        "data": {
+            "object": {
+                "id": sub_id,
+                "customer": "cus_123",
+                "status": status,
+                "metadata": {"user_uid": "u1"},
+                "items": {"data": [{"price": {"id": "price_x"}}]},
+            }
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stub_stripe(monkeypatch):
+    """Avoid env/signature deps: stub config + signature verification."""
+    monkeypatch.setattr(billing, "get_stripe_config", lambda: SimpleNamespace(webhook_secret="whsec"))
+    # verify returns whatever event the individual test injects via closure.
+
+
+async def test_stale_incomplete_does_not_downgrade_active_subscription(monkeypatch):
+    """A late `incomplete` event must not overwrite an already-active sub."""
+    existing = SimpleNamespace(
+        user_uid="u1", plan="plus", status="active", stripe_subscription_id="sub_123",
+    )
+    store = _FakeBillingStore(existing=existing)
+    monkeypatch.setattr(billing, "verify_stripe_signature", lambda **_: _subscription_event(status="incomplete"))
+
+    result = await billing.handle_stripe_webhook(_build_request(store))
+
+    assert result["data"]["reason"] == "stale_incomplete"
+    assert store.upserts == []  # no write — active state preserved
+
+
+async def test_incomplete_for_new_subscription_is_persisted_as_free(monkeypatch):
+    """A genuine first `incomplete` (no prior active row) downgrades to free."""
+    store = _FakeBillingStore(existing=None)
+    monkeypatch.setattr(billing, "verify_stripe_signature", lambda **_: _subscription_event(status="incomplete"))
+
+    await billing.handle_stripe_webhook(_build_request(store))
+
+    assert len(store.upserts) == 1
+    assert store.upserts[0]["plan"] == "free"
+
+
+async def test_active_subscription_is_persisted_as_plus(monkeypatch):
+    """An active subscription event grants the paid plan."""
+    store = _FakeBillingStore(existing=None)
+    monkeypatch.setattr(billing, "verify_stripe_signature", lambda **_: _subscription_event(status="active"))
+
+    await billing.handle_stripe_webhook(_build_request(store))
+
+    assert len(store.upserts) == 1
+    assert store.upserts[0]["plan"] == "plus"

--- a/backend/test/unit/api/router/test_collab_router.py
+++ b/backend/test/unit/api/router/test_collab_router.py
@@ -132,11 +132,12 @@ class _FakeUserBillingStore:
     async def get_user_billing(self, user_uid: str):
         if self.plan is None:
             return None
-        # Lightweight stand-in for UserBilling — only `.plan` is read.
+        # Lightweight stand-in for UserBilling — `.plan` and `.status` are read.
         class _Billing:
             pass
         b = _Billing()
         b.plan = self.plan
+        b.status = "active"
         return b
 
 

--- a/backend/test/unit/api/utils/test_rate_limiter.py
+++ b/backend/test/unit/api/utils/test_rate_limiter.py
@@ -80,16 +80,19 @@ class _FakeUserBillingStore:
         plan: str | None,
         cycle_start: datetime | None = None,
         cycle_end: datetime | None = None,
+        status: str = "active",
     ):
         self.plan = plan
         self.cycle_start = cycle_start
         self.cycle_end = cycle_end
+        self.status = status
 
     async def get_user_billing(self, user_uid: str):
         if self.plan is None:
             return None
         return SimpleNamespace(
             plan=self.plan,
+            status=self.status,
             current_period_start=self.cycle_start,
             current_period_end=self.cycle_end,
         )
@@ -100,6 +103,7 @@ def _build_request(
     plan: str | None,
     cycle_start: datetime | None = None,
     cycle_end: datetime | None = None,
+    status: str = "active",
 ):
     return SimpleNamespace(
         app=SimpleNamespace(
@@ -108,6 +112,7 @@ def _build_request(
                 plan=plan,
                 cycle_start=cycle_start,
                 cycle_end=cycle_end,
+                status=status,
             ),
         ),
         scope={"route": SimpleNamespace(path="/foo")},
@@ -174,6 +179,19 @@ async def test_rate_limiter_uses_plus_limits(monkeypatch):
     ]
     assert len(fake_store.cycle_calls) == 1
     assert fake_store.cycle_calls[0]["limit"] == MONTHLY_UTC_LIMITS["plus"]
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_gates_incomplete_plus_to_free_limits(monkeypatch):
+    """A plus plan with a never-paid `incomplete` status gets only free limits."""
+    monkeypatch.setenv(BILLING_ENABLED_ENV, "true")
+    fake_store = _FakeRedisStore()
+    request = _build_request(fake_store, plan="plus", status="incomplete")
+
+    await rate_limiter(request=request, user_id="user-123")
+
+    assert fake_store.fixed_calls[1]["limit"] == DAILY_UTC_LIMITS["free"]
+    assert fake_store.cycle_calls == []  # no billing cycle -> fixed monthly window
 
 
 @pytest.mark.asyncio

--- a/backend/test/unit/api/utils/test_token_plan.py
+++ b/backend/test/unit/api/utils/test_token_plan.py
@@ -25,7 +25,7 @@ class _StubBillingStore:
         self.calls.append(user_uid)
         if self.plan is None:
             return None
-        return SimpleNamespace(plan=self.plan)
+        return SimpleNamespace(plan=self.plan, status="active")
 
 
 @pytest.mark.asyncio

--- a/backend/test/unit/collab/test_capacity.py
+++ b/backend/test/unit/collab/test_capacity.py
@@ -23,9 +23,10 @@ def test_cap_for_plan_unknown_or_none_uses_free_default():
 
 
 class _Billing:
-    def __init__(self, plan):
+    def __init__(self, plan, status="active"):
         """Init."""
         self.plan = plan
+        self.status = status
 
 
 async def test_get_room_cap_uses_owners_plan_not_joiners():
@@ -45,6 +46,20 @@ async def test_get_room_cap_uses_owners_plan_not_joiners():
     assert cap == 20
     graph_store.get_owner_uid.assert_awaited_once_with("b1")
     billing_store.get_user_billing.assert_awaited_once_with("alice")
+
+
+async def test_get_room_cap_gates_incomplete_plus_to_free():
+    """A never-paid (`incomplete`) plus subscription only gets the free cap."""
+    graph_store = AsyncMock()
+    graph_store.get_owner_uid = AsyncMock(return_value="alice")
+    billing_store = AsyncMock()
+    billing_store.get_user_billing = AsyncMock(return_value=_Billing(plan="plus", status="incomplete"))
+
+    cap = await get_room_cap_for_board(
+        graph_store=graph_store, user_billing_store=billing_store, board_uid="b1",
+    )
+
+    assert cap == DEFAULT_CAP
 
 
 async def test_get_room_cap_defaults_to_free_when_billing_missing():

--- a/backend/test/unit/datatypes/test_effective_plan.py
+++ b/backend/test/unit/datatypes/test_effective_plan.py
@@ -1,0 +1,23 @@
+"""Tests for status-gated plan resolution (billing access guard)."""
+
+import pytest
+
+from topix.datatypes.user_billing import effective_plan
+
+
+@pytest.mark.parametrize("status", ["active", "trialing", "past_due"])
+def test_paid_plan_granted_for_access_statuses(status):
+    """A paid plan keeps access while the subscription status grants it."""
+    assert effective_plan("plus", status) == "plus"
+
+
+@pytest.mark.parametrize("status", ["incomplete", "canceled"])
+def test_paid_plan_revoked_for_non_access_statuses(status):
+    """A never-paid/canceled subscription must not grant a paid plan."""
+    assert effective_plan("plus", status) == "free"
+
+
+@pytest.mark.parametrize("status", ["active", "incomplete", "canceled", "past_due"])
+def test_free_plan_stays_free(status):
+    """A free plan is unaffected by status."""
+    assert effective_plan("free", status) == "free"

--- a/backend/topix/api/router/billing.py
+++ b/backend/topix/api/router/billing.py
@@ -245,6 +245,11 @@ async def handle_stripe_webhook(request: Request):
         user_uid = data_object.get("client_reference_id") or data_object.get("metadata", {}).get("user_uid")
         if not user_uid:
             return {"processed": False, "reason": "missing_user_uid"}
+        # Async payment methods complete the session before funds clear; only
+        # grant access once payment is settled (card checkouts are "paid").
+        payment_status = data_object.get("payment_status")
+        if payment_status not in ("paid", "no_payment_required"):
+            return {"processed": False, "reason": "payment_not_settled", "event_type": event_type}
         await user_billing_store.upsert_user_billing(
             user_uid=user_uid,
             data={

--- a/backend/topix/api/router/billing.py
+++ b/backend/topix/api/router/billing.py
@@ -14,7 +14,7 @@ from topix.api.utils.billing.stripe_config import get_stripe_config
 from topix.api.utils.billing.stripe_webhook import verify_stripe_signature
 from topix.api.utils.decorators import with_standard_response
 from topix.api.utils.security import get_current_user_uid
-from topix.datatypes.user_billing import BillingStatus, effective_plan
+from topix.datatypes.user_billing import ACCESS_GRANTING_STATUSES, BillingStatus, effective_plan
 from topix.store.user import UserStore
 from topix.store.user_billing import UserBillingStore
 
@@ -225,6 +225,108 @@ async def create_portal_session(
     }
 
 
+async def _handle_checkout_completed(data_object: dict, user_billing_store: UserBillingStore) -> dict:
+    """Persist billing state from a completed checkout session.
+
+    Only grants access once payment is settled — async payment methods complete
+    the session before funds clear (card checkouts are "paid").
+    """
+    user_uid = data_object.get("client_reference_id") or data_object.get("metadata", {}).get("user_uid")
+    if not user_uid:
+        return {"processed": False, "reason": "missing_user_uid"}
+    payment_status = data_object.get("payment_status")
+    if payment_status not in ("paid", "no_payment_required"):
+        return {"processed": False, "reason": "payment_not_settled"}
+    await user_billing_store.upsert_user_billing(
+        user_uid=user_uid,
+        data={
+            "plan": "plus",
+            "status": "active",
+            "stripe_customer_id": data_object.get("customer"),
+            "stripe_subscription_id": data_object.get("subscription"),
+        },
+    )
+    return {"processed": True, "event_type": "checkout.session.completed"}
+
+
+async def _resolve_webhook_user_uid(
+    data_object: dict,
+    stripe_subscription_id: str | None,
+    stripe_customer_id: str | None,
+    user_billing_store: UserBillingStore,
+) -> str | None:
+    """Resolve the local user from event metadata, then subscription/customer id."""
+    user_uid = data_object.get("metadata", {}).get("user_uid")
+    if not user_uid and stripe_subscription_id:
+        billing = await user_billing_store.get_user_billing_by_stripe_subscription_id(stripe_subscription_id)
+        user_uid = billing.user_uid if billing else None
+    if not user_uid and stripe_customer_id:
+        billing = await user_billing_store.get_user_billing_by_stripe_customer_id(stripe_customer_id)
+        user_uid = billing.user_uid if billing else None
+    return user_uid
+
+
+async def _handle_subscription_event(
+    event_type: str, data_object: dict, user_billing_store: UserBillingStore
+) -> dict:
+    """Persist billing state from a subscription lifecycle event.
+
+    Gates the plan on subscription status and ignores stale `incomplete` events
+    so out-of-order delivery cannot downgrade an already-active subscription.
+    """
+    stripe_customer_id = data_object.get("customer")
+    stripe_subscription_id = data_object.get("id")
+    status_value = _resolve_status(data_object.get("status", "incomplete"))
+    cancel_at = data_object.get("cancel_at")
+    cancel_at_period_end = bool(data_object.get("cancel_at_period_end", False))
+
+    item_period_start = None
+    item_period_end = None
+    items = (data_object.get("items") or {}).get("data") or []
+    if items:
+        first_item = items[0] or {}
+        item_period_start = first_item.get("current_period_start")
+        item_period_end = first_item.get("current_period_end")
+
+    user_uid = await _resolve_webhook_user_uid(
+        data_object, stripe_subscription_id, stripe_customer_id, user_billing_store
+    )
+    if not user_uid:
+        logger.warning("Stripe webhook %s ignored: no user mapping", event_type)
+        return {"processed": False, "reason": "no_user_mapping", "event_type": event_type}
+
+    # Guard against out-of-order delivery: `incomplete` is only ever a
+    # pre-activation state, so a late/duplicate incomplete event must never
+    # downgrade a subscription we already recorded as active. Stripe does not
+    # guarantee webhook ordering.
+    if status_value == "incomplete":
+        existing = await user_billing_store.get_user_billing(user_uid)
+        if (
+            existing
+            and existing.stripe_subscription_id == stripe_subscription_id
+            and existing.status in ACCESS_GRANTING_STATUSES
+        ):
+            logger.info("Ignoring stale incomplete event for active subscription %s", stripe_subscription_id)
+            return {"processed": False, "reason": "stale_incomplete", "event_type": event_type}
+
+    # A deleted subscription is always free; otherwise gate on status so a
+    # never-paid (`incomplete`) subscription stays free until payment succeeds.
+    plan = "free" if event_type.endswith(".deleted") else effective_plan("plus", status_value)
+    await user_billing_store.upsert_user_billing(
+        user_uid=user_uid,
+        data={
+            "plan": plan,
+            "status": status_value,
+            "stripe_customer_id": stripe_customer_id,
+            "stripe_subscription_id": stripe_subscription_id,
+            "current_period_start": _timestamp_to_datetime(data_object.get("current_period_start") or item_period_start),
+            "current_period_end": _timestamp_to_datetime(data_object.get("current_period_end") or item_period_end or cancel_at),
+            "cancel_at_period_end": cancel_at_period_end or cancel_at is not None,
+        },
+    )
+    return {"processed": True, "event_type": event_type}
+
+
 @router.post("/webhook")
 @with_standard_response
 async def handle_stripe_webhook(request: Request):
@@ -242,75 +344,13 @@ async def handle_stripe_webhook(request: Request):
     user_billing_store: UserBillingStore = request.app.user_billing_store
 
     if event_type == "checkout.session.completed":
-        user_uid = data_object.get("client_reference_id") or data_object.get("metadata", {}).get("user_uid")
-        if not user_uid:
-            return {"processed": False, "reason": "missing_user_uid"}
-        # Async payment methods complete the session before funds clear; only
-        # grant access once payment is settled (card checkouts are "paid").
-        payment_status = data_object.get("payment_status")
-        if payment_status not in ("paid", "no_payment_required"):
-            return {"processed": False, "reason": "payment_not_settled", "event_type": event_type}
-        await user_billing_store.upsert_user_billing(
-            user_uid=user_uid,
-            data={
-                "plan": "plus",
-                "status": "active",
-                "stripe_customer_id": data_object.get("customer"),
-                "stripe_subscription_id": data_object.get("subscription"),
-            },
-        )
-        return {"processed": True, "event_type": event_type}
+        return await _handle_checkout_completed(data_object, user_billing_store)
 
     if event_type in {
         "customer.subscription.created",
         "customer.subscription.updated",
         "customer.subscription.deleted",
     }:
-        stripe_customer_id = data_object.get("customer")
-        stripe_subscription_id = data_object.get("id")
-        status_value = _resolve_status(data_object.get("status", "incomplete"))
-        cancel_at = data_object.get("cancel_at")
-        cancel_at_period_end = bool(data_object.get("cancel_at_period_end", False))
-
-        item_period_start = None
-        item_period_end = None
-        items = (data_object.get("items") or {}).get("data") or []
-        if items:
-            first_item = items[0] or {}
-            item_period_start = first_item.get("current_period_start")
-            item_period_end = first_item.get("current_period_end")
-
-        user_uid = data_object.get("metadata", {}).get("user_uid")
-        if not user_uid and stripe_subscription_id:
-            billing = await user_billing_store.get_user_billing_by_stripe_subscription_id(stripe_subscription_id)
-            user_uid = billing.user_uid if billing else None
-        if not user_uid and stripe_customer_id:
-            billing = await user_billing_store.get_user_billing_by_stripe_customer_id(stripe_customer_id)
-            user_uid = billing.user_uid if billing else None
-
-        if not user_uid:
-            logger.warning("Stripe webhook %s ignored: no user mapping", event_type)
-            return {"processed": False, "reason": "no_user_mapping", "event_type": event_type}
-
-        # Only grant a paid plan when the subscription status actually grants
-        # access. A subscription created before its first payment is
-        # `incomplete` and must stay free until payment succeeds.
-        if event_type.endswith(".deleted"):
-            plan = "free"
-        else:
-            plan = effective_plan("plus", status_value)
-        await user_billing_store.upsert_user_billing(
-            user_uid=user_uid,
-            data={
-                "plan": plan,
-                "status": status_value,
-                "stripe_customer_id": stripe_customer_id,
-                "stripe_subscription_id": stripe_subscription_id,
-                "current_period_start": _timestamp_to_datetime(data_object.get("current_period_start") or item_period_start),
-                "current_period_end": _timestamp_to_datetime(data_object.get("current_period_end") or item_period_end or cancel_at),
-                "cancel_at_period_end": cancel_at_period_end or cancel_at is not None,
-            },
-        )
-        return {"processed": True, "event_type": event_type}
+        return await _handle_subscription_event(event_type, data_object, user_billing_store)
 
     return {"processed": False, "event_type": event_type, "reason": "ignored_event"}

--- a/backend/topix/api/router/billing.py
+++ b/backend/topix/api/router/billing.py
@@ -14,7 +14,7 @@ from topix.api.utils.billing.stripe_config import get_stripe_config
 from topix.api.utils.billing.stripe_webhook import verify_stripe_signature
 from topix.api.utils.decorators import with_standard_response
 from topix.api.utils.security import get_current_user_uid
-from topix.datatypes.user_billing import BillingStatus
+from topix.datatypes.user_billing import BillingStatus, effective_plan
 from topix.store.user import UserStore
 from topix.store.user_billing import UserBillingStore
 
@@ -287,7 +287,13 @@ async def handle_stripe_webhook(request: Request):
             logger.warning("Stripe webhook %s ignored: no user mapping", event_type)
             return {"processed": False, "reason": "no_user_mapping", "event_type": event_type}
 
-        plan = "free" if status_value == "canceled" or event_type.endswith(".deleted") else "plus"
+        # Only grant a paid plan when the subscription status actually grants
+        # access. A subscription created before its first payment is
+        # `incomplete` and must stay free until payment succeeds.
+        if event_type.endswith(".deleted"):
+            plan = "free"
+        else:
+            plan = effective_plan("plus", status_value)
         await user_billing_store.upsert_user_billing(
             user_uid=user_uid,
             data={

--- a/backend/topix/api/utils/rate_limit/entitlements.py
+++ b/backend/topix/api/utils/rate_limit/entitlements.py
@@ -4,13 +4,18 @@ from fastapi import Request
 
 from topix.api.utils.rate_limit.types import BillingCycle, EntitlementContext, PlanType
 from topix.api.utils.rate_limit.windows import as_utc
+from topix.datatypes.user_billing import effective_plan
 from topix.store.user_billing import UserBillingStore
 
 DEFAULT_PLAN: PlanType = "free"
 
 
 async def resolve_entitlement_context(request: Request, user_uid: str) -> EntitlementContext:
-    """Resolve plan and optional billing context for the request user."""
+    """Resolve plan and optional billing context for the request user.
+
+    The plan is gated on subscription status so a never-paid (`incomplete`)
+    subscription does not grant paid entitlements.
+    """
     store: UserBillingStore | None = getattr(request.app, "user_billing_store", None)
     if store is None:
         return EntitlementContext(plan=DEFAULT_PLAN)
@@ -19,6 +24,8 @@ async def resolve_entitlement_context(request: Request, user_uid: str) -> Entitl
     if billing is None:
         return EntitlementContext(plan=DEFAULT_PLAN)
 
+    plan = effective_plan(billing.plan, billing.status)
+
     cycle_start = billing.current_period_start
     cycle_end = billing.current_period_end
 
@@ -26,7 +33,7 @@ async def resolve_entitlement_context(request: Request, user_uid: str) -> Entitl
         start_utc = as_utc(cycle_start)
         end_utc = as_utc(cycle_end)
         if start_utc < end_utc:
-            return EntitlementContext(plan=billing.plan, cycle=BillingCycle(start=start_utc, end=end_utc))
+            return EntitlementContext(plan=plan, cycle=BillingCycle(start=start_utc, end=end_utc))
 
     # Fallback: no cycle information yet (e.g. free user or pre-billing setup).
-    return EntitlementContext(plan=billing.plan)
+    return EntitlementContext(plan=plan)

--- a/backend/topix/api/utils/rate_limit/token_plan.py
+++ b/backend/topix/api/utils/rate_limit/token_plan.py
@@ -4,7 +4,7 @@ import os
 
 from fastapi import Request
 
-from topix.datatypes.user_billing import BillingPlan
+from topix.datatypes.user_billing import BillingPlan, effective_plan
 from topix.store.user_billing import UserBillingStore
 
 BILLING_ENABLED_ENV = "VITE_BILLING_ENABLED"
@@ -34,4 +34,6 @@ async def resolve_plan_for_token(request: Request, user_uid: str) -> BillingPlan
     if billing is None:
         return "free"
 
-    return billing.plan
+    # Gate on status so a never-paid (`incomplete`) subscription never yields a
+    # paid plan claim in the access token.
+    return effective_plan(billing.plan, billing.status)

--- a/backend/topix/collab/capacity.py
+++ b/backend/topix/collab/capacity.py
@@ -19,6 +19,7 @@ import logging
 
 from typing import Final
 
+from topix.datatypes.user_billing import effective_plan
 from topix.store.graph import GraphStore
 from topix.store.user_billing import UserBillingStore
 
@@ -57,5 +58,7 @@ async def get_room_cap_for_board(
         logger.warning("collab capacity: board %s has no owner; using default cap", board_uid)
         return DEFAULT_CAP
     billing = await user_billing_store.get_user_billing(owner_uid)
-    plan = billing.plan if billing else DEFAULT_PLAN
+    # Gate on status so a never-paid (`incomplete`) subscription does not grant
+    # the paid room capacity.
+    plan = effective_plan(billing.plan, billing.status) if billing else DEFAULT_PLAN
     return cap_for_plan(plan)

--- a/backend/topix/datatypes/user_billing.py
+++ b/backend/topix/datatypes/user_billing.py
@@ -8,6 +8,23 @@ from pydantic import BaseModel, Field
 BillingPlan = Literal["free", "plus"]
 BillingStatus = Literal["active", "trialing", "past_due", "canceled", "incomplete"]
 
+# Subscription statuses that actually grant paid access. `incomplete` (a
+# subscription created before its first payment succeeds) and `canceled` must
+# NOT grant access; `past_due` keeps access during Stripe's retry grace window.
+ACCESS_GRANTING_STATUSES: frozenset[str] = frozenset({"active", "trialing", "past_due"})
+
+
+def effective_plan(plan: BillingPlan, status: BillingStatus) -> BillingPlan:
+    """Resolve the plan a user is truly entitled to, gated on subscription status.
+
+    A paid plan only grants access while the subscription is in an
+    access-granting status; otherwise the user falls back to ``free``. This
+    guards against never-paid (``incomplete``) subscriptions granting Plus.
+    """
+    if plan != "free" and status not in ACCESS_GRANTING_STATUSES:
+        return "free"
+    return plan
+
 
 class UserBilling(BaseModel):
     """Billing model representing a user's current plan and status."""


### PR DESCRIPTION
## Problem (prod incident — billing is ON)

Stripe fires \`customer.subscription.created\` with status **\`incomplete\`** *before* the first payment succeeds. The webhook granted \`plus\` to every status except \`canceled\`/\`deleted\`, and **neither entitlement gate checked \`status\`**. Result: a never-paid subscription (e.g. an AMEX 3DS/SCA failure that keeps retrying) was written to the DB as \`plan="plus"\` and the user received real Plus access (200/day rate limits instead of 50/day).

Observed in Stripe: multiple "Subscription creation" payments in \`Canceled\` status (no decline reason → abandoned/failed authentication), while the corresponding customers sit at \`plan=plus, status=incomplete\` in \`user_billing\`.

## Fix

Single source of truth + three call sites:

- **\`datatypes/user_billing.py\`** — new \`effective_plan(plan, status)\`. A paid plan only grants access while status ∈ \`{active, trialing, past_due}\`; \`incomplete\`/\`canceled\` → \`free\`. (\`past_due\` kept as access-granting to avoid cutting off real customers during Stripe's retry grace window — self-heals to \`active\` on a successful retry.)
- **\`entitlements.py\`** and **\`token_plan.py\`** — both run \`billing.plan\` through \`effective_plan\`. This stops improper access **immediately and independent of the DB contents**, since server-side enforcement reads billing state live.
- **\`billing.py\` webhook** — stops *persisting* a paid plan for non-access statuses.

## Tests

- New \`test_effective_plan.py\` (status → effective plan matrix).
- New rate-limiter case: \`incomplete\` Plus subscriber gets free limits.
- Updated existing rate-limiter fixtures to carry \`status\`.
- 19 passed, ruff clean.

## Post-deploy DB cleanup (optional, hygiene — access already gated by code)

Audit who was over-entitled:
\`\`\`sql
SELECT user_uid, plan, status, stripe_customer_id, stripe_subscription_id, updated_at
FROM user_billing
WHERE plan <> 'free' AND status NOT IN ('active', 'trialing', 'past_due')
ORDER BY updated_at DESC;
\`\`\`
Then downgrade:
\`\`\`sql
UPDATE user_billing SET plan = 'free', updated_at = NOW()
WHERE plan <> 'free' AND status NOT IN ('active', 'trialing', 'past_due');
\`\`\`

## Note on stale tokens

Over-entitled users hold JWTs still claiming \`plan: plus\` until expiry/refresh — affects only frontend UI; server-side gates now enforce correctly regardless of the token claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)