### PR TITLE
refactor(agent): single services transport seam (desktop-relay groundwork)

### DIFF
--- a/webui/src/features/agent/engine/byok-relay-fallback.test.ts
+++ b/webui/src/features/agent/engine/byok-relay-fallback.test.ts
@@ -1,21 +1,27 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 
-// The default transports for search/code go through the shared api layer. Mock
-// it so we can drive the "over quota → retry with the user's key" fallback.
-vi.mock("@/api", () => ({ apiFetch: vi.fn() }))
+// The default transports for search/code go through the shared services
+// transport (→ fetchWithAuthRaw). Mock it to drive the "over quota (429) → retry
+// with the user's key" fallback. A 429 is a non-ok Response, not a throw.
+const fetchWithAuthRaw = vi.hoisted(() => vi.fn())
+vi.mock("@/api", () => ({ fetchWithAuthRaw }))
 
-import { apiFetch } from "@/api"
 import { managedSearchClient } from "./web-search"
 import { managedCodeClient } from "./code-interpreter"
 
 
-const apiFetchMock = vi.mocked(apiFetch)
+const jsonResponse = <T,>(data: T): Response =>
+  ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response
 
 
-const headersOf = (callIndex: number): Record<string, string> => {
-  const opts = apiFetchMock.mock.calls[callIndex]?.[0] as { headers?: Record<string, string> }
-  return opts?.headers ?? {}
+const errorResponse = (status: number): Response =>
+  ({ ok: false, status }) as unknown as Response
+
+
+const providerKeyOf = (callIndex: number): string | null => {
+  const init = fetchWithAuthRaw.mock.calls[callIndex]?.[1] as { headers: Headers } | undefined
+  return init ? init.headers.get("X-Provider-Key") : null
 }
 
 
@@ -24,42 +30,42 @@ afterEach(() => vi.clearAllMocks())
 
 describe("search BYOK fallback on 429", () => {
   it("retries with X-Provider-Key when the managed call is over quota", async () => {
-    apiFetchMock
-      .mockRejectedValueOnce(new Error("429 Too Many Requests - over quota"))
-      .mockResolvedValueOnce({ data: { answer: "", results: [{ url: "https://a.com", title: "A", content: "b" }] } })
+    fetchWithAuthRaw
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(jsonResponse({ answer: "", results: [{ url: "https://a.com", title: "A", content: "b" }] }))
 
     const results = await managedSearchClient({ runId: "r1", engine: "exa", byokKey: "exa-user" }).search("cats")
 
-    expect(apiFetchMock).toHaveBeenCalledTimes(2)
-    expect(headersOf(0)["X-Provider-Key"]).toBeUndefined() // 1st call: our keys
-    expect(headersOf(1)["X-Provider-Key"]).toBe("exa-user") // retry: user's key
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(2)
+    expect(providerKeyOf(0)).toBeNull() // 1st call: our keys
+    expect(providerKeyOf(1)).toBe("exa-user") // retry: user's key
     expect(results[0].url).toBe("https://a.com")
   })
 
   it("does not retry (and rethrows) when there's no BYOK key", async () => {
-    apiFetchMock.mockRejectedValueOnce(new Error("429 Too Many Requests"))
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(429))
     await expect(managedSearchClient({ runId: "r1" }).search("cats")).rejects.toThrow("429")
-    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(1)
   })
 
   it("does not retry on a non-429 error", async () => {
-    apiFetchMock.mockRejectedValueOnce(new Error("500 Internal Server Error"))
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(500))
     await expect(managedSearchClient({ byokKey: "exa-user" }).search("cats")).rejects.toThrow("500")
-    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(1)
   })
 })
 
 
 describe("code BYOK fallback on 429", () => {
   it("retries the run with X-Provider-Key when over quota", async () => {
-    apiFetchMock
-      .mockRejectedValueOnce(new Error("429 Too Many Requests"))
-      .mockResolvedValueOnce({ data: { status: "success", stdout: "ok", stderr: "", duration_ms: 3 } })
+    fetchWithAuthRaw
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(jsonResponse({ status: "success", stdout: "ok", stderr: "", duration_ms: 3 }))
 
     const r = await managedCodeClient({ runId: "r1", byokKey: "dtn-user" }).run("print(1)", "python")
 
-    expect(apiFetchMock).toHaveBeenCalledTimes(2)
-    expect(headersOf(1)["X-Provider-Key"]).toBe("dtn-user")
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(2)
+    expect(providerKeyOf(1)).toBe("dtn-user")
     expect(r.ok).toBe(true)
   })
 })

--- a/webui/src/features/agent/engine/code-interpreter.ts
+++ b/webui/src/features/agent/engine/code-interpreter.ts
@@ -9,11 +9,11 @@
  * Signed-out has no authed proxy → off.
  */
 import { z } from "zod"
-import { apiFetch } from "@/api"
 import { defineTool, type Tool } from "./types"
 import type { CodeClient, CodeResult } from "./services/clients"
 import { resolveService } from "./services/resolve"
 import { isOverQuotaError, runIdHeaders } from "./services/run"
+import { servicesPost } from "./services/transport"
 
 
 type CodeResponse = {
@@ -30,19 +30,17 @@ export type CodePost = (body: { code: string; language: string }) => Promise<Cod
 
 const makeDefaultCodePost = (runId?: string, byokKey?: string, alwaysByok = false): CodePost => async (body) => {
   const call = (withKey: boolean) =>
-    apiFetch<{ data: CodeResponse }>({
-      path: "/ai/code",
-      method: "POST",
-      body,
-      headers: { ...runIdHeaders(runId), ...(withKey && byokKey ? { "X-Provider-Key": byokKey } : {}) },
+    servicesPost<CodeResponse>("/ai/code", body, {
+      ...runIdHeaders(runId),
+      ...(withKey && byokKey ? { "X-Provider-Key": byokKey } : {}),
     })
   // byok mode → run on the user's Daytona key directly; managed → ours first,
   // fall back to their key on a 429 (over quota).
-  if (alwaysByok && byokKey) return (await call(true)).data
+  if (alwaysByok && byokKey) return call(true)
   try {
-    return (await call(false)).data
+    return await call(false)
   } catch (e) {
-    if (byokKey && isOverQuotaError(e)) return (await call(true)).data
+    if (byokKey && isOverQuotaError(e)) return call(true)
     throw e
   }
 }

--- a/webui/src/features/agent/engine/fetch-url.ts
+++ b/webui/src/features/agent/engine/fetch-url.ts
@@ -4,11 +4,11 @@
  * (browser CORS + no key relay), like the other non-LLM services.
  */
 import { z } from "zod"
-import { apiFetch } from "@/api"
 import { defineTool, type Tool } from "./types"
 import type { FetchClient, PageContent } from "./services/clients"
 import { resolveService } from "./services/resolve"
 import { runIdHeaders } from "./services/run"
+import { servicesPost } from "./services/transport"
 
 
 type FetchResponse = { url: string; title: string | null; text: string }
@@ -18,15 +18,8 @@ type FetchResponse = { url: string; title: string | null; text: string }
 export type FetchPost = (body: { url: string }) => Promise<FetchResponse>
 
 
-const makeDefaultFetchPost = (runId?: string): FetchPost => async (body) => {
-  const res = await apiFetch<{ data: FetchResponse }>({
-    path: "/ai/fetch",
-    method: "POST",
-    body,
-    headers: runIdHeaders(runId),
-  })
-  return res.data
-}
+const makeDefaultFetchPost = (runId?: string): FetchPost => async (body) =>
+  servicesPost<FetchResponse>("/ai/fetch", body, runIdHeaders(runId))
 
 
 /** Managed fetch client — reads a page via the `/ai/fetch` proxy. */

--- a/webui/src/features/agent/engine/managed-client.ts
+++ b/webui/src/features/agent/engine/managed-client.ts
@@ -8,11 +8,9 @@
  * BYOK client — only the transport differs. Metering (per run) lands in G4.
  */
 import type { ChatCompletionMessage } from "openai/resources/chat/completions"
-import { apiFetch, fetchWithAuthRaw } from "@/api"
-import { API_URL } from "@/config/api"
-import { handleStreamingResponse } from "../utils/stream/digest"
 import { fromOpenAiMessage, toOpenAiMessages, toOpenAiTools } from "./byok-client"
 import { runIdHeaders } from "./services/run"
+import { servicesPost, servicesStream } from "./services/transport"
 import type { LlmClient, LlmMessage, LlmStreamEvent, LlmToolDef, LlmTurn } from "./types"
 
 
@@ -37,27 +35,12 @@ export type ManagedStreamLine =
 export type LlmStreamPost = (body: ManagedRequest) => AsyncIterable<ManagedStreamLine>
 
 
-const makeDefaultPost = (runId?: string): LlmTurnPost => async (body) => {
-  const res = await apiFetch<{ data: { choices: { message: ChatCompletionMessage }[] } }>({
-    path: "/ai/llm",
-    method: "POST",
-    body,
-    headers: runIdHeaders(runId),
-  })
-  return res.data
-}
+const makeDefaultPost = (runId?: string): LlmTurnPost => (body) =>
+  servicesPost<{ choices: { message: ChatCompletionMessage }[] }>("/ai/llm", body, runIdHeaders(runId))
 
 
-const makeDefaultStreamPost = (runId?: string): LlmStreamPost => async function* (body) {
-  const headers = new Headers({ "Content-Type": "application/json", ...runIdHeaders(runId) })
-  const res = await fetchWithAuthRaw(new URL("/ai/llm/stream", API_URL).toString(), {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  })
-  if (!res.ok) throw new Error(`/ai/llm/stream failed: ${res.status}`)
-  yield* handleStreamingResponse<ManagedStreamLine>(res)
-}
+const makeDefaultStreamPost = (runId?: string): LlmStreamPost => (body) =>
+  servicesStream<ManagedStreamLine>("/ai/llm/stream", body, runIdHeaders(runId))
 
 
 export class ManagedLlmClient implements LlmClient {

--- a/webui/src/features/agent/engine/managed-run-id.test.ts
+++ b/webui/src/features/agent/engine/managed-run-id.test.ts
@@ -1,17 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 
-// The managed factories' DEFAULT transports route through the shared api layer.
-// Mock it so we can assert the per-run X-Run-Id header is attached (metering).
-vi.mock("@/api", () => ({
-  apiFetch: vi.fn(),
-  fetchWithAuthRaw: vi.fn(),
-}))
-vi.mock("@/config/api", () => ({ API_URL: "https://api.test" }))
-vi.mock("../utils/stream/digest", () => ({ handleStreamingResponse: vi.fn() }))
+// The managed factories' DEFAULT transports route through the shared services
+// transport (→ fetchWithAuthRaw). Mock it so we can assert the per-run X-Run-Id
+// header is attached (metering) across every client + the streaming path.
+const fetchWithAuthRaw = vi.hoisted(() => vi.fn())
+vi.mock("@/api", () => ({ fetchWithAuthRaw }))
 
-import { apiFetch, fetchWithAuthRaw } from "@/api"
-import { handleStreamingResponse } from "../utils/stream/digest"
 import { managedLlmClient } from "./managed-client"
 import { managedSearchClient } from "./web-search"
 import { managedCodeClient } from "./code-interpreter"
@@ -19,70 +14,72 @@ import { managedFetchClient } from "./fetch-url"
 import type { LlmMessage } from "./types"
 
 
-const apiFetchMock = vi.mocked(apiFetch)
-const rawMock = vi.mocked(fetchWithAuthRaw)
-const streamMock = vi.mocked(handleStreamingResponse)
+const jsonResponse = <T,>(data: T): Response =>
+  ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response
 
 
-// Header value passed to the last apiFetch call, whatever HeadersInit shape it took.
-const lastRunIdHeader = (): string | undefined => {
-  const opts = apiFetchMock.mock.calls.at(-1)?.[0] as { headers?: Record<string, string> } | undefined
-  return opts?.headers?.["X-Run-Id"]
+// Run-id header on the last transport call (all clients send a Headers object).
+const lastRunIdHeader = (): string | null => {
+  const init = fetchWithAuthRaw.mock.calls.at(-1)?.[1] as { headers: Headers } | undefined
+  return init ? init.headers.get("X-Run-Id") : null
 }
 
 
-afterEach(() => {
-  vi.clearAllMocks()
-})
+afterEach(() => vi.clearAllMocks())
 
 
 describe("managed default transports attach X-Run-Id", () => {
   it("LLM /ai/llm sends the run id", async () => {
-    apiFetchMock.mockResolvedValue({ data: { choices: [{ message: { role: "assistant", content: "ok" } }] } })
+    fetchWithAuthRaw.mockResolvedValue(
+      jsonResponse({ choices: [{ message: { role: "assistant", content: "ok" } }] }),
+    )
     const messages: LlmMessage[] = [{ role: "user", content: "hi" }]
     await managedLlmClient("auto", { runId: "run-42" }).complete(messages, [])
     expect(lastRunIdHeader()).toBe("run-42")
   })
 
   it("search /ai/search sends the run id", async () => {
-    apiFetchMock.mockResolvedValue({ data: { answer: "", results: [] } })
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ answer: "", results: [] }))
     await managedSearchClient({ runId: "run-42" }).search("cats")
     expect(lastRunIdHeader()).toBe("run-42")
   })
 
   it("code /ai/code sends the run id", async () => {
-    apiFetchMock.mockResolvedValue({ data: { status: "success", stdout: "", stderr: "", duration_ms: 1 } })
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ status: "success", stdout: "", stderr: "", duration_ms: 1 }))
     await managedCodeClient({ runId: "run-42" }).run("1+1", "python")
     expect(lastRunIdHeader()).toBe("run-42")
   })
 
   it("fetch /ai/fetch sends the run id", async () => {
-    apiFetchMock.mockResolvedValue({ data: { url: "https://a.com", title: null, text: "" } })
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ url: "https://a.com", title: null, text: "" }))
     await managedFetchClient({ runId: "run-42" }).fetch("https://a.com")
     expect(lastRunIdHeader()).toBe("run-42")
   })
 
-  it("omits the header entirely when no run id is given", async () => {
-    apiFetchMock.mockResolvedValue({ data: { answer: "", results: [] } })
+  it("omits the run-id header entirely when no run id is given", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ answer: "", results: [] }))
     await managedSearchClient({}).search("q")
-    const opts = apiFetchMock.mock.calls.at(-1)?.[0] as { headers?: Record<string, string> }
-    expect(opts.headers).toEqual({})
+    expect(lastRunIdHeader()).toBeNull()
   })
 
-  it("streaming /ai/llm/stream sets the run id header", async () => {
-    rawMock.mockResolvedValue({ ok: true } as Response)
-    streamMock.mockReturnValue((async function* () {
-      yield { type: "final", message: { role: "assistant", content: "done" } }
-    })() as ReturnType<typeof handleStreamingResponse>)
+  it("streaming /ai/llm/stream sets the run id + JSON content-type", async () => {
+    const ndjson = JSON.stringify({ type: "final", message: { role: "assistant", content: "done", refusal: null } }) + "\n"
+    fetchWithAuthRaw.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(ndjson))
+          c.close()
+        },
+      }),
+    } as unknown as Response)
 
     const messages: LlmMessage[] = [{ role: "user", content: "hi" }]
-    const it = managedLlmClient("auto", { runId: "run-99" }).completeStream!(messages, [])
-    // drain the stream so the transport actually runs
-    for await (const _ev of it) void _ev
+    for await (const _ev of managedLlmClient("auto", { runId: "run-99" }).completeStream!(messages, [])) void _ev
 
-    const init = rawMock.mock.calls.at(-1)?.[1] as RequestInit
-    const headers = init.headers as Headers
-    expect(headers.get("X-Run-Id")).toBe("run-99")
-    expect(headers.get("Content-Type")).toBe("application/json")
+    const init = fetchWithAuthRaw.mock.calls.at(-1)?.[1] as { headers: Headers }
+    expect(init.headers.get("X-Run-Id")).toBe("run-99")
+    expect(init.headers.get("Content-Type")).toBe("application/json")
   })
 })

--- a/webui/src/features/agent/engine/services/transport-clients.test.ts
+++ b/webui/src/features/agent/engine/services/transport-clients.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+
+// Exercise each managed client's DEFAULT transport path (no injected post) end
+// to end: client → makeDefault*Post → servicesPost/Stream → fetchWithAuthRaw.
+const fetchWithAuthRaw = vi.hoisted(() => vi.fn())
+vi.mock("@/api", () => ({ fetchWithAuthRaw }))
+
+
+import { managedSearchClient } from "../web-search"
+import { managedCodeClient } from "../code-interpreter"
+import { managedFetchClient } from "../fetch-url"
+import { managedLlmClient } from "../managed-client"
+import type { LlmMessage, LlmStreamEvent } from "../types"
+
+
+const jsonResponse = <T,>(data: T): Response =>
+  ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response
+
+
+const errorResponse = (status: number): Response =>
+  ({ ok: false, status }) as unknown as Response
+
+
+const streamResponse = (lines: unknown[]): Response => {
+  const ndjson = lines.map((l) => JSON.stringify(l)).join("\n") + "\n"
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(ndjson))
+      c.close()
+    },
+  })
+  return { ok: true, status: 200, body } as unknown as Response
+}
+
+
+const headersOf = (callIndex: number): Headers =>
+  (fetchWithAuthRaw.mock.calls[callIndex][1] as { headers: Headers }).headers
+
+
+const urlOf = (callIndex: number): string => fetchWithAuthRaw.mock.calls[callIndex][0] as string
+
+
+beforeEach(() => fetchWithAuthRaw.mockReset())
+
+
+describe("managedSearchClient (default transport)", () => {
+  it("hits /ai/search with the run id and no provider key on the managed happy path", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ answer: "", results: [{ url: "https://a.com" }] }))
+    const results = await managedSearchClient({ runId: "run-1" }).search("cats")
+    expect(results).toEqual([{ url: "https://a.com" }])
+    expect(urlOf(0)).toMatch(/\/ai\/search$/)
+    expect(headersOf(0).get("X-Run-Id")).toBe("run-1")
+    expect(headersOf(0).get("X-Provider-Key")).toBeNull()
+    expect(fetchWithAuthRaw).toHaveBeenCalledOnce()
+  })
+
+  it("falls back to the BYOK key on a 429 (our-keys-first, yours-as-fallback)", async () => {
+    fetchWithAuthRaw
+      .mockResolvedValueOnce(errorResponse(429)) // managed → over quota
+      .mockResolvedValueOnce(jsonResponse({ answer: "", results: [{ url: "https://b.com" }] })) // retry w/ key
+    const results = await managedSearchClient({ byokKey: "exa-key", engine: "exa" }).search("dogs")
+    expect(results).toEqual([{ url: "https://b.com" }])
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(2)
+    expect(headersOf(0).get("X-Provider-Key")).toBeNull() // first: our keys
+    expect(headersOf(1).get("X-Provider-Key")).toBe("exa-key") // retry: relayed key
+  })
+
+  it("sends the BYOK key up front in byok mode (alwaysByok)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ answer: "", results: [] }))
+    await managedSearchClient({ byokKey: "exa-key", alwaysByok: true }).search("q")
+    expect(fetchWithAuthRaw).toHaveBeenCalledOnce()
+    expect(headersOf(0).get("X-Provider-Key")).toBe("exa-key")
+  })
+
+  it("propagates a non-429 error without retrying", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(500))
+    await expect(managedSearchClient({ byokKey: "exa-key" }).search("q")).rejects.toThrow()
+    expect(fetchWithAuthRaw).toHaveBeenCalledOnce() // no fallback on 500
+  })
+})
+
+
+describe("managedCodeClient (default transport)", () => {
+  it("maps a successful /ai/code response to a CodeResult", async () => {
+    fetchWithAuthRaw.mockResolvedValue(
+      jsonResponse({ status: "success", stdout: "2", stderr: "", duration_ms: 5 }),
+    )
+    const r = await managedCodeClient({ runId: "r" }).run("print(1+1)", "python")
+    expect(r).toEqual({ ok: true, stdout: "2", stderr: "", error: undefined })
+    expect(urlOf(0)).toMatch(/\/ai\/code$/)
+  })
+
+  it("falls back to the BYOK Daytona key on 429", async () => {
+    fetchWithAuthRaw
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(jsonResponse({ status: "success", stdout: "ok", stderr: "", duration_ms: 1 }))
+    const r = await managedCodeClient({ byokKey: "dt-key" }).run("x", "python")
+    expect(r.ok).toBe(true)
+    expect(headersOf(1).get("X-Provider-Key")).toBe("dt-key")
+  })
+})
+
+
+describe("managedFetchClient (default transport)", () => {
+  it("maps /ai/fetch to a PageContent", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ url: "https://x.com", title: "X", text: "body" }))
+    const page = await managedFetchClient({ runId: "r" }).fetch("https://x.com")
+    expect(page).toEqual({ url: "https://x.com", title: "X", text: "body" })
+    expect(urlOf(0)).toMatch(/\/ai\/fetch$/)
+  })
+})
+
+
+describe("managedLlmClient (default transport)", () => {
+  const messages: LlmMessage[] = [{ role: "user", content: "hi" }]
+
+  const drain = async (it: AsyncIterable<LlmStreamEvent>): Promise<LlmStreamEvent[]> => {
+    const out: LlmStreamEvent[] = []
+    for await (const ev of it) out.push(ev)
+    return out
+  }
+
+  it("posts a non-stream turn to /ai/llm and maps the choice", async () => {
+    fetchWithAuthRaw.mockResolvedValue(
+      jsonResponse({ choices: [{ message: { role: "assistant", content: "the answer" } }] }),
+    )
+    const turn = await managedLlmClient("auto", { runId: "r" }).complete(messages, [])
+    expect(turn).toEqual({ kind: "text", text: "the answer" })
+    expect(urlOf(0)).toMatch(/\/ai\/llm$/)
+  })
+
+  it("streams /ai/llm/stream NDJSON into mapped events", async () => {
+    fetchWithAuthRaw.mockResolvedValue(
+      streamResponse([
+        { type: "delta", text: "He" },
+        { type: "delta", text: "llo" },
+        { type: "final", message: { role: "assistant", content: "Hello", refusal: null } },
+      ]),
+    )
+    const events = await drain(managedLlmClient("auto", { runId: "r" }).completeStream!(messages, []))
+    expect(events).toEqual([
+      { kind: "delta", text: "He" },
+      { kind: "delta", text: "llo" },
+      { kind: "final", turn: { kind: "text", text: "Hello" } },
+    ])
+    expect(urlOf(0)).toMatch(/\/ai\/llm\/stream$/)
+  })
+})

--- a/webui/src/features/agent/engine/services/transport.test.ts
+++ b/webui/src/features/agent/engine/services/transport.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { API_URL } from "@/config/api"
+
+
+// The transport is the ONLY thing that touches @/api; mock the raw fetch so we
+// can assert URL/headers/body and simulate status codes without a network.
+const fetchWithAuthRaw = vi.hoisted(() => vi.fn())
+vi.mock("@/api", () => ({ fetchWithAuthRaw }))
+
+
+import { isOverQuotaError } from "./run"
+import {
+  getServicesBaseUrl,
+  servicesPost,
+  servicesStream,
+  setServicesBaseUrl,
+} from "./transport"
+
+
+const jsonResponse = <T,>(data: T): Response =>
+  ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response
+
+
+const errorResponse = (status: number): Response =>
+  ({ ok: false, status }) as unknown as Response
+
+
+const streamResponse = (lines: unknown[]): Response => {
+  const ndjson = lines.map((l) => JSON.stringify(l)).join("\n") + "\n"
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(ndjson))
+      c.close()
+    },
+  })
+  return { ok: true, status: 200, body } as unknown as Response
+}
+
+
+const lastCall = () => fetchWithAuthRaw.mock.calls.at(-1) as [string, RequestInit & { headers: Headers }]
+
+
+beforeEach(() => fetchWithAuthRaw.mockReset())
+afterEach(() => setServicesBaseUrl(API_URL)) // undo any base-url swap
+
+
+describe("servicesPost", () => {
+  it("unwraps the { data } envelope", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ answer: "hi", results: [] }))
+    const out = await servicesPost<{ answer: string; results: unknown[] }>("/ai/search", { query: "q" })
+    expect(out).toEqual({ answer: "hi", results: [] })
+  })
+
+  it("POSTs to baseUrl + path with JSON content-type and the body serialized", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ ok: true }))
+    await servicesPost("/ai/code", { code: "1+1", language: "python" })
+    const [url, init] = lastCall()
+    expect(url).toBe(`${new URL("/ai/code", getServicesBaseUrl()).toString()}`)
+    expect(init.method).toBe("POST")
+    expect(init.headers.get("Content-Type")).toBe("application/json")
+    expect(init.body).toBe(JSON.stringify({ code: "1+1", language: "python" }))
+  })
+
+  it("merges caller headers (run id + provider key)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({}))
+    await servicesPost("/ai/search", { query: "q" }, { "X-Run-Id": "r1", "X-Provider-Key": "sk-x" })
+    const [, init] = lastCall()
+    expect(init.headers.get("X-Run-Id")).toBe("r1")
+    expect(init.headers.get("X-Provider-Key")).toBe("sk-x")
+  })
+
+  it("throws an error whose message keeps 429 as a token (isOverQuotaError contract)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(429))
+    const err = await servicesPost("/ai/search", {}).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(isOverQuotaError(err)).toBe(true)
+  })
+
+  it("throws on other non-2xx without matching the over-quota signal", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(500))
+    const err = await servicesPost("/ai/search", {}).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(isOverQuotaError(err)).toBe(false)
+  })
+
+  it("routes through a swapped base URL (the desktop seam)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({}))
+    setServicesBaseUrl("http://localhost:9999")
+    await servicesPost("/ai/fetch", { url: "https://x.com" })
+    const [url] = lastCall()
+    expect(url).toBe("http://localhost:9999/ai/fetch")
+  })
+})
+
+
+describe("servicesStream", () => {
+  const drain = async <T,>(it: AsyncIterable<T>): Promise<T[]> => {
+    const out: T[] = []
+    for await (const x of it) out.push(x)
+    return out
+  }
+
+  it("yields the NDJSON frames in order", async () => {
+    fetchWithAuthRaw.mockResolvedValue(
+      streamResponse([{ type: "delta", text: "a" }, { type: "delta", text: "b" }, { type: "final" }]),
+    )
+    const frames = await drain(servicesStream("/ai/llm/stream", { model: "auto" }))
+    expect(frames).toEqual([{ type: "delta", text: "a" }, { type: "delta", text: "b" }, { type: "final" }])
+  })
+
+  it("throws (429-detectable) before streaming when the response is not ok", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(429))
+    const err = await drain(servicesStream("/ai/llm/stream", {})).catch((e) => e)
+    expect(isOverQuotaError(err)).toBe(true)
+  })
+})

--- a/webui/src/features/agent/engine/services/transport.ts
+++ b/webui/src/features/agent/engine/services/transport.ts
@@ -1,0 +1,84 @@
+/**
+ * Services transport — the single seam through which every managed `/ai/*` call
+ * (search / code / fetch / llm / …) reaches the relay.
+ *
+ * Today the relay is the cloud backend (`API_URL`). This module is the ONE place
+ * that owns "where the relay lives", so a future standalone/desktop build can
+ * bundle the same backend locally and point every service at it with a single
+ * `setServicesBaseUrl(...)` call — no per-client change. All requests go through
+ * `fetchWithAuthRaw`, so auth (bearer + 401 refresh) is identical to the rest of
+ * the app; only the base URL is swappable here.
+ */
+import { API_URL } from "@/config/api"
+import { fetchWithAuthRaw } from "@/api"
+import { handleStreamingResponse } from "../../utils/stream/digest"
+
+
+let baseUrl: string = API_URL
+
+
+/**
+ * Point the `/ai/*` services at a different backend (e.g. a bundled local
+ * backend on desktop). Call once at bootstrap; defaults to the cloud `API_URL`.
+ */
+export const setServicesBaseUrl = (url: string): void => {
+  baseUrl = url
+}
+
+
+/** The base URL the services currently resolve against. */
+export const getServicesBaseUrl = (): string => baseUrl
+
+
+const buildUrl = (path: string): string => new URL(path, baseUrl).toString()
+
+
+const jsonHeaders = (extra?: Record<string, string>): Headers =>
+  new Headers({ "Content-Type": "application/json", ...(extra ?? {}) })
+
+
+/**
+ * Fold the HTTP status into the thrown error's message with `429` kept as a
+ * standalone token, so `isOverQuotaError`'s `\b429\b` match keeps working (it
+ * drives the over-quota → BYOK fallback across the search/code clients).
+ */
+const failed = (path: string, status: number): Error => new Error(`${path} failed: ${status}`)
+
+
+/**
+ * POST a JSON body to a service endpoint and return the `{ data }` envelope's
+ * payload (the shape `with_standard_response` wraps every `/ai/*` reply in).
+ */
+export async function servicesPost<T>(
+  path: string,
+  body: unknown,
+  headers?: Record<string, string>,
+): Promise<T> {
+  const res = await fetchWithAuthRaw(buildUrl(path), {
+    method: "POST",
+    headers: jsonHeaders(headers),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw failed(path, res.status)
+  const json = (await res.json()) as { data: T }
+  return json.data
+}
+
+
+/**
+ * POST a JSON body and stream the NDJSON response as typed lines (the `/ai/llm/
+ * stream` shape). Not wrapped in a `{ data }` envelope — each line is a frame.
+ */
+export async function* servicesStream<T>(
+  path: string,
+  body: unknown,
+  headers?: Record<string, string>,
+): AsyncGenerator<T> {
+  const res = await fetchWithAuthRaw(buildUrl(path), {
+    method: "POST",
+    headers: jsonHeaders(headers),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw failed(path, res.status)
+  yield* handleStreamingResponse<T>(res)
+}

--- a/webui/src/features/agent/engine/web-search.ts
+++ b/webui/src/features/agent/engine/web-search.ts
@@ -9,11 +9,11 @@
  * not stored). Signed-out has no authed proxy → off.
  */
 import { z } from "zod"
-import { apiFetch } from "@/api"
 import { defineTool, type AgentEvent, type Tool } from "./types"
 import type { SearchClient, SearchResult } from "./services/clients"
 import { resolveService } from "./services/resolve"
 import { isOverQuotaError, runIdHeaders } from "./services/run"
+import { servicesPost } from "./services/transport"
 
 
 type SearchResponse = { answer: string; results: SearchResult[] }
@@ -25,19 +25,17 @@ export type SearchPost = (body: { query: string; engine?: string }) => Promise<S
 
 const makeDefaultSearchPost = (runId?: string, byokKey?: string, alwaysByok = false): SearchPost => async (body) => {
   const call = (withKey: boolean) =>
-    apiFetch<{ data: SearchResponse }>({
-      path: "/ai/search",
-      method: "POST",
-      body,
-      headers: { ...runIdHeaders(runId), ...(withKey && byokKey ? { "X-Provider-Key": byokKey } : {}) },
+    servicesPost<SearchResponse>("/ai/search", body, {
+      ...runIdHeaders(runId),
+      ...(withKey && byokKey ? { "X-Provider-Key": byokKey } : {}),
     })
   // byok mode: the user's key IS the source → send it up front. managed mode:
   // our keys first, fall back to the user's key only if we're over quota (429).
-  if (alwaysByok && byokKey) return (await call(true)).data
+  if (alwaysByok && byokKey) return call(true)
   try {
-    return (await call(false)).data
+    return await call(false)
   } catch (e) {
-    if (byokKey && isOverQuotaError(e)) return (await call(true)).data
+    if (byokKey && isOverQuotaError(e)) return call(true)
     throw e
   }
 }


### PR DESCRIPTION
## What

Consolidates every managed `/ai/*` call (search / code / fetch / llm) behind a single **`ServicesTransport`** (`servicesPost` / `servicesStream`). Previously each client built its transport inline against `apiFetch`/`fetchWithAuthRaw` + `API_URL`.

## Why

Groundwork for the standalone/desktop app on the roadmap. Today the relay is the cloud backend; with one seam that owns *where the relay lives*, a desktop build can bundle the same backend locally and point all services at it with a single `setServicesBaseUrl(...)` — no per-client change. It also removes the scattered base-URL/header duplication.

## Notes

- Both helpers go through `fetchWithAuthRaw`, so auth (bearer + 401 refresh) is unchanged.
- The `\b429\b` message token is preserved so `isOverQuotaError` still drives the "our keys first → BYOK on 429" fallback in search/code.
- **No behavior change** on the web app — base URL still defaults to `API_URL`.
- Deferred: A3 (making "relay available" independent of cloud sign-in) — lands with the standalone app.

## Tests

- `transport.test.ts` — envelope unwrap, header merge, base-URL swap, 429/500 error contract, NDJSON streaming.
- `transport-clients.test.ts` — each client's default path end-to-end (path, run-id, provider-key relay, 429 fallback, stream mapping).
- Updated `managed-run-id.test.ts` + `byok-relay-fallback.test.ts` to the new transport.
- Full agent suite: 220 passing; `make lint-ui` clean.
