### PR TITLE
feat: document Q&A on the local agent (Mistral parse + per-board BM25)

### DIFF
--- a/backend/test/unit/api/router/test_ai_parse_router.py
+++ b/backend/test/unit/api/router/test_ai_parse_router.py
@@ -16,6 +16,7 @@ class _FakeParser:
     """Stand-in for MistralParser: records the api key, returns fixed pages."""
 
     last_api_key: str | None = None
+    num_pages: int = 2  # what get_num_pages reports (drives the page-limit gate)
 
     def __init__(self, api_key: str | None = None):
         _FakeParser.last_api_key = api_key
@@ -24,6 +25,9 @@ class _FakeParser:
     def from_config(cls):
         return cls(api_key="server-key")
 
+    def get_num_pages(self, filepath) -> int:
+        return _FakeParser.num_pages
+
     async def parse(self, filepath, max_pages: int = 200):
         return [{"markdown": "# Page 1", "page": 0}, {"markdown": "body", "page": 1}]
 
@@ -31,6 +35,7 @@ class _FakeParser:
 def _client(monkeypatch) -> TestClient:
     monkeypatch.setattr(ai_module, "MistralParser", _FakeParser)
     _FakeParser.last_api_key = None
+    _FakeParser.num_pages = 2
     app = FastAPI()
     app.include_router(router)
 
@@ -72,3 +77,26 @@ def test_parse_rejects_non_pdf(monkeypatch):
         "/ai/parse", files={"file": ("notes.txt", b"hello", "text/plain")}
     )
     assert res.status_code == 400
+
+
+def test_parse_rejects_oversize_file(monkeypatch):
+    """A PDF over the 5 MB byte limit is rejected (413) before OCR."""
+    big = b"%PDF-1.4 " + b"x" * (5 * 1024 * 1024)
+    res = _client(monkeypatch).post("/ai/parse", files={"file": ("big.pdf", big, "application/pdf")})
+    assert res.status_code == 413
+
+
+def test_parse_rejects_too_many_pages(monkeypatch):
+    """A PDF over the 50-page limit is rejected (400) before OCR."""
+    client = _client(monkeypatch)  # resets num_pages, so set it after
+    _FakeParser.num_pages = 51
+    res = client.post("/ai/parse", files=_pdf_file())
+    assert res.status_code == 400
+
+
+def test_parse_accepts_a_pdf_at_the_page_limit(monkeypatch):
+    """Exactly 50 pages is allowed (boundary)."""
+    client = _client(monkeypatch)
+    _FakeParser.num_pages = 50
+    res = client.post("/ai/parse", files=_pdf_file())
+    assert res.status_code == 200

--- a/backend/test/unit/api/router/test_ai_parse_router.py
+++ b/backend/test/unit/api/router/test_ai_parse_router.py
@@ -1,0 +1,74 @@
+"""Unit tests for POST /ai/parse — PDF → markdown via Mistral OCR.
+
+The Mistral client is faked, so no network and no key are needed; we exercise
+the endpoint's file handling, PDF gate, BYOK-key pass-through, and shaping.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import topix.api.router.ai as ai_module
+
+from topix.api.router.ai import meter_run, router
+
+
+class _FakeParser:
+    """Stand-in for MistralParser: records the api key, returns fixed pages."""
+
+    last_api_key: str | None = None
+
+    def __init__(self, api_key: str | None = None):
+        _FakeParser.last_api_key = api_key
+
+    @classmethod
+    def from_config(cls):
+        return cls(api_key="server-key")
+
+    async def parse(self, filepath, max_pages: int = 200):
+        return [{"markdown": "# Page 1", "page": 0}, {"markdown": "body", "page": 1}]
+
+
+def _client(monkeypatch) -> TestClient:
+    monkeypatch.setattr(ai_module, "MistralParser", _FakeParser)
+    _FakeParser.last_api_key = None
+    app = FastAPI()
+    app.include_router(router)
+
+    async def _no_meter():
+        return None
+
+    app.dependency_overrides[meter_run] = _no_meter
+    return TestClient(app)
+
+
+def _pdf_file() -> dict:
+    return {"file": ("doc.pdf", b"%PDF-1.4 fake", "application/pdf")}
+
+
+def test_parse_returns_joined_markdown_and_page_count(monkeypatch):
+    """A PDF OCRs to markdown (pages joined with a blank line) + a page count."""
+    res = _client(monkeypatch).post("/ai/parse", files=_pdf_file())
+    assert res.status_code == 200
+    data = res.json()["data"]
+    assert data["markdown"] == "# Page 1\n\nbody"
+    assert data["pages"] == 2
+
+
+def test_parse_uses_server_key_by_default(monkeypatch):
+    """No X-Provider-Key → MistralParser.from_config() (our key)."""
+    _client(monkeypatch).post("/ai/parse", files=_pdf_file())
+    assert _FakeParser.last_api_key == "server-key"
+
+
+def test_parse_relays_byok_provider_key(monkeypatch):
+    """X-Provider-Key → MistralParser is constructed with the user's key (relayed)."""
+    _client(monkeypatch).post("/ai/parse", files=_pdf_file(), headers={"X-Provider-Key": "user-mistral-key"})
+    assert _FakeParser.last_api_key == "user-mistral-key"
+
+
+def test_parse_rejects_non_pdf(monkeypatch):
+    """A non-PDF upload is a 400 (only PDFs are supported at launch)."""
+    res = _client(monkeypatch).post(
+        "/ai/parse", files={"file": ("notes.txt", b"hello", "text/plain")}
+    )
+    assert res.status_code == 400

--- a/backend/topix/api/router/ai.py
+++ b/backend/topix/api/router/ai.py
@@ -12,12 +12,14 @@ so a managed turn reuses the exact BYOK mapping — only the transport differs.
 """
 
 import json
+import os
+import tempfile
 
 from typing import Annotated, Any, Literal
 
 import litellm
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, File, Header, HTTPException, Request, Response, UploadFile, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
@@ -37,6 +39,7 @@ from topix.api.utils.rate_limit.policy import resolve_allowed_model_tiers
 from topix.api.utils.rate_limit.service import enforce_rate_limit
 from topix.api.utils.security import decode_and_validate_token, get_current_user_uid
 from topix.config import catalog
+from topix.nlp.parser import MistralParser
 
 router = APIRouter(prefix="/ai", tags=["ai"])
 
@@ -406,3 +409,40 @@ async def ai_fetch(
         "title": first.title if first else None,
         "text": (first.content if first else "") or output.answer or "",
     }
+
+
+@router.post("/parse/", include_in_schema=False)
+@router.post("/parse")
+@with_standard_response
+async def ai_parse(
+    response: Response,
+    request: Request,
+    user_id: Annotated[str | None, Depends(optional_user_uid)],
+    _meter: Annotated[None, Depends(meter_run)],
+    file: UploadFile = File(..., description="PDF to OCR into markdown"),
+    x_provider_key: Annotated[str | None, Header()] = None,
+):
+    """OCR an uploaded PDF into markdown via Mistral; returns `{markdown, pages}`.
+
+    Uses our Mistral key by default, or relays the user's `X-Provider-Key` (a
+    Mistral key) for this call only — never stored. Only PDFs are supported; the
+    bytes are OCR'd from a short-lived temp file and never persisted server-side
+    (the client owns the resulting markdown, offline-first).
+    """
+    filename = file.filename or ""
+    if not (file.content_type == "application/pdf" or filename.lower().endswith(".pdf")):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Only PDF files are supported")
+
+    parser = MistralParser(api_key=x_provider_key) if x_provider_key else MistralParser.from_config()
+
+    file_bytes = await file.read()
+    tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
+    try:
+        tmp.write(file_bytes)
+        tmp.close()
+        pages = await parser.parse(tmp.name)
+    finally:
+        os.unlink(tmp.name)
+
+    markdown = "\n\n".join(str(page["markdown"]) for page in pages)
+    return {"markdown": markdown, "pages": len(pages)}

--- a/backend/topix/api/router/ai.py
+++ b/backend/topix/api/router/ai.py
@@ -47,6 +47,9 @@ router = APIRouter(prefix="/ai", tags=["ai"])
 RUN_TTL_SECONDS = 3600
 # Light abuse guard for the unauthenticated BYOK relay (per client IP, per minute).
 BYOK_IP_PER_MINUTE = 120
+# Upload limits for /ai/parse (mirror the client's pre-checks in doc-attach.tsx).
+MAX_PDF_BYTES = 5 * 1024 * 1024
+MAX_PDF_PAGES = 50
 
 # Token is OPTIONAL here: a BYOK relay call (X-Provider-Key) may be tokenless.
 _oauth2_optional = OAuth2PasswordBearer(tokenUrl="/users/signin", auto_error=False)
@@ -433,13 +436,26 @@ async def ai_parse(
     if not (file.content_type == "application/pdf" or filename.lower().endswith(".pdf")):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Only PDF files are supported")
 
+    file_bytes = await file.read()
+    if len(file_bytes) > MAX_PDF_BYTES:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            f"PDF must be under {MAX_PDF_BYTES // (1024 * 1024)} MB",
+        )
+
     parser = MistralParser(api_key=x_provider_key) if x_provider_key else MistralParser.from_config()
 
-    file_bytes = await file.read()
     tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
     try:
         tmp.write(file_bytes)
         tmp.close()
+        # Page-count gate BEFORE OCR (get_num_pages reads pypdf locally, no spend).
+        # -1 = unreadable; let parse() surface the real error rather than gate on it.
+        page_count = parser.get_num_pages(tmp.name)
+        if page_count > MAX_PDF_PAGES:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, f"PDF must be under {MAX_PDF_PAGES} pages"
+            )
         pages = await parser.parse(tmp.name)
     finally:
         os.unlink(tmp.name)

--- a/webui/src/features/agent/components/chat/assistant-message.tsx
+++ b/webui/src/features/agent/components/chat/assistant-message.tsx
@@ -4,6 +4,7 @@ import { ResponseActions } from "./actions/response-actions"
 import { useMemo } from "react"
 import { isReasoningTextStep, type ReasoningStep, type ReasoningTextStep } from "../../types/stream"
 import { SourcesView } from "./sources-view"
+import { DocSourcesView } from "./doc-sources-view"
 
 
 const EMPTY_STEPS: ReasoningStep[] = []
@@ -32,6 +33,7 @@ export const AssistantMessage = ({
         isStreaming={message.streaming || false}
       />
       {!message.streaming && <SourcesView answer={resp} />}
+      {!message.streaming && <DocSourcesView answer={resp} />}
       {!message.streaming && responseMarkdown && (
         <ResponseActions
           message={responseMarkdown}

--- a/webui/src/features/agent/components/chat/doc-attach.tsx
+++ b/webui/src/features/agent/components/chat/doc-attach.tsx
@@ -18,6 +18,11 @@ import { resolveParseClient } from "@/features/agent/engine/doc-parse"
 import { ingestDocument } from "@/features/agent/local/ingest-doc"
 
 
+// Instant client-side reject (saves the upload); the /ai/parse endpoint enforces
+// the same limits authoritatively. Keep MAX_FILE_BYTES in sync with MAX_PDF_BYTES.
+const MAX_FILE_BYTES = 5 * 1024 * 1024
+
+
 /**
  * Attach a PDF to the current local board for document Q&A: OCR it to markdown
  * (via `/ai/parse`), chunk + persist it, and rebuild the board's search index so
@@ -68,6 +73,10 @@ export const DocAttachButton = ({ boardId }: { boardId: string }) => {
     const file = e.target.files?.[0]
     e.target.value = "" // allow re-picking the same file
     if (!file || busy || inFlight.current) return
+    if (file.size > MAX_FILE_BYTES) {
+      toast.error(`PDF must be under ${MAX_FILE_BYTES / (1024 * 1024)} MB.`)
+      return
+    }
     inFlight.current = true
     try {
       // Same-name on this board → confirm override (parse only AFTER the user

--- a/webui/src/features/agent/components/chat/doc-attach.tsx
+++ b/webui/src/features/agent/components/chat/doc-attach.tsx
@@ -14,6 +14,9 @@ import {
 import { generateUuid } from "@/lib/common"
 import { useIsSignedIn } from "@/lib/auth"
 import { getLocalStores } from "@/features/local-stores"
+import { getCanvasStoreRef } from "@/features/board/harness/canvas-store-ref"
+import { useBoardAppStore } from "@/features/board/harness/store/board-app-store"
+import { addDocumentNode } from "@/features/board/harness/agent/doc-node"
 import { resolveParseClient } from "@/features/agent/engine/doc-parse"
 import { ingestDocument } from "@/features/agent/local/ingest-doc"
 
@@ -52,12 +55,16 @@ export const DocAttachButton = ({ boardId }: { boardId: string }) => {
     const id = toast(`Reading ${file.name}…`, { icon: <Spinner />, duration: Infinity })
     try {
       const { markdown, pages } = await client.parse(file)
-      const { chunks, replaced } = await ingestDocument({ boardId, title: file.name, markdown, pages })
+      const { docId, chunks, replaced } = await ingestDocument({ boardId, title: file.name, markdown, pages })
       toast.dismiss(id)
-      if (chunks === 0) {
+      if (chunks === 0 || !docId) {
         toast.error("No readable text found in that PDF.")
         return
       }
+      // Surface the document as a node on the canvas (id = docId). No-op on a
+      // same-name override (the node already exists).
+      const store = getCanvasStoreRef()
+      if (store) addDocumentNode(store, { docId, title: file.name, boardId, rootId: useBoardAppStore.getState().rootId })
       toast.success(
         `${replaced ? "Replaced" : "Added"} ${file.name} — ${chunks} passages ready to ask about.`,
       )

--- a/webui/src/features/agent/components/chat/doc-attach.tsx
+++ b/webui/src/features/agent/components/chat/doc-attach.tsx
@@ -1,12 +1,21 @@
 import { useRef, useState } from "react"
 import { toast } from "sonner"
 import { CircleNotchIcon, DocumentFileIcon } from "@/components/icons"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { generateUuid } from "@/lib/common"
 import { useIsSignedIn } from "@/lib/auth"
 import { getLocalStores } from "@/features/local-stores"
 import { resolveParseClient } from "@/features/agent/engine/doc-parse"
-import { chunkMarkdown } from "@/features/agent/engine/doc-chunk"
-import { refreshDocIndex } from "@/features/board/search/use-doc-index"
+import { ingestDocument } from "@/features/agent/local/ingest-doc"
 
 
 /**
@@ -14,51 +23,54 @@ import { refreshDocIndex } from "@/features/board/search/use-doc-index"
  * (via `/ai/parse`), chunk + persist it, and rebuild the board's search index so
  * the agent's `doc_search` tool can ground answers in it.
  *
- * Greys out when parsing isn't available (no managed access and no BYOK Mistral
- * key → `resolveParseClient` is null), so the feature is blocked, not broken.
+ * Titles are unique per board (the offline-first analog of a filename in a
+ * folder): a same-name upload prompts to override in place. Greys out when
+ * parsing is unavailable (no managed access and no BYOK Mistral key).
  */
 export const DocAttachButton = ({ boardId }: { boardId: string }) => {
   const signedIn = useIsSignedIn()
   const inputRef = useRef<HTMLInputElement>(null)
   const [busy, setBusy] = useState(false)
+  const [override, setOverride] = useState<File | null>(null)
   const canParse = resolveParseClient({ signedIn }) !== null
 
-  const onPick = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-    const file = e.target.files?.[0]
-    e.target.value = "" // allow re-picking the same file
-    if (!file || busy) return
-
+  const ingest = async (file: File): Promise<void> => {
     const client = resolveParseClient({ signedIn, runId: generateUuid() })
     if (!client) {
       toast.error("Sign in or add a Mistral key to upload documents.")
       return
     }
-
     setBusy(true)
     const id = toast(`Reading ${file.name}…`, { icon: <Spinner />, duration: Infinity })
     try {
       const { markdown, pages } = await client.parse(file)
-      const chunks = chunkMarkdown(markdown)
-      if (chunks.length === 0) {
-        toast.dismiss(id)
+      const { chunks, replaced } = await ingestDocument({ boardId, title: file.name, markdown, pages })
+      toast.dismiss(id)
+      if (chunks === 0) {
         toast.error("No readable text found in that PDF.")
         return
       }
-      const docId = generateUuid()
-      const { docs } = await getLocalStores()
-      await docs.addDocument({ id: docId, boardId, title: file.name, pages, createdAt: Date.now() })
-      await docs.addChunks(
-        chunks.map((c) => ({ chunkId: `${docId}#${c.index}`, docId, boardId, index: c.index, text: c.text })),
+      toast.success(
+        `${replaced ? "Replaced" : "Added"} ${file.name} — ${chunks} passages ready to ask about.`,
       )
-      await refreshDocIndex(boardId)
-      toast.dismiss(id)
-      toast.success(`Added ${file.name} — ${chunks.length} passages ready to ask about.`)
     } catch (err) {
       toast.dismiss(id)
       toast.error(err instanceof Error ? `Couldn't read the PDF: ${err.message}` : "Couldn't read the PDF.")
     } finally {
       setBusy(false)
     }
+  }
+
+  const onPick = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0]
+    e.target.value = "" // allow re-picking the same file
+    if (!file || busy) return
+    // Same-name on this board → confirm override (parse only AFTER the user
+    // decides, so a cancelled override never spends an OCR call).
+    const { docs } = await getLocalStores()
+    const existing = await docs.findByTitle(boardId, file.name)
+    if (existing) setOverride(file)
+    else void ingest(file)
   }
 
   return (
@@ -80,6 +92,30 @@ export const DocAttachButton = ({ boardId }: { boardId: string }) => {
       >
         {busy ? <Spinner /> : <DocumentFileIcon className="size-4" strokeWidth={2} />}
       </button>
+
+      <AlertDialog open={override !== null} onOpenChange={(o) => !o && setOverride(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Replace “{override?.name}”?</AlertDialogTitle>
+            <AlertDialogDescription>
+              A document with this name is already on this board. Uploading will replace its
+              contents.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setOverride(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const file = override
+                setOverride(null)
+                if (file) void ingest(file)
+              }}
+            >
+              Replace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/webui/src/features/agent/components/chat/doc-attach.tsx
+++ b/webui/src/features/agent/components/chat/doc-attach.tsx
@@ -30,6 +30,9 @@ import { ingestDocument } from "@/features/agent/local/ingest-doc"
 export const DocAttachButton = ({ boardId }: { boardId: string }) => {
   const signedIn = useIsSignedIn()
   const inputRef = useRef<HTMLInputElement>(null)
+  // Synchronous re-entrancy guard: `busy` state lags a render, so a rapid second
+  // file-select could slip through before it flips. A ref closes that window.
+  const inFlight = useRef(false)
   const [busy, setBusy] = useState(false)
   const [override, setOverride] = useState<File | null>(null)
   const canParse = resolveParseClient({ signedIn }) !== null
@@ -64,13 +67,18 @@ export const DocAttachButton = ({ boardId }: { boardId: string }) => {
   const onPick = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
     const file = e.target.files?.[0]
     e.target.value = "" // allow re-picking the same file
-    if (!file || busy) return
-    // Same-name on this board → confirm override (parse only AFTER the user
-    // decides, so a cancelled override never spends an OCR call).
-    const { docs } = await getLocalStores()
-    const existing = await docs.findByTitle(boardId, file.name)
-    if (existing) setOverride(file)
-    else void ingest(file)
+    if (!file || busy || inFlight.current) return
+    inFlight.current = true
+    try {
+      // Same-name on this board → confirm override (parse only AFTER the user
+      // decides, so a cancelled override never spends an OCR call).
+      const { docs } = await getLocalStores()
+      const existing = await docs.findByTitle(boardId, file.name)
+      if (existing) setOverride(file)
+      else await ingest(file)
+    } finally {
+      inFlight.current = false
+    }
   }
 
   return (

--- a/webui/src/features/agent/components/chat/doc-attach.tsx
+++ b/webui/src/features/agent/components/chat/doc-attach.tsx
@@ -1,0 +1,90 @@
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+import { CircleNotchIcon, DocumentFileIcon } from "@/components/icons"
+import { generateUuid } from "@/lib/common"
+import { useIsSignedIn } from "@/lib/auth"
+import { getLocalStores } from "@/features/local-stores"
+import { resolveParseClient } from "@/features/agent/engine/doc-parse"
+import { chunkMarkdown } from "@/features/agent/engine/doc-chunk"
+import { refreshDocIndex } from "@/features/board/search/use-doc-index"
+
+
+/**
+ * Attach a PDF to the current local board for document Q&A: OCR it to markdown
+ * (via `/ai/parse`), chunk + persist it, and rebuild the board's search index so
+ * the agent's `doc_search` tool can ground answers in it.
+ *
+ * Greys out when parsing isn't available (no managed access and no BYOK Mistral
+ * key → `resolveParseClient` is null), so the feature is blocked, not broken.
+ */
+export const DocAttachButton = ({ boardId }: { boardId: string }) => {
+  const signedIn = useIsSignedIn()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = useState(false)
+  const canParse = resolveParseClient({ signedIn }) !== null
+
+  const onPick = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0]
+    e.target.value = "" // allow re-picking the same file
+    if (!file || busy) return
+
+    const client = resolveParseClient({ signedIn, runId: generateUuid() })
+    if (!client) {
+      toast.error("Sign in or add a Mistral key to upload documents.")
+      return
+    }
+
+    setBusy(true)
+    const id = toast(`Reading ${file.name}…`, { icon: <Spinner />, duration: Infinity })
+    try {
+      const { markdown, pages } = await client.parse(file)
+      const chunks = chunkMarkdown(markdown)
+      if (chunks.length === 0) {
+        toast.dismiss(id)
+        toast.error("No readable text found in that PDF.")
+        return
+      }
+      const docId = generateUuid()
+      const { docs } = await getLocalStores()
+      await docs.addDocument({ id: docId, boardId, title: file.name, pages, createdAt: Date.now() })
+      await docs.addChunks(
+        chunks.map((c) => ({ chunkId: `${docId}#${c.index}`, docId, boardId, index: c.index, text: c.text })),
+      )
+      await refreshDocIndex(boardId)
+      toast.dismiss(id)
+      toast.success(`Added ${file.name} — ${chunks.length} passages ready to ask about.`)
+    } catch (err) {
+      toast.dismiss(id)
+      toast.error(err instanceof Error ? `Couldn't read the PDF: ${err.message}` : "Couldn't read the PDF.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="hidden"
+        onChange={(e) => void onPick(e)}
+      />
+      <button
+        type="button"
+        disabled={!canParse || busy}
+        onClick={() => inputRef.current?.click()}
+        aria-label="Attach a PDF"
+        title={canParse ? "Attach a PDF to ask about it" : "Sign in or add a Mistral key to attach documents"}
+        className="flex items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-secondary-foreground disabled:opacity-40 disabled:pointer-events-none"
+      >
+        {busy ? <Spinner /> : <DocumentFileIcon className="size-4" strokeWidth={2} />}
+      </button>
+    </>
+  )
+}
+
+
+const Spinner = () => (
+  <CircleNotchIcon className="size-4 animate-spin [animation-duration:750ms]" strokeWidth={2} />
+)

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -1,0 +1,49 @@
+import { DocumentFileIcon } from "@/components/icons"
+import type { AgentResponse } from "../../types/stream"
+import { extractDocSources } from "../../utils/doc-sources"
+
+
+/**
+ * Document Sources for an answer (F2 B7) — the documents `doc_search` actually
+ * retrieved from this turn, keyed by the unique `docId`. Each entry expands to
+ * the passages that grounded the answer (option a). Rendered inline (native
+ * `<details>`) with an `id="doc-<docId>"` anchor, so a linkified title in the
+ * answer can scroll straight to its source.
+ */
+export const DocSourcesView = ({ answer }: { answer: AgentResponse }) => {
+  const sources = extractDocSources(answer)
+  if (sources.length === 0) return null
+
+  return (
+    <div className="mt-2 min-w-0 space-y-1">
+      <div className="ml-1 flex items-center gap-1 text-xs font-mono text-muted-foreground">
+        <DocumentFileIcon className="size-4 shrink-0 text-primary" strokeWidth={2} />
+        <span className="text-primary">Documents</span>
+      </div>
+      {sources.map((s) => (
+        <details
+          key={s.docId}
+          id={`doc-${s.docId}`}
+          className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent"
+        >
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-1.5 text-xs">
+            <DocumentFileIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
+            <span className="truncate text-primary">{s.docTitle || "Document"}</span>
+            <span className="ml-auto shrink-0 text-muted-foreground">
+              {s.passages.length} passage{s.passages.length === 1 ? "" : "s"}
+            </span>
+          </summary>
+          {s.passages.length > 0 && (
+            <div className="space-y-2 px-3 pb-2 pt-1">
+              {s.passages.map((p, i) => (
+                <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {p}
+                </p>
+              ))}
+            </div>
+          )}
+        </details>
+      ))}
+    </div>
+  )
+}

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -1,4 +1,5 @@
-import { DocumentFileIcon } from "@/components/icons"
+import { useNavigate } from "@tanstack/react-router"
+import { DocumentFileIcon, MapPinIcon } from "@/components/icons"
 import type { AgentResponse } from "../../types/stream"
 import { extractDocSources } from "../../utils/doc-sources"
 
@@ -11,8 +12,14 @@ import { extractDocSources } from "../../utils/doc-sources"
  * answer can scroll straight to its source.
  */
 export const DocSourcesView = ({ answer }: { answer: AgentResponse }) => {
+  const navigate = useNavigate()
   const sources = extractDocSources(answer)
   if (sources.length === 0) return null
+
+  // The doc node's id IS the docId, so ?center=<docId> jumps to it (useCenterFromUrl).
+  const locate = (docId: string): void => {
+    void navigate({ to: ".", replace: true, search: (prev: Record<string, unknown>) => ({ ...prev, center: docId }) })
+  }
 
   return (
     <div className="mt-2 min-w-0 space-y-1">
@@ -32,6 +39,19 @@ export const DocSourcesView = ({ answer }: { answer: AgentResponse }) => {
             <span className="ml-auto shrink-0 text-muted-foreground">
               {s.passages.length} passage{s.passages.length === 1 ? "" : "s"}
             </span>
+            <button
+              type="button"
+              aria-label="Find on board"
+              title="Find on board"
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
+              onClick={(e) => {
+                e.preventDefault() // don't toggle the <details>
+                e.stopPropagation()
+                locate(s.docId)
+              }}
+            >
+              <MapPinIcon className="size-3.5" strokeWidth={2} />
+            </button>
           </summary>
           {s.passages.length > 0 && (
             <div className="space-y-2 px-3 pb-2 pt-1">

--- a/webui/src/features/agent/engine/doc-chunk.test.ts
+++ b/webui/src/features/agent/engine/doc-chunk.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { chunkMarkdown } from "./doc-chunk"
+
+
+describe("chunkMarkdown", () => {
+  it("returns [] for empty or whitespace-only input", () => {
+    expect(chunkMarkdown("")).toEqual([])
+    expect(chunkMarkdown("   \n\n  ")).toEqual([])
+  })
+
+  it("keeps a short document as a single chunk with index 0", () => {
+    const out = chunkMarkdown("# Title\n\nA short paragraph.")
+    expect(out).toHaveLength(1)
+    expect(out[0]).toEqual({ index: 0, text: "# Title\n\nA short paragraph." })
+  })
+
+  it("packs paragraphs up to maxChars across multiple sequential chunks", () => {
+    const para = (n: number) => `para ${n} ` + "x".repeat(40)
+    const md = [para(1), para(2), para(3), para(4)].join("\n\n")
+    const out = chunkMarkdown(md, { maxChars: 100, overlap: 0 })
+    expect(out.length).toBeGreaterThan(1)
+    out.forEach((c, i) => expect(c.index).toBe(i))
+    // Without overlap, no chunk exceeds maxChars.
+    out.forEach((c) => expect(c.text.length).toBeLessThanOrEqual(100))
+  })
+
+  it("hard-splits a single block larger than maxChars", () => {
+    const out = chunkMarkdown("y".repeat(250), { maxChars: 100, overlap: 0 })
+    expect(out.map((c) => c.text.length)).toEqual([100, 100, 50])
+  })
+
+  it("prepends the previous chunk's tail as overlap (after the first chunk)", () => {
+    const md = ["A".repeat(60), "B".repeat(60)].join("\n\n")
+    const out = chunkMarkdown(md, { maxChars: 70, overlap: 10 })
+    expect(out).toHaveLength(2)
+    expect(out[0].text).toBe("A".repeat(60))
+    // 2nd chunk carries the last 10 chars of chunk 0 as a bridge.
+    expect(out[1].text.startsWith("A".repeat(10) + "\n\n")).toBe(true)
+    expect(out[1].text.endsWith("B".repeat(60))).toBe(true)
+  })
+})

--- a/webui/src/features/agent/engine/doc-chunk.test.ts
+++ b/webui/src/features/agent/engine/doc-chunk.test.ts
@@ -1,41 +1,125 @@
 import { describe, expect, it } from "vitest"
-import { chunkMarkdown } from "./doc-chunk"
+import { chunkMarkdown, type Chunk } from "./doc-chunk"
 
 
-describe("chunkMarkdown", () => {
+const strip = (s: string): string => s.replace(/\s/g, "")
+const joined = (chunks: Chunk[]): string => chunks.map((c) => c.text).join("\n\n")
+
+
+describe("chunkMarkdown — basics", () => {
   it("returns [] for empty or whitespace-only input", () => {
     expect(chunkMarkdown("")).toEqual([])
     expect(chunkMarkdown("   \n\n  ")).toEqual([])
+    expect(chunkMarkdown("\r\n\r\n \t ")).toEqual([])
   })
 
   it("keeps a short document as a single chunk with index 0", () => {
     const out = chunkMarkdown("# Title\n\nA short paragraph.")
-    expect(out).toHaveLength(1)
-    expect(out[0]).toEqual({ index: 0, text: "# Title\n\nA short paragraph." })
+    expect(out).toEqual([{ index: 0, text: "# Title\n\nA short paragraph." }])
+  })
+})
+
+
+describe("chunkMarkdown — invariants (hold for any input/options)", () => {
+  const cases: { name: string; md: string; maxChars: number; overlap: number }[] = [
+    { name: "many small paras", md: Array.from({ length: 30 }, (_, i) => `para ${i} ${"x".repeat(30)}`).join("\n\n"), maxChars: 100, overlap: 0 },
+    { name: "with overlap", md: Array.from({ length: 12 }, (_, i) => `para ${i} ${"y".repeat(50)}`).join("\n\n"), maxChars: 120, overlap: 20 },
+    { name: "one giant block", md: "z".repeat(1000), maxChars: 100, overlap: 0 },
+    { name: "giant then small", md: "z".repeat(250) + "\n\ntail", maxChars: 100, overlap: 0 },
+    { name: "small then giant", md: "head\n\n" + "z".repeat(250), maxChars: 100, overlap: 0 },
+    { name: "headings only", md: "# A\n\n## B\n\n### C", maxChars: 100, overlap: 0 },
+    { name: "ragged blank lines", md: "a\n\n\n\n\nb\n\n\n c ", maxChars: 100, overlap: 0 },
+    { name: "block exactly maxChars", md: "q".repeat(100), maxChars: 100, overlap: 0 },
+    { name: "block maxChars+1", md: "q".repeat(101), maxChars: 100, overlap: 0 },
+  ]
+
+  for (const { name, md, maxChars, overlap } of cases) {
+    it(`[${name}] indices are sequential and chunks are non-empty`, () => {
+      const out = chunkMarkdown(md, { maxChars, overlap })
+      out.forEach((c, i) => expect(c.index).toBe(i))
+      out.forEach((c) => expect(c.text.trim().length).toBeGreaterThan(0))
+    })
+
+    it(`[${name}] is deterministic`, () => {
+      expect(chunkMarkdown(md, { maxChars, overlap })).toEqual(chunkMarkdown(md, { maxChars, overlap }))
+    })
+  }
+
+  it("overlap=0 loses no content (stripped concat === stripped source)", () => {
+    for (const { md, maxChars } of cases) {
+      const out = chunkMarkdown(md, { maxChars, overlap: 0 })
+      // Packing only inserts whitespace and hard-split only slices → no chars lost.
+      expect(strip(joined(out))).toBe(strip(md))
+    }
   })
 
-  it("packs paragraphs up to maxChars across multiple sequential chunks", () => {
-    const para = (n: number) => `para ${n} ` + "x".repeat(40)
-    const md = [para(1), para(2), para(3), para(4)].join("\n\n")
-    const out = chunkMarkdown(md, { maxChars: 100, overlap: 0 })
-    expect(out.length).toBeGreaterThan(1)
-    out.forEach((c, i) => expect(c.index).toBe(i))
-    // Without overlap, no chunk exceeds maxChars.
-    out.forEach((c) => expect(c.text.length).toBeLessThanOrEqual(100))
+  it("overlap=0 → no chunk exceeds maxChars", () => {
+    for (const { md, maxChars } of cases) {
+      for (const c of chunkMarkdown(md, { maxChars, overlap: 0 })) {
+        expect(c.text.length).toBeLessThanOrEqual(maxChars)
+      }
+    }
+  })
+})
+
+
+describe("chunkMarkdown — packing + hard-split boundaries", () => {
+  it("does not split a block that is exactly maxChars", () => {
+    expect(chunkMarkdown("q".repeat(100), { maxChars: 100, overlap: 0 })).toEqual([
+      { index: 0, text: "q".repeat(100) },
+    ])
   })
 
-  it("hard-splits a single block larger than maxChars", () => {
+  it("hard-splits a single block larger than maxChars into ceil(len/maxChars) pieces", () => {
     const out = chunkMarkdown("y".repeat(250), { maxChars: 100, overlap: 0 })
     expect(out.map((c) => c.text.length)).toEqual([100, 100, 50])
   })
 
-  it("prepends the previous chunk's tail as overlap (after the first chunk)", () => {
+  it("flushes a pending small block before hard-splitting a following giant block", () => {
+    const out = chunkMarkdown("head\n\n" + "z".repeat(250), { maxChars: 100, overlap: 0 })
+    expect(out[0].text).toBe("head") // not merged into the giant fragments
+    expect(out.slice(1).map((c) => c.text.length)).toEqual([100, 100, 50])
+  })
+
+  it("starts a fresh chunk for a small block after a hard-split giant block", () => {
+    const out = chunkMarkdown("z".repeat(250) + "\n\ntail", { maxChars: 100, overlap: 0 })
+    expect(out.map((c) => c.text)).toEqual(["z".repeat(100), "z".repeat(100), "z".repeat(50), "tail"])
+  })
+
+  it("packs multiple blocks into one chunk when they fit", () => {
+    const out = chunkMarkdown("aaa\n\nbbb\n\nccc", { maxChars: 100, overlap: 0 })
+    expect(out).toEqual([{ index: 0, text: "aaa\n\nbbb\n\nccc" }])
+  })
+})
+
+
+describe("chunkMarkdown — overlap", () => {
+  it("prepends the previous chunk's tail to each subsequent chunk (not the first)", () => {
     const md = ["A".repeat(60), "B".repeat(60)].join("\n\n")
     const out = chunkMarkdown(md, { maxChars: 70, overlap: 10 })
     expect(out).toHaveLength(2)
-    expect(out[0].text).toBe("A".repeat(60))
-    // 2nd chunk carries the last 10 chars of chunk 0 as a bridge.
-    expect(out[1].text.startsWith("A".repeat(10) + "\n\n")).toBe(true)
-    expect(out[1].text.endsWith("B".repeat(60))).toBe(true)
+    expect(out[0].text).toBe("A".repeat(60)) // first chunk: no prefix
+    expect(out[1].text).toBe("A".repeat(10) + "\n\n" + "B".repeat(60))
+  })
+
+  it("clamps an overlap >= maxChars to maxChars-1 without throwing", () => {
+    const md = ["A".repeat(40), "B".repeat(40)].join("\n\n")
+    const out = chunkMarkdown(md, { maxChars: 50, overlap: 999 })
+    expect(out).toHaveLength(2)
+    // bounded by the previous chunk length (40) and the clamp (49) → 40.
+    expect(out[1].text.startsWith("A".repeat(40) + "\n\n")).toBe(true)
+  })
+})
+
+
+describe("chunkMarkdown — line endings", () => {
+  it("splits CRLF-delimited paragraphs (PDF exports) the same as LF", () => {
+    const crlf = "para one\r\n\r\npara two\r\n\r\npara three"
+    const lf = "para one\n\npara two\n\npara three"
+    expect(chunkMarkdown(crlf, { maxChars: 20, overlap: 0 })).toEqual(
+      chunkMarkdown(lf, { maxChars: 20, overlap: 0 }),
+    )
+    // and it actually produced >1 chunk (i.e. the blank lines were recognized)
+    expect(chunkMarkdown(crlf, { maxChars: 20, overlap: 0 }).length).toBeGreaterThan(1)
   })
 })

--- a/webui/src/features/agent/engine/doc-chunk.ts
+++ b/webui/src/features/agent/engine/doc-chunk.ts
@@ -1,0 +1,55 @@
+/**
+ * Markdown-aware chunker for document Q&A (F2 B3).
+ *
+ * Splits a document's markdown into retrieval chunks: greedily pack
+ * paragraph-ish blocks (split on blank lines) up to `maxChars`, hard-splitting
+ * any single oversized block, and carry a small `overlap` tail from the previous
+ * chunk so a fact that straddles a boundary is still findable. Pure + synchronous
+ * so it's trivially testable; ids are assigned by the indexer (B5), not here.
+ */
+
+
+export type Chunk = { index: number; text: string }
+
+
+// ~1200 chars ≈ a few hundred tokens per chunk; 150-char overlap for continuity.
+const DEFAULT_MAX_CHARS = 1200
+const DEFAULT_OVERLAP = 150
+
+
+/** Split markdown into overlapping chunks. Returns [] for empty/whitespace input. */
+export const chunkMarkdown = (
+  markdown: string,
+  opts: { maxChars?: number; overlap?: number } = {},
+): Chunk[] => {
+  const maxChars = Math.max(1, opts.maxChars ?? DEFAULT_MAX_CHARS)
+  const overlap = Math.max(0, Math.min(opts.overlap ?? DEFAULT_OVERLAP, maxChars - 1))
+
+  const text = markdown.trim()
+  if (!text) return []
+
+  const blocks = text.split(/\n{2,}/).map((b) => b.trim()).filter(Boolean)
+  const packed: string[] = []
+  let cur = ""
+  const flush = (): void => {
+    if (cur) packed.push(cur)
+    cur = ""
+  }
+
+  for (const block of blocks) {
+    if (block.length > maxChars) {
+      flush()
+      for (let i = 0; i < block.length; i += maxChars) packed.push(block.slice(i, i + maxChars))
+      continue
+    }
+    if (cur && cur.length + 2 + block.length > maxChars) flush()
+    cur = cur ? `${cur}\n\n${block}` : block
+  }
+  flush()
+
+  // Prepend the tail of the previous chunk (context bridge across boundaries).
+  return packed.map((chunk, index) => {
+    if (index === 0 || overlap === 0) return { index, text: chunk }
+    return { index, text: `${packed[index - 1].slice(-overlap)}\n\n${chunk}` }
+  })
+}

--- a/webui/src/features/agent/engine/doc-chunk.ts
+++ b/webui/src/features/agent/engine/doc-chunk.ts
@@ -25,7 +25,9 @@ export const chunkMarkdown = (
   const maxChars = Math.max(1, opts.maxChars ?? DEFAULT_MAX_CHARS)
   const overlap = Math.max(0, Math.min(opts.overlap ?? DEFAULT_OVERLAP, maxChars - 1))
 
-  const text = markdown.trim()
+  // Normalize CRLF/CR so paragraph splitting works on PDF exports that use
+  // Windows/old-Mac line endings (otherwise `\r\n\r\n` isn't a blank line).
+  const text = markdown.replace(/\r\n?/g, "\n").trim()
   if (!text) return []
 
   const blocks = text.split(/\n{2,}/).map((b) => b.trim()).filter(Boolean)

--- a/webui/src/features/agent/engine/doc-parse.test.ts
+++ b/webui/src/features/agent/engine/doc-parse.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+
+// Default path goes through the services transport → fetchWithAuthRaw; mock it.
+const fetchWithAuthRaw = vi.hoisted(() => vi.fn())
+vi.mock("@/api", () => ({ fetchWithAuthRaw }))
+
+
+import { managedParseClient, resolveParseClient, type ParsePost } from "./doc-parse"
+
+
+const jsonResponse = <T,>(data: T): Response =>
+  ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response
+
+
+const errorResponse = (status: number): Response =>
+  ({ ok: false, status, text: async () => "" }) as unknown as Response
+
+
+const providerKeyOf = (callIndex: number): string | null => {
+  const init = fetchWithAuthRaw.mock.calls[callIndex]?.[1] as { headers: Headers } | undefined
+  return init ? init.headers.get("X-Provider-Key") : null
+}
+
+
+const pdf = (): File => new File(["%PDF-1.4"], "doc.pdf", { type: "application/pdf" })
+
+
+beforeEach(() => fetchWithAuthRaw.mockReset())
+
+
+describe("managedParseClient", () => {
+  it("returns the parsed markdown + page count from an injected post", async () => {
+    const post = vi.fn<ParsePost>(async () => ({ markdown: "# Title\n\nbody", pages: 2 }))
+    const out = await managedParseClient({ post }).parse(pdf())
+    expect(out).toEqual({ markdown: "# Title\n\nbody", pages: 2 })
+  })
+
+  it("hits /ai/parse with the run id and no provider key on the managed happy path", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ markdown: "x", pages: 1 }))
+    await managedParseClient({ runId: "run-1" }).parse(pdf())
+    expect(fetchWithAuthRaw.mock.calls[0][0]).toMatch(/\/ai\/parse$/)
+    const init = fetchWithAuthRaw.mock.calls[0][1] as { headers: Headers; body: unknown }
+    expect(init.headers.get("X-Run-Id")).toBe("run-1")
+    expect(providerKeyOf(0)).toBeNull()
+    expect(init.body).toBeInstanceOf(FormData)
+  })
+
+  it("falls back to the BYOK Mistral key on a 429", async () => {
+    fetchWithAuthRaw
+      .mockResolvedValueOnce(errorResponse(429))
+      .mockResolvedValueOnce(jsonResponse({ markdown: "y", pages: 1 }))
+    const out = await managedParseClient({ byokKey: "mistral-key" }).parse(pdf())
+    expect(out.markdown).toBe("y")
+    expect(fetchWithAuthRaw).toHaveBeenCalledTimes(2)
+    expect(providerKeyOf(0)).toBeNull()
+    expect(providerKeyOf(1)).toBe("mistral-key")
+  })
+
+  it("sends the BYOK key up front in byok mode (alwaysByok)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ markdown: "z", pages: 1 }))
+    await managedParseClient({ byokKey: "mistral-key", alwaysByok: true }).parse(pdf())
+    expect(fetchWithAuthRaw).toHaveBeenCalledOnce()
+    expect(providerKeyOf(0)).toBe("mistral-key")
+  })
+
+  it("does not retry on a non-429 error", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(500))
+    await expect(managedParseClient({ byokKey: "mistral-key" }).parse(pdf())).rejects.toThrow()
+    expect(fetchWithAuthRaw).toHaveBeenCalledOnce()
+  })
+})
+
+
+describe("resolveParseClient (drives the upload grey-out)", () => {
+  it("signed out with no key → null (off → upload greyed)", () => {
+    expect(resolveParseClient({ signedIn: false })).toBeNull()
+  })
+
+  it("signed out WITH a BYOK Mistral key → a client (relayed)", () => {
+    expect(resolveParseClient({ signedIn: false, byokKey: "mistral-key" })).not.toBeNull()
+  })
+
+  it("signed in → a client (managed, our key)", () => {
+    expect(resolveParseClient({ signedIn: true })).not.toBeNull()
+  })
+})

--- a/webui/src/features/agent/engine/doc-parse.ts
+++ b/webui/src/features/agent/engine/doc-parse.ts
@@ -1,0 +1,85 @@
+/**
+ * Document parsing as a service — a managed `ParseClient` + resolution.
+ *
+ * PDFs can't be OCR'd in the browser, so parsing always goes through `/ai/parse`
+ * (Mistral OCR). "Our keys first, yours as fallback": a signed-in user hits our
+ * proxy with our Mistral key; if that's over quota (429) and the user has a BYOK
+ * Mistral key, the same call is retried with `X-Provider-Key` (relayed, not
+ * stored). Signed-out with a BYOK key → relayed directly; otherwise off (so the
+ * upload affordance greys out).
+ */
+import type { ServiceResolution } from "./services/kinds"
+import { resolveService } from "./services/resolve"
+import { isOverQuotaError, runIdHeaders } from "./services/run"
+import { servicesUpload } from "./services/transport"
+
+
+/** The `/ai/parse` reply: the document's OCR'd markdown + its page count. */
+export type ParseResponse = { markdown: string; pages: number }
+
+
+/** POST a file to `/ai/parse`. Injectable for tests. */
+export type ParsePost = (file: File) => Promise<ParseResponse>
+
+
+export interface ParseClient {
+  parse(file: File): Promise<ParseResponse>
+}
+
+
+const makeDefaultParsePost = (runId?: string, byokKey?: string, alwaysByok = false): ParsePost => async (file) => {
+  const call = (withKey: boolean) => {
+    const form = new FormData()
+    form.append("file", file)
+    return servicesUpload<ParseResponse>("/ai/parse", form, {
+      ...runIdHeaders(runId),
+      ...(withKey && byokKey ? { "X-Provider-Key": byokKey } : {}),
+    })
+  }
+  // byok mode → the user's Mistral key IS the source; managed → ours first, fall
+  // back to their key only on a 429 (over quota).
+  if (alwaysByok && byokKey) return call(true)
+  try {
+    return await call(false)
+  } catch (e) {
+    if (byokKey && isOverQuotaError(e)) return call(true)
+    throw e
+  }
+}
+
+
+/** Managed parse client — our Mistral key via `/ai/parse`, BYOK key as fallback. */
+export const managedParseClient = (
+  opts: { runId?: string; byokKey?: string; alwaysByok?: boolean; post?: ParsePost } = {},
+): ParseClient => {
+  const post = opts.post ?? makeDefaultParsePost(opts.runId, opts.byokKey, opts.alwaysByok)
+  return {
+    parse: (file: File) => post(file),
+  }
+}
+
+
+/**
+ * Resolve the parse service to a client, or `null` when unavailable — the signal
+ * the upload UI uses to grey out. A BYOK Mistral key makes parsing available
+ * even signed-out (relayed); signed-in prefers our key with the key as the
+ * over-limit fallback.
+ */
+export const resolveParseClient = (opts: {
+  signedIn: boolean
+  runId?: string
+  byokKey?: string | null
+}): ParseClient | null => {
+  const cred = opts.byokKey ? { provider: "mistral", apiKey: opts.byokKey } : undefined
+  const resolution: ServiceResolution = resolveService("parse", {
+    signedIn: opts.signedIn,
+    preferManaged: opts.signedIn,
+    byok: cred ? { parse: cred } : {},
+  })
+  if (resolution.mode === "off") return null
+  return managedParseClient({
+    runId: opts.runId,
+    byokKey: opts.byokKey ?? undefined,
+    alwaysByok: resolution.mode === "byok",
+  })
+}

--- a/webui/src/features/agent/engine/doc-search.test.ts
+++ b/webui/src/features/agent/engine/doc-search.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { DocChunkIndex } from "@/features/board/search/doc-index"
+import type { ToolContext } from "./types"
+import { makeDocSearchTool } from "./doc-search"
+
+
+describe("makeDocSearchTool", () => {
+  it("is named doc_search and returns the index's matching passages", async () => {
+    const index = new DocChunkIndex()
+    await index.rebuild([
+      { chunkId: "c0", docId: "d1", docTitle: "Report", text: "Q3 revenue grew 20% year over year." },
+      { chunkId: "c1", docId: "d1", docTitle: "Report", text: "Headcount stayed flat." },
+    ])
+    const tool = makeDocSearchTool(index)
+    expect(tool.name).toBe("doc_search")
+
+    const out = (await tool.run({ query: "revenue growth" }, {} as ToolContext)) as {
+      results: { chunkId: string; docId: string; docTitle: string; text: string }[]
+    }
+    expect(out.results.length).toBeGreaterThan(0)
+    expect(out.results[0]).toMatchObject({ chunkId: "c0", docId: "d1", docTitle: "Report" })
+    expect(out.results[0].text).toContain("revenue")
+  })
+
+  it("returns an empty result set when nothing is indexed", async () => {
+    const out = (await makeDocSearchTool(new DocChunkIndex()).run({ query: "x" }, {} as ToolContext)) as {
+      results: unknown[]
+    }
+    expect(out.results).toEqual([])
+  })
+})

--- a/webui/src/features/agent/engine/doc-search.ts
+++ b/webui/src/features/agent/engine/doc-search.ts
@@ -1,0 +1,28 @@
+/**
+ * The `doc_search` agent tool (F2 B5) — retrieval over the board's uploaded
+ * documents, backed by the per-board `DocChunkIndex` (BM25). Offered to the
+ * local agent only when a board actually has indexed chunks.
+ *
+ * Returns the matching passages (for the model to read + answer) plus their
+ * `chunkId`/`docId`/`docTitle` so the answer can be cited back to a document
+ * (the chunk → doc citation mapping lands in B7).
+ */
+import { z } from "zod"
+import { defineTool, type Tool } from "./types"
+import type { DocChunkIndex } from "@/features/board/search/doc-index"
+
+
+/** Build the `doc_search` tool over a board's document-chunk index. */
+export const makeDocSearchTool = (index: DocChunkIndex): Tool =>
+  defineTool({
+    name: "doc_search",
+    description:
+      "Search the document(s) uploaded to this board and return matching passages" +
+      " to ground and cite the answer. Use this for questions about an uploaded" +
+      " document; cite the passages you rely on.",
+    parameters: z.object({ query: z.string().describe("What to look up in the documents") }),
+    run: async ({ query }) => {
+      const results = await index.query(query, 6)
+      return { results }
+    },
+  })

--- a/webui/src/features/agent/engine/services/kinds.ts
+++ b/webui/src/features/agent/engine/services/kinds.ts
@@ -12,10 +12,10 @@
  * resolution logic (`resolve.ts`) is trivially unit-testable.
  */
 
-export type ServiceKind = "llm" | "search" | "code" | "fetch"
+export type ServiceKind = "llm" | "search" | "code" | "fetch" | "parse"
 
 
-export const SERVICE_KINDS: readonly ServiceKind[] = ["llm", "search", "code", "fetch"]
+export const SERVICE_KINDS: readonly ServiceKind[] = ["llm", "search", "code", "fetch", "parse"]
 
 
 export type ServiceMode = "byok" | "managed" | "off"

--- a/webui/src/features/agent/engine/services/transport.test.ts
+++ b/webui/src/features/agent/engine/services/transport.test.ts
@@ -13,6 +13,7 @@ import {
   getServicesBaseUrl,
   servicesPost,
   servicesStream,
+  servicesUpload,
   setServicesBaseUrl,
 } from "./transport"
 
@@ -100,6 +101,27 @@ describe("servicesPost", () => {
     await servicesPost("/ai/fetch", { url: "https://x.com" })
     const [url] = lastCall()
     expect(url).toBe("http://localhost:9999/ai/fetch")
+  })
+})
+
+
+describe("servicesUpload", () => {
+  it("sends the FormData as-is and does NOT set Content-Type (browser owns the boundary)", async () => {
+    fetchWithAuthRaw.mockResolvedValue(jsonResponse({ markdown: "# x", pages: 1 }))
+    const form = new FormData()
+    form.append("file", new Blob(["%PDF"], { type: "application/pdf" }), "doc.pdf")
+    const out = await servicesUpload<{ markdown: string; pages: number }>("/ai/parse", form, { "X-Run-Id": "r1" })
+    expect(out).toEqual({ markdown: "# x", pages: 1 })
+    const [, init] = lastCall()
+    expect(init.body).toBe(form)
+    expect(init.headers.get("Content-Type")).toBeNull()
+    expect(init.headers.get("X-Run-Id")).toBe("r1")
+  })
+
+  it("throws a 429-detectable error on over-quota", async () => {
+    fetchWithAuthRaw.mockResolvedValue(errorResponse(429))
+    const err = await servicesUpload("/ai/parse", new FormData()).catch((e) => e)
+    expect(isOverQuotaError(err)).toBe(true)
   })
 })
 

--- a/webui/src/features/agent/engine/services/transport.ts
+++ b/webui/src/features/agent/engine/services/transport.ts
@@ -70,6 +70,27 @@ export async function servicesPost<T>(
 
 
 /**
+ * POST a multipart form (file upload) to a service endpoint and return the
+ * `{ data }` envelope's payload. Unlike `servicesPost` it does NOT set
+ * Content-Type — the browser must set the multipart boundary itself.
+ */
+export async function servicesUpload<T>(
+  path: string,
+  form: FormData,
+  headers?: Record<string, string>,
+): Promise<T> {
+  const res = await fetchWithAuthRaw(buildUrl(path), {
+    method: "POST",
+    headers: new Headers(headers ?? {}),
+    body: form,
+  })
+  if (!res.ok) throw await failed(path, res)
+  const json = (await res.json()) as { data: T }
+  return json.data
+}
+
+
+/**
  * POST a JSON body and stream the NDJSON response as typed lines (the `/ai/llm/
  * stream` shape). Not wrapped in a `{ data }` envelope — each line is a frame.
  */

--- a/webui/src/features/agent/local/agent-event-to-step.test.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.test.ts
@@ -163,6 +163,35 @@ describe("stepsFromEvents", () => {
   })
 
 
+  it("maps a doc_search result to a structured doc_search output (docId-keyed refs)", () => {
+    const [step] = stepsFromEvents(
+      [
+        { type: "tool_start", toolName: "doc_search", args: { query: "revenue" } },
+        {
+          type: "tool_result",
+          toolName: "doc_search",
+          result: {
+            results: [
+              { chunkId: "A#0", docId: "A", docTitle: "Report.pdf", text: "revenue grew" },
+              { chunkId: "x", docId: "", docTitle: "No.pdf", text: "dropped (no docId)" },
+            ],
+          },
+        },
+      ],
+      "b",
+    )
+    expect(step.type === "tool_call" && step.name).toBe("doc_search")
+    if (step.type === "tool_call" && typeof step.output !== "string") {
+      expect(step.output).toEqual({
+        type: "doc_search",
+        references: [{ chunkId: "A#0", docId: "A", docTitle: "Report.pdf", text: "revenue grew" }],
+      })
+    } else {
+      throw new Error("expected a structured doc_search output")
+    }
+  })
+
+
   it("coalesces a run of cumulative streaming deltas into ONE reasoning step", () => {
     const events: AgentEvent[] = [
       { type: "assistant_text", text: "Nap" },

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -27,6 +27,7 @@ const toToolName = (name: string): ToolName => {
   if (name === "code_interpreter") return "code_interpreter"
   if (name === "search_notes") return "memory_search"
   if (name === "fetch") return "fetch"
+  if (name === "doc_search") return "doc_search"
   return name as ToolName
 }
 
@@ -80,6 +81,20 @@ const toOutput = (name: string, args: unknown, result: unknown, boardId: string)
     // output so a fetched link surfaces alongside search sources.
     const ann = toUrlAnnotation(result)
     return ann ? { type: "web_search", answer: "", searchResults: [ann] } : JSON.stringify(result)
+  }
+  if (name === "doc_search") {
+    // Result: { results: [{ chunkId, docId, docTitle, text }] } → structured
+    // references the answer's document Sources view reads (keyed by docId).
+    const raw = field(result, "results")
+    const references = (Array.isArray(raw) ? raw : [])
+      .map((r) => ({
+        chunkId: asStr(field(r, "chunkId")) ?? "",
+        docId: asStr(field(r, "docId")) ?? "",
+        docTitle: asStr(field(r, "docTitle")) ?? "",
+        text: asStr(field(r, "text")) ?? "",
+      }))
+      .filter((r) => r.docId !== "")
+    return { type: "doc_search", references }
   }
   if (name.startsWith("learn_generate")) {
     return `Loaded ${name.replace("learn_generate_", "").replace(/_/g, " ")} guidance`

--- a/webui/src/features/agent/local/ingest-doc.test.ts
+++ b/webui/src/features/agent/local/ingest-doc.test.ts
@@ -22,12 +22,13 @@ describe("ingestDocument", () => {
 
     const { docs } = await getLocalStores()
     expect((await docs.listDocuments("b1")).map((d) => d.title)).toEqual(["Report.pdf"])
-    expect((await docs.chunksForDoc(res.docId)).length).toBe(res.chunks)
+    expect((await docs.chunksForDoc(res.docId as string)).length).toBe(res.chunks)
   })
 
   it("chunk ids are the docId prefixed (stable + unique per doc)", async () => {
-    const { docId } = await ingestDocument({ boardId: "b1", title: "A.pdf", markdown: "x".repeat(3000), pages: 1 })
+    const { docId: rawId } = await ingestDocument({ boardId: "b1", title: "A.pdf", markdown: "x".repeat(3000), pages: 1 })
     const { docs } = await getLocalStores()
+    const docId = rawId as string
     const ids = (await docs.chunksForDoc(docId)).map((c) => c.chunkId)
     expect(ids.every((id) => id.startsWith(`${docId}#`))).toBe(true)
     expect(new Set(ids).size).toBe(ids.length) // unique
@@ -42,8 +43,8 @@ describe("ingestDocument", () => {
 
     const { docs } = await getLocalStores()
     expect((await docs.listDocuments("b1")).length).toBe(1) // no duplicate
-    expect((await docs.getDocument(first.docId))?.pages).toBe(2) // metadata updated
-    const text = (await docs.chunksForDoc(first.docId)).map((c) => c.text).join(" ")
+    expect((await docs.getDocument(first.docId as string))?.pages).toBe(2) // metadata updated
+    const text = (await docs.chunksForDoc(first.docId as string)).map((c) => c.text).join(" ")
     expect(text).toContain("brand new content")
     expect(text).not.toContain("old content") // old chunks gone
   })
@@ -58,6 +59,27 @@ describe("ingestDocument", () => {
     } finally {
       setDocIndexRef(null)
     }
+  })
+
+  it("an unreadable (0-chunk) parse persists nothing and returns docId null", async () => {
+    const res = await ingestDocument({ boardId: "b1", title: "Blank.pdf", markdown: "   \n\n  ", pages: 3 })
+    expect(res).toEqual({ docId: null, chunks: 0, replaced: false })
+    const { docs } = await getLocalStores()
+    expect(await docs.listDocuments("b1")).toEqual([]) // no empty doc record created
+  })
+
+  it("a same-title empty re-parse leaves the existing document untouched (no wipe)", async () => {
+    const first = await ingestDocument({ boardId: "b1", title: "Report.pdf", markdown: "real content", pages: 1 })
+    const { docs } = await getLocalStores()
+    const before = await docs.chunksForDoc(first.docId as string)
+    expect(before.length).toBeGreaterThan(0)
+
+    // Re-upload same name but it OCRs to nothing → must NOT clobber the good doc.
+    const res = await ingestDocument({ boardId: "b1", title: "Report.pdf", markdown: "", pages: 1 })
+    expect(res.chunks).toBe(0)
+    expect((await docs.listDocuments("b1")).length).toBe(1) // still there
+    const after = await docs.chunksForDoc(first.docId as string)
+    expect(after.map((c) => c.text)).toEqual(before.map((c) => c.text)) // chunks intact
   })
 
   it("distinct titles on the same board coexist (each its own doc)", async () => {

--- a/webui/src/features/agent/local/ingest-doc.test.ts
+++ b/webui/src/features/agent/local/ingest-doc.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { resetIdb } from "@/test/canvas"
+import { getLocalStores } from "@/features/local-stores"
+import { DocChunkIndex } from "@/features/board/search/doc-index"
+import { setDocIndexRef } from "@/features/board/search/doc-index-ref"
+import { ingestDocument } from "./ingest-doc"
+
+
+beforeEach(() => resetIdb())
+
+
+describe("ingestDocument", () => {
+  it("chunks + persists a new document and reports the chunk count", async () => {
+    const res = await ingestDocument({
+      boardId: "b1",
+      title: "Report.pdf",
+      markdown: "# Q3\n\nRevenue grew 20%.\n\nHeadcount stayed flat.",
+      pages: 1,
+    })
+    expect(res.replaced).toBe(false)
+    expect(res.chunks).toBeGreaterThan(0)
+
+    const { docs } = await getLocalStores()
+    expect((await docs.listDocuments("b1")).map((d) => d.title)).toEqual(["Report.pdf"])
+    expect((await docs.chunksForDoc(res.docId)).length).toBe(res.chunks)
+  })
+
+  it("chunk ids are the docId prefixed (stable + unique per doc)", async () => {
+    const { docId } = await ingestDocument({ boardId: "b1", title: "A.pdf", markdown: "x".repeat(3000), pages: 1 })
+    const { docs } = await getLocalStores()
+    const ids = (await docs.chunksForDoc(docId)).map((c) => c.chunkId)
+    expect(ids.every((id) => id.startsWith(`${docId}#`))).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length) // unique
+  })
+
+  it("a same-title re-ingest overrides in place: same docId, chunks replaced, no duplicate doc", async () => {
+    const first = await ingestDocument({ boardId: "b1", title: "Report.pdf", markdown: "old content here", pages: 1 })
+    const second = await ingestDocument({ boardId: "b1", title: "Report.pdf", markdown: "brand new content", pages: 2 })
+
+    expect(second.replaced).toBe(true)
+    expect(second.docId).toBe(first.docId) // reused id → prior citations stay valid
+
+    const { docs } = await getLocalStores()
+    expect((await docs.listDocuments("b1")).length).toBe(1) // no duplicate
+    expect((await docs.getDocument(first.docId))?.pages).toBe(2) // metadata updated
+    const text = (await docs.chunksForDoc(first.docId)).map((c) => c.text).join(" ")
+    expect(text).toContain("brand new content")
+    expect(text).not.toContain("old content") // old chunks gone
+  })
+
+  it("refreshes the active doc index so the new content is searchable immediately", async () => {
+    const index = new DocChunkIndex()
+    setDocIndexRef(index)
+    try {
+      await ingestDocument({ boardId: "b1", title: "Bio.pdf", markdown: "Photosynthesis converts light.", pages: 1 })
+      const hits = await index.query("photosynthesis")
+      expect(hits[0]?.docTitle).toBe("Bio.pdf")
+    } finally {
+      setDocIndexRef(null)
+    }
+  })
+
+  it("distinct titles on the same board coexist (each its own doc)", async () => {
+    await ingestDocument({ boardId: "b1", title: "A.pdf", markdown: "alpha", pages: 1 })
+    await ingestDocument({ boardId: "b1", title: "B.pdf", markdown: "beta", pages: 1 })
+    const { docs } = await getLocalStores()
+    expect((await docs.listDocuments("b1")).map((d) => d.title).sort()).toEqual(["A.pdf", "B.pdf"])
+  })
+})

--- a/webui/src/features/agent/local/ingest-doc.ts
+++ b/webui/src/features/agent/local/ingest-doc.ts
@@ -13,7 +13,7 @@ import { refreshDocIndex } from "@/features/board/search/use-doc-index"
 import { chunkMarkdown } from "@/features/agent/engine/doc-chunk"
 
 
-export type IngestResult = { docId: string; chunks: number; replaced: boolean }
+export type IngestResult = { docId: string | null; chunks: number; replaced: boolean }
 
 
 /**
@@ -38,6 +38,13 @@ export const ingestDocument = async (opts: {
     index: c.index,
     text: c.text,
   }))
+
+  // An unreadable PDF (no OCR text → no chunks) must NOT persist: it would save
+  // an empty document and, on a same-name re-upload, replaceDocument would wipe
+  // the existing good version's chunks. Leave any existing doc untouched.
+  if (chunkRecords.length === 0) {
+    return { docId: null, chunks: 0, replaced: false }
+  }
 
   await docs.replaceDocument(
     { id: docId, boardId: opts.boardId, title: opts.title, pages: opts.pages, createdAt: Date.now() },

--- a/webui/src/features/agent/local/ingest-doc.ts
+++ b/webui/src/features/agent/local/ingest-doc.ts
@@ -1,0 +1,49 @@
+/**
+ * Ingest a parsed document into a board's local store (F2 B6).
+ *
+ * Chunk the OCR'd markdown, persist it as a document + chunks, and refresh the
+ * board's search index so `doc_search` sees it immediately. Titles are unique
+ * per board (enforced at the UI): a same-title upload REUSES the existing
+ * document's id (override in place) so citations in earlier answers stay valid.
+ * The `docId` is the stable internal handle; the title is the human/model label.
+ */
+import { generateUuid } from "@/lib/common"
+import { getLocalStores } from "@/features/local-stores"
+import { refreshDocIndex } from "@/features/board/search/use-doc-index"
+import { chunkMarkdown } from "@/features/agent/engine/doc-chunk"
+
+
+export type IngestResult = { docId: string; chunks: number; replaced: boolean }
+
+
+/**
+ * Persist a parsed document (markdown → chunks) on a board and reindex it.
+ * Returns the (possibly reused) doc id, the chunk count, and whether it replaced
+ * a same-title document.
+ */
+export const ingestDocument = async (opts: {
+  boardId: string
+  title: string
+  markdown: string
+  pages: number
+}): Promise<IngestResult> => {
+  const { docs } = await getLocalStores()
+  const existing = await docs.findByTitle(opts.boardId, opts.title)
+  const docId = existing?.id ?? generateUuid()
+
+  const chunkRecords = chunkMarkdown(opts.markdown).map((c) => ({
+    chunkId: `${docId}#${c.index}`,
+    docId,
+    boardId: opts.boardId,
+    index: c.index,
+    text: c.text,
+  }))
+
+  await docs.replaceDocument(
+    { id: docId, boardId: opts.boardId, title: opts.title, pages: opts.pages, createdAt: Date.now() },
+    chunkRecords,
+  )
+  await refreshDocIndex(opts.boardId)
+
+  return { docId, chunks: chunkRecords.length, replaced: existing !== undefined }
+}

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -168,15 +168,21 @@ export function useLocalSubmitPrompt(boardId: string) {
         const fetchUrl = resolveFetchClient({ signedIn, runId })
         // Offer doc_search only when the board actually has indexed document chunks.
         const docIndex = getDocIndexRef()
+        const hasDocs = !!docIndex && docIndex.count() > 0
         const tools = [
           ...AGENT_TOOLS,
           ...(webSearch ? [makeWebSearchTool(webSearch)] : []),
           ...(code ? [makeCodeInterpreterTool(code)] : []),
           ...(fetchUrl ? [makeFetchTool(fetchUrl)] : []),
-          ...(docIndex && docIndex.count() > 0 ? [makeDocSearchTool(docIndex)] : []),
+          ...(hasDocs && docIndex ? [makeDocSearchTool(docIndex)] : []),
         ]
+        // When documents are attached, steer grounding + citation-by-title (titles
+        // are unique per board, so a title names exactly one document).
+        const systemWithDocs = hasDocs
+          ? `${system}\n\nThis board has uploaded documents. For questions about them, call doc_search and ground your answer in the returned passages, referring to each document by its exact title.`
+          : system
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
-        for await (const ev of runAgent({ system, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search } })) {
+        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search } })) {
           // Streaming yields a cumulative assistant_text per token — replace the
           // previous snapshot in place instead of appending one event per token.
           const prev = events[events.length - 1]

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -15,6 +15,8 @@ import { useIsSignedIn } from "@/lib/auth"
 import { agentBuildTools, searchNotes } from "@/features/agent/engine/tools"
 import { skillTools } from "@/features/agent/engine/skills"
 import { getSearchIndexRef } from "@/features/board/search/search-index-ref"
+import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
+import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
 import type { AgentEvent } from "@/features/agent/engine/types"
 import { planSystemPrompt } from "@/features/agent/prompts"
 import { useByokStore } from "@/features/agent/byok/byok-store"
@@ -164,11 +166,14 @@ export function useLocalSubmitPrompt(boardId: string) {
         const webSearch = resolveSearchClient({ signedIn, runId, engine: searchEngine, byok: searchByok() })
         const code = resolveCodeClient({ signedIn, runId, byokKey: codeByok() })
         const fetchUrl = resolveFetchClient({ signedIn, runId })
+        // Offer doc_search only when the board actually has indexed document chunks.
+        const docIndex = getDocIndexRef()
         const tools = [
           ...AGENT_TOOLS,
           ...(webSearch ? [makeWebSearchTool(webSearch)] : []),
           ...(code ? [makeCodeInterpreterTool(code)] : []),
           ...(fetchUrl ? [makeFetchTool(fetchUrl)] : []),
+          ...(docIndex && docIndex.count() > 0 ? [makeDocSearchTool(docIndex)] : []),
         ]
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
         for await (const ev of runAgent({ system, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search } })) {

--- a/webui/src/features/agent/types/stream.ts
+++ b/webui/src/features/agent/types/stream.ts
@@ -5,6 +5,7 @@ import {
   EditNoteIcon,
   ImageGenerationIcon,
   ImageSearchWidgetIcon,
+  DocumentFileIcon,
   LinkIcon,
   MemorySearchIcon,
   NoteIcon,
@@ -114,6 +115,7 @@ export type ToolName =
   | "web_collector"
   | "synthesizer"
   | "fetch"
+  | "doc_search"
   | "raw_message"
   | "image_description"
   | "topic_illustrator"
@@ -140,6 +142,7 @@ export const ToolNameDescription: Record<ToolName, string> = {
   web_collector: "Collect web content",
   synthesizer: "Synthesize response",
   fetch: "Fetch and analyze web page content",
+  doc_search: "Search uploaded documents",
   raw_message: "Reasoning",
   image_description: "Describe image",
   topic_illustrator: "Illustrate topic",
@@ -160,6 +163,7 @@ export const ToolNameIcon: Record<ToolName, AppIconComponent> = {
   answer_reformulate: NoteIcon,
   web_search: BrowserSearchIcon,
   memory_search: MemorySearchIcon,
+  doc_search: DocumentFileIcon,
   outline_generator: OutlineGeneratorIcon,
   web_collector: WebCollectorIcon,
   synthesizer: NoteIcon,

--- a/webui/src/features/agent/types/tool-outputs.ts
+++ b/webui/src/features/agent/types/tool-outputs.ts
@@ -39,6 +39,23 @@ export interface MemorySearchOutput {
   references: RefAnnotation[]
 }
 
+
+/** One retrieved document passage (a `doc_search` hit) — its text plus the
+ *  document it belongs to. `docId` is the unique key; `docTitle` is the label. */
+export interface DocRef {
+  chunkId: string
+  docId: string
+  docTitle: string
+  text: string
+}
+
+
+/** The `doc_search` tool output: the passages retrieved from board documents. */
+export interface DocSearchOutput {
+  type: "doc_search"
+  references: DocRef[]
+}
+
 export interface CodeInterpreterOutput {
   type: "code_interpreter"
   status: "success" | "error" | "timeout"
@@ -120,6 +137,7 @@ export interface ImageGenerationOutput {
 export type ToolOutput =
   | WebSearchOutput
   | MemorySearchOutput
+  | DocSearchOutput
   | CodeInterpreterOutput
   | WriteNoteOutput
   | CreateNoteOutput

--- a/webui/src/features/agent/utils/doc-sources.test.ts
+++ b/webui/src/features/agent/utils/doc-sources.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import type { AgentResponse, ReasoningStep, ToolCallStep } from "../types/stream"
+import type { DocSearchOutput, ToolOutput } from "../types/tool-outputs"
+import { extractDocSources, linkifyDocTitles, type DocSource } from "./doc-sources"
+
+
+const docStep = (refs: DocSearchOutput["references"]): ToolCallStep => ({
+  type: "tool_call",
+  id: `s-${refs.map((r) => r.chunkId).join("-")}`,
+  name: "doc_search",
+  thought: "",
+  output: { type: "doc_search", references: refs },
+  state: "completed",
+  eventMessages: [],
+})
+
+
+const answer = (steps: ReasoningStep[]): AgentResponse => ({ steps })
+const ref = (chunkId: string, docId: string, docTitle: string, text: string) => ({ chunkId, docId, docTitle, text })
+
+
+describe("extractDocSources", () => {
+  it("returns [] when there are no doc_search steps", () => {
+    const textStep: ReasoningStep = { type: "reasoning_step", id: "t", reasoning: "", message: "hi" }
+    expect(extractDocSources(answer([textStep]))).toEqual([])
+  })
+
+  it("collects distinct docs in first-seen order with their passages", () => {
+    const out = extractDocSources(
+      answer([
+        docStep([ref("A#0", "A", "Report.pdf", "revenue grew"), ref("B#0", "B", "Bio.pdf", "photosynthesis")]),
+      ]),
+    )
+    expect(out.map((s) => s.docId)).toEqual(["A", "B"])
+    expect(out[0]).toEqual({ docId: "A", docTitle: "Report.pdf", passages: ["revenue grew"] })
+  })
+
+  it("merges the same docId across refs/steps and dedupes passages", () => {
+    const out = extractDocSources(
+      answer([
+        docStep([ref("A#0", "A", "Report.pdf", "one"), ref("A#1", "A", "Report.pdf", "two")]),
+        docStep([ref("A#0", "A", "Report.pdf", "one")]), // duplicate passage across a 2nd call
+      ]),
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].passages).toEqual(["one", "two"])
+  })
+
+  it("keeps same-title-but-different-docId documents separate (unique key = docId)", () => {
+    const out = extractDocSources(
+      answer([docStep([ref("A#0", "A", "report.pdf", "x"), ref("B#0", "B", "report.pdf", "y")])]),
+    )
+    expect(out.map((s) => s.docId)).toEqual(["A", "B"])
+  })
+
+  it("ignores non-doc_search steps, string outputs, and refs with no docId", () => {
+    const webStep = {
+      type: "tool_call",
+      id: "w",
+      name: "web_search",
+      thought: "",
+      output: { type: "web_search", answer: "", searchResults: [] } as ToolOutput,
+      state: "completed",
+      eventMessages: [],
+    } as ToolCallStep
+    const stringStep = { ...docStep([]), output: "raw string" as ToolOutput } as ToolCallStep
+    const out = extractDocSources(
+      answer([webStep, stringStep, docStep([ref("A#0", "A", "R.pdf", "keep"), ref("x", "", "No.pdf", "drop")])]),
+    )
+    expect(out.map((s) => s.docId)).toEqual(["A"])
+  })
+})
+
+
+describe("linkifyDocTitles", () => {
+  const src = (docId: string, docTitle: string): DocSource => ({ docId, docTitle, passages: [] })
+
+  it("wraps an exact title occurrence in a link to its anchor", () => {
+    expect(linkifyDocTitles("See Report.pdf for details.", [src("A", "Report.pdf")])).toBe(
+      "See [Report.pdf](#doc-A) for details.",
+    )
+  })
+
+  it("wraps every occurrence", () => {
+    expect(linkifyDocTitles("Report.pdf and again Report.pdf", [src("A", "Report.pdf")])).toBe(
+      "[Report.pdf](#doc-A) and again [Report.pdf](#doc-A)",
+    )
+  })
+
+  it("does not match a substring inside a larger word", () => {
+    expect(linkifyDocTitles("mynotes.pdf and notes.pdfx", [src("A", "notes.pdf")])).toBe(
+      "mynotes.pdf and notes.pdfx",
+    )
+  })
+
+  it("prefers the longest title so a contained title isn't half-matched", () => {
+    const out = linkifyDocTitles("Report v2.pdf beats Report", [src("A", "Report"), src("B", "Report v2.pdf")])
+    expect(out).toContain("[Report v2.pdf](#doc-B)")
+    expect(out).toContain("beats [Report](#doc-A)")
+    expect(out).not.toContain("[Report](#doc-A) v2.pdf") // the long title wasn't split
+  })
+
+  it("does not double-wrap a title already inside a markdown link", () => {
+    const already = "[Report.pdf](#doc-A)"
+    expect(linkifyDocTitles(already, [src("A", "Report.pdf")])).toBe(already)
+  })
+
+  it("handles regex-special characters in the title", () => {
+    expect(linkifyDocTitles("open a+b (1).pdf now", [src("A", "a+b (1).pdf")])).toBe(
+      "open [a+b (1).pdf](#doc-A) now",
+    )
+  })
+
+  it("returns the markdown unchanged when there are no titled sources", () => {
+    expect(linkifyDocTitles("nothing to link", [])).toBe("nothing to link")
+    expect(linkifyDocTitles("x", [src("A", "   ")])).toBe("x")
+  })
+})

--- a/webui/src/features/agent/utils/doc-sources.ts
+++ b/webui/src/features/agent/utils/doc-sources.ts
@@ -1,0 +1,74 @@
+/**
+ * Document-citation helpers (F2 B7) — pure, render-time, non-mutating.
+ *
+ * Sources are derived from what `doc_search` actually returned this turn (keyed
+ * by the unique `docId`), NOT parsed from the answer text — so a citation can
+ * never be ambiguous or mis-repaired. Titles are unique per board, so an exact
+ * title occurrence in the answer can be safely linkified to its document.
+ */
+import type { AgentResponse } from "../types/stream"
+import { isToolCallStep } from "../types/stream"
+
+
+/** A cited document: its unique id, label, and the passages the agent retrieved. */
+export type DocSource = { docId: string; docTitle: string; passages: string[] }
+
+
+/**
+ * Collect the distinct documents `doc_search` surfaced across an answer's steps,
+ * in first-seen order, each with its retrieved passages (deduped). Keyed by
+ * `docId` so same-title docs never merge.
+ */
+export const extractDocSources = (answer: AgentResponse): DocSource[] => {
+  const byId = new Map<string, DocSource>()
+  for (const step of answer.steps) {
+    if (!isToolCallStep(step) || typeof step.output === "string" || step.output.type !== "doc_search") {
+      continue
+    }
+    for (const ref of step.output.references) {
+      if (!ref.docId) continue
+      const existing = byId.get(ref.docId)
+      const passage = ref.text.trim()
+      if (existing) {
+        if (passage && !existing.passages.includes(passage)) existing.passages.push(passage)
+      } else {
+        byId.set(ref.docId, {
+          docId: ref.docId,
+          docTitle: ref.docTitle,
+          passages: passage ? [passage] : [],
+        })
+      }
+    }
+  }
+  return [...byId.values()]
+}
+
+
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+
+/**
+ * Wrap exact occurrences of a cited document's title in the answer markdown with
+ * a link to its Sources anchor (`#doc-<docId>`). Non-mutating in spirit: only
+ * exact title strings are decorated, longest-first so a title that contains
+ * another isn't half-matched, and occurrences already inside a markdown link
+ * `](...)` are left alone. Unknown/misspelled references are simply not linked.
+ */
+export const linkifyDocTitles = (markdown: string, sources: DocSource[]): string => {
+  const titled = sources.filter((s) => s.docTitle.trim().length > 0)
+  if (titled.length === 0) return markdown
+  // Longest titles first so "Report v2.pdf" wins over "Report".
+  const ordered = [...titled].sort((a, b) => b.docTitle.length - a.docTitle.length)
+
+  let out = markdown
+  for (const s of ordered) {
+    const title = escapeRegExp(s.docTitle)
+    // Boundaries: not preceded by a word char or "[" (avoids substring matches
+    // like "notes.pdf" inside "mynotes.pdf", and titles already inside a link),
+    // and not followed by a word char or "](" (avoids "Report.pdf" in
+    // "Report.pdfx", and double-wrapping an existing link).
+    const re = new RegExp(`(?<![\\w[])${title}(?![\\w]|\\]\\()`, "g")
+    out = out.replace(re, (match) => `[${match}](#doc-${s.docId})`)
+  }
+  return out
+}

--- a/webui/src/features/board/components/flow/floating-assistant/floating-island.tsx
+++ b/webui/src/features/board/components/flow/floating-assistant/floating-island.tsx
@@ -6,6 +6,8 @@ import { ThinkingIndicator } from "@/components/animations/thinking-indicator"
 import { cn } from "@/lib/utils"
 import { SendMessageError } from "@/features/agent/api/send-message"
 import { useChatSubmit } from "@/features/agent/hooks/use-chat-submit"
+import { useChat } from "@/features/agent/hooks/chat-context"
+import { DocAttachButton } from "@/features/agent/components/chat/doc-attach"
 import { buildMessageContext, useHasMessageContext } from "@/features/agent/hooks/use-message-context"
 import { SettingsButton } from "@/features/agent/settings/settings-button"
 import { useHasUsableModel } from "@/features/agent/services/use-agent-availability"
@@ -29,6 +31,8 @@ export const FloatingIsland = ({ boardId, onOpenFullSheet }: FloatingIslandProps
   const latestAssistantMessage = useCurrentAssistantMessage()
   const isStreaming = latestAssistantMessage?.streaming === true
   const submit = useChatSubmit()
+  // Document Q&A lives on the local (in-browser) agent only.
+  const { local } = useChat()
   const hasMessageContext = useHasMessageContext()
   // Single boolean derivation — only re-renders when a surface opens or
   // closes, never when its content/title changes. Cheap.
@@ -125,6 +129,7 @@ export const FloatingIsland = ({ boardId, onOpenFullSheet }: FloatingIslandProps
             ⌘↵
           </span>
           </div>
+          {local && <DocAttachButton boardId={boardId} />}
           <SettingsButton emphasize={!hasModel} />
         </div>
       </div>

--- a/webui/src/features/board/harness/agent/doc-node.test.ts
+++ b/webui/src/features/board/harness/agent/doc-node.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { asNodeId } from "@canvas-harness/core"
+import { addNode, freshStore, resetIdb } from "@/test/canvas"
+import { addDocumentNode } from "./doc-node"
+
+
+beforeEach(() => resetIdb())
+
+
+const titleOf = (store: ReturnType<typeof freshStore>, id: string): string | undefined =>
+  (store.getNode(asNodeId(id))?.data as { label?: { markdown?: string } } | undefined)?.label?.markdown
+
+
+describe("addDocumentNode", () => {
+  it("adds a 'document' node whose id is the docId, carrying the title", () => {
+    const store = freshStore("c")
+    addDocumentNode(store, { docId: "d1", title: "Report.pdf", boardId: "b1" })
+    const node = store.getNode(asNodeId("d1"))
+    expect(node?.type).toBe("document")
+    expect(titleOf(store, "d1")).toBe("Report.pdf")
+  })
+
+  it("places the node beneath existing board content", () => {
+    const store = freshStore("c")
+    addNode(store, "old")
+    store.updateNode(asNodeId("old"), { x: 0, y: 100, w: 200, h: 120 }) // bottom 220
+    addDocumentNode(store, { docId: "d1", title: "A.pdf", boardId: "b1" })
+    expect(store.getNode(asNodeId("d1"))!.y).toBeGreaterThanOrEqual(220)
+  })
+
+  it("is a no-op when a node with that id already exists (override reuses the id)", () => {
+    const store = freshStore("c")
+    addDocumentNode(store, { docId: "d1", title: "A.pdf", boardId: "b1" })
+    const y0 = store.getNode(asNodeId("d1"))!.y
+    addDocumentNode(store, { docId: "d1", title: "A.pdf", boardId: "b1" })
+    expect(store.getAllNodes().filter((n) => String(n.id) === "d1")).toHaveLength(1) // no duplicate
+    expect(store.getNode(asNodeId("d1"))!.y).toBe(y0) // untouched
+  })
+
+  it("stamps the current folder layer (parentId) when a rootId is given", () => {
+    const store = freshStore("c")
+    addDocumentNode(store, { docId: "d1", title: "A.pdf", boardId: "b1", rootId: "folder-1" })
+    expect((store.getNode(asNodeId("d1"))?.data as { parentId?: string }).parentId).toBe("folder-1")
+  })
+})

--- a/webui/src/features/board/harness/agent/doc-node.ts
+++ b/webui/src/features/board/harness/agent/doc-node.ts
@@ -1,0 +1,39 @@
+/**
+ * Represent an uploaded document as a single `document` node on the canvas
+ * (F2 — doc node). NOT a mindmap: exactly one node per document, whose id IS the
+ * `docId`, so delete/override/citation all key off the same id. The node is a
+ * lightweight pointer — its markdown/chunks live in `DocRepo`.
+ *
+ * Built by running a dim0 `Note` (type "document") through the shared
+ * `convertNoteToNode`, so the harness node's data shape is exactly what
+ * `DocumentView` renders (label + "completed" status) and round-trips cleanly.
+ */
+import { asNodeId, type CanvasStore } from "@canvas-harness/core"
+import { createDefaultNote } from "@/features/board/types/note"
+import { noteToNode } from "@/features/board/harness/convert/note-to-node"
+import { beneathBorderOrigin } from "./beneath-border"
+
+
+/**
+ * Add a `document` node (id = docId) for an uploaded file, placed beneath the
+ * current graph border. No-op if the node already exists (same-name override
+ * keeps the id and the placed node — only the doc's chunks changed).
+ */
+export const addDocumentNode = (
+  store: CanvasStore,
+  opts: { docId: string; title: string; boardId: string; rootId?: string | null },
+): void => {
+  const id = asNodeId(opts.docId)
+  if (store.getNode(id)) return // already on the canvas (override reuses the id)
+
+  const note = createDefaultNote({ boardId: opts.boardId, nodeType: "rectangle" })
+  note.id = opts.docId
+  note.type = "document"
+  note.label = { markdown: opts.title }
+  note.properties.status = { type: "keyword", value: "completed" }
+  if (opts.rootId) note.parentId = opts.rootId
+
+  const node = noteToNode(note)
+  const origin = beneathBorderOrigin(store)
+  store.batch(() => store.addNode({ ...node, id, x: origin.x, y: origin.y }))
+}

--- a/webui/src/features/board/harness/agent/use-doc-node-cascade.test.ts
+++ b/webui/src/features/board/harness/agent/use-doc-node-cascade.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import type { Node, Op, OpBatch } from "@canvas-harness/core"
+import { removedDocNodeIds } from "./use-doc-node-cascade"
+
+
+const node = (id: string, type: string): Node => ({ id, type } as unknown as Node)
+const removeOp = (id: string, type: string): Op => ({ type: "node.remove", node: node(id, type) } as unknown as Op)
+const addOp = (id: string): Op => ({ type: "node.add", node: node(id, "document") } as unknown as Op)
+
+
+const batch = (origin: OpBatch["origin"], ops: Op[]): OpBatch =>
+  ({ id: "b", clientId: "c", ts: 0, origin, ops } as unknown as OpBatch)
+
+
+describe("removedDocNodeIds", () => {
+  it("returns the ids of removed document nodes on a genuine (local) edit", () => {
+    expect(
+      removedDocNodeIds(batch("local", [removeOp("d1", "document"), removeOp("n1", "rect")])),
+    ).toEqual(["d1"])
+  })
+
+  it("collects multiple removed document nodes", () => {
+    expect(
+      removedDocNodeIds(batch("local", [removeOp("d1", "document"), removeOp("d2", "document")])),
+    ).toEqual(["d1", "d2"])
+  })
+
+  it("IGNORES remote-origin batches — a hydrate/clear must never cascade-delete docs", () => {
+    // applyContentToStore clears the scene as a `remote` batch on reload / layer
+    // switch; treating that as a delete would wipe every document.
+    expect(removedDocNodeIds(batch("remote", [removeOp("d1", "document")]))).toEqual([])
+  })
+
+  it("ignores non-remove ops and non-document node removals", () => {
+    expect(removedDocNodeIds(batch("local", [addOp("d1"), removeOp("n1", "rect"), removeOp("n2", "sheet")]))).toEqual([])
+  })
+})

--- a/webui/src/features/board/harness/agent/use-doc-node-cascade.ts
+++ b/webui/src/features/board/harness/agent/use-doc-node-cascade.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react"
+import type { CanvasStore, OpBatch } from "@canvas-harness/core"
+import { getLocalStores } from "@/features/local-stores"
+import { refreshDocIndex } from "@/features/board/search/use-doc-index"
+
+
+/**
+ * Doc ids whose `document` node was removed by a GENUINE (non-remote) edit.
+ *
+ * CRITICAL: ignores `origin: "remote"` batches. Hydrate / layer-switch clears the
+ * scene as a `remote` batch (see applyContentToStore); without this guard a
+ * reload would cascade-delete every document. Only a real user/local delete
+ * should tear down the underlying doc + chunks.
+ */
+export const removedDocNodeIds = (batch: OpBatch): string[] => {
+  if (batch.origin === "remote") return []
+  const ids: string[] = []
+  for (const op of batch.ops) {
+    if (op.type === "node.remove" && op.node.type === "document") ids.push(String(op.node.id))
+  }
+  return ids
+}
+
+
+/**
+ * Cascade a document node's deletion to its stored doc + chunks, then reindex —
+ * so removing the node from the canvas doesn't leave orphaned chunks the agent
+ * would still search. Local boards only.
+ */
+export const useDocNodeCascade = (store: CanvasStore, boardId: string, enabled: boolean): void => {
+  useEffect(() => {
+    if (!enabled || !boardId) return
+    return store.subscribe("change", (batch) => {
+      const ids = removedDocNodeIds(batch)
+      if (ids.length === 0) return
+      void (async () => {
+        const { docs } = await getLocalStores()
+        for (const id of ids) await docs.deleteDocument(id)
+        await refreshDocIndex(boardId)
+      })()
+    })
+  }, [store, boardId, enabled])
+}

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -64,6 +64,7 @@ import { useBlockFolderCopy } from "./use-block-folder-copy"
 import { resolveStoredEdgeColors, useStampNewEdges } from "./use-stamp-new-edges"
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useLocalSearchIndex } from "@/features/board/search/use-search-index"
+import { useLocalDocIndex } from "@/features/board/search/use-doc-index"
 import { useStyleMemory } from "./use-style-memory"
 import { CUSTOM_NODE_TYPES } from "./custom-node-types"
 import { useLocalPresence } from "./use-local-presence"
@@ -162,6 +163,7 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
   useStampNewEdges(store, boardId, rootId)
   useStampNewNodes(store, boardId, rootId)
   useLocalSearchIndex(store, local)
+  useLocalDocIndex(boardId ?? "", local)
   useBlockFolderCopy(store)
   useHarnessApplyMindMap(store, boardId, rootId)
   useHydrateIconNodes(store, boardId, rootId, ready)

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -65,6 +65,7 @@ import { resolveStoredEdgeColors, useStampNewEdges } from "./use-stamp-new-edges
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useLocalSearchIndex } from "@/features/board/search/use-search-index"
 import { useLocalDocIndex } from "@/features/board/search/use-doc-index"
+import { useDocNodeCascade } from "@/features/board/harness/agent/use-doc-node-cascade"
 import { useStyleMemory } from "./use-style-memory"
 import { CUSTOM_NODE_TYPES } from "./custom-node-types"
 import { useLocalPresence } from "./use-local-presence"
@@ -164,6 +165,7 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
   useStampNewNodes(store, boardId, rootId)
   useLocalSearchIndex(store, local)
   useLocalDocIndex(boardId ?? "", local)
+  useDocNodeCascade(store, boardId ?? "", local)
   useBlockFolderCopy(store)
   useHarnessApplyMindMap(store, boardId, rootId)
   useHydrateIconNodes(store, boardId, rootId, ready)

--- a/webui/src/features/board/persist/local/board-registry.ts
+++ b/webui/src/features/board/persist/local/board-registry.ts
@@ -22,7 +22,7 @@ export type BoardRegistryOptions = { engine?: StorageEngine; dbName?: string }
 
 // Every store a board's data spans — the cascade-delete transaction covers all.
 const BOARD_COLLECTIONS: Collection[] = [
-  "boards", "views", "snapshots", "oplog", "chats", "chat_messages",
+  "boards", "views", "snapshots", "oplog", "chats", "chat_messages", "documents", "chunks",
 ]
 
 
@@ -145,6 +145,11 @@ export class BoardRegistry {
         await t.delete("chat_messages", { lower: [chat.id, ""], upper: [chat.id, "￿"] })
         await t.delete("chats", chat.id)
       }
+      // Cascade the board's uploaded documents + their retrieval chunks.
+      const docs = await t.list<{ id: string }>("documents", { index: "by-board", range: { lower: id, upper: id } })
+      for (const doc of docs) await t.delete("documents", doc.id)
+      const chunks = await t.list<{ chunkId: string }>("chunks", { index: "by-board", range: { lower: id, upper: id } })
+      for (const chunk of chunks) await t.delete("chunks", chunk.chunkId)
     })
   }
 

--- a/webui/src/features/board/persist/local/doc-repo.test.ts
+++ b/webui/src/features/board/persist/local/doc-repo.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { engineCases } from "@/test/engines"
+import type { StorageEngine } from "./engine"
+import type { ChunkRecord, DocumentRecord } from "./idb"
+import { DocRepo } from "./doc-repo"
+
+
+const doc = (id: string, boardId: string, title = id): DocumentRecord => ({
+  id,
+  boardId,
+  title,
+  pages: 1,
+  createdAt: 0,
+})
+
+
+const chunk = (chunkId: string, docId: string, boardId: string, index = 0): ChunkRecord => ({
+  chunkId,
+  docId,
+  boardId,
+  index,
+  text: `text ${chunkId}`,
+})
+
+
+for (const { label, make } of engineCases) describe(`DocRepo (${label})`, () => {
+  let engine: StorageEngine
+  let repo: DocRepo
+
+
+  beforeEach(async () => {
+    engine = await make()
+    repo = new DocRepo(engine)
+  })
+
+
+  afterEach(() => engine.close())
+
+
+  it("round-trips a document and lists it per board", async () => {
+    await repo.addDocument(doc("d1", "b1", "Report"))
+    expect(await repo.getDocument("d1")).toMatchObject({ id: "d1", boardId: "b1", title: "Report" })
+    expect((await repo.listDocuments("b1")).map((d) => d.id)).toEqual(["d1"])
+  })
+
+
+  it("scopes listDocuments to the board (no cross-board leakage)", async () => {
+    await repo.addDocument(doc("d1", "b1"))
+    await repo.addDocument(doc("d2", "b2"))
+    expect((await repo.listDocuments("b1")).map((d) => d.id)).toEqual(["d1"])
+    expect((await repo.listDocuments("b2")).map((d) => d.id)).toEqual(["d2"])
+    expect(await repo.listDocuments("nope")).toEqual([])
+  })
+
+
+  it("stores + reads chunks by board and by doc", async () => {
+    await repo.addChunks([
+      chunk("d1#0", "d1", "b1", 0),
+      chunk("d1#1", "d1", "b1", 1),
+      chunk("d2#0", "d2", "b1", 0),
+    ])
+    expect((await repo.chunksForBoard("b1")).length).toBe(3) // whole board → rebuild index
+    expect((await repo.chunksForDoc("d1")).map((c) => c.chunkId).sort()).toEqual(["d1#0", "d1#1"])
+    expect((await repo.chunksForDoc("d2")).map((c) => c.chunkId)).toEqual(["d2#0"])
+  })
+
+
+  it("addChunks([]) is a no-op", async () => {
+    await repo.addChunks([])
+    expect(await repo.chunksForBoard("b1")).toEqual([])
+  })
+
+
+  it("deleteDocument removes the doc + its chunks, leaving other docs intact", async () => {
+    await repo.addDocument(doc("d1", "b1"))
+    await repo.addDocument(doc("d2", "b1"))
+    await repo.addChunks([chunk("d1#0", "d1", "b1"), chunk("d1#1", "d1", "b1", 1), chunk("d2#0", "d2", "b1")])
+
+    await repo.deleteDocument("d1")
+
+    expect(await repo.getDocument("d1")).toBeUndefined()
+    expect(await repo.chunksForDoc("d1")).toEqual([])
+    expect((await repo.listDocuments("b1")).map((d) => d.id)).toEqual(["d2"]) // d2 survives
+    expect((await repo.chunksForDoc("d2")).map((c) => c.chunkId)).toEqual(["d2#0"]) // d2 chunks survive
+  })
+})

--- a/webui/src/features/board/persist/local/doc-repo.test.ts
+++ b/webui/src/features/board/persist/local/doc-repo.test.ts
@@ -71,6 +71,36 @@ for (const { label, make } of engineCases) describe(`DocRepo (${label})`, () => 
   })
 
 
+  it("findByTitle returns the board's doc with that exact title, else undefined", async () => {
+    await repo.addDocument(doc("d1", "b1", "Report.pdf"))
+    await repo.addDocument(doc("d2", "b2", "Report.pdf")) // same title, different board
+    expect((await repo.findByTitle("b1", "Report.pdf"))?.id).toBe("d1")
+    expect((await repo.findByTitle("b2", "Report.pdf"))?.id).toBe("d2") // scoped per board
+    expect(await repo.findByTitle("b1", "Missing.pdf")).toBeUndefined()
+    expect(await repo.findByTitle("b1", "report.pdf")).toBeUndefined() // exact match, case-sensitive
+  })
+
+
+  it("replaceDocument upserts the doc and replaces exactly its chunks", async () => {
+    await repo.replaceDocument(doc("d1", "b1", "R"), [chunk("d1#0", "d1", "b1", 0), chunk("d1#1", "d1", "b1", 1)])
+    await repo.addChunks([chunk("d2#0", "d2", "b1")]) // an unrelated doc's chunk
+
+    // Re-ingest d1 with fewer chunks (override): old d1 chunks gone, d2 untouched.
+    await repo.replaceDocument({ ...doc("d1", "b1", "R"), pages: 9 }, [chunk("d1#0", "d1", "b1", 0)])
+
+    expect((await repo.getDocument("d1"))?.pages).toBe(9) // metadata updated in place
+    expect((await repo.chunksForDoc("d1")).map((c) => c.chunkId)).toEqual(["d1#0"]) // replaced, not appended
+    expect((await repo.chunksForDoc("d2")).map((c) => c.chunkId)).toEqual(["d2#0"]) // untouched
+  })
+
+
+  it("replaceDocument works as a fresh insert when the doc is new", async () => {
+    await repo.replaceDocument(doc("d9", "b1", "New"), [chunk("d9#0", "d9", "b1")])
+    expect((await repo.getDocument("d9"))?.title).toBe("New")
+    expect((await repo.chunksForDoc("d9")).length).toBe(1)
+  })
+
+
   it("deleteDocument removes the doc + its chunks, leaving other docs intact", async () => {
     await repo.addDocument(doc("d1", "b1"))
     await repo.addDocument(doc("d2", "b1"))

--- a/webui/src/features/board/persist/local/doc-repo.ts
+++ b/webui/src/features/board/persist/local/doc-repo.ts
@@ -42,6 +42,28 @@ export class DocRepo {
   }
 
 
+  /** The board's document with this exact title, if any (titles are unique per board). */
+  async findByTitle(boardId: string, title: string): Promise<DocumentRecord | undefined> {
+    const docs = await this.listDocuments(boardId)
+    return docs.find((d) => d.title === title)
+  }
+
+
+  /**
+   * Upsert a document and (re)place its chunks in one transaction — the write for
+   * both a fresh upload and a same-name override (reuse the existing `docId` so
+   * prior citations stay valid). Any previous chunks of `doc.id` are cleared first.
+   */
+  async replaceDocument(doc: DocumentRecord, chunks: ChunkRecord[]): Promise<void> {
+    await this.engine.tx(["documents", "chunks"], async (t) => {
+      const old = await t.list<ChunkRecord>("chunks", { index: "by-doc", range: eq(doc.id) })
+      for (const c of old) await t.delete("chunks", c.chunkId)
+      await t.put("documents", doc)
+      for (const c of chunks) await t.put("chunks", c)
+    })
+  }
+
+
   /** Persist a document's chunks (one transaction). */
   async addChunks(chunks: ChunkRecord[]): Promise<void> {
     if (chunks.length === 0) return

--- a/webui/src/features/board/persist/local/doc-repo.ts
+++ b/webui/src/features/board/persist/local/doc-repo.ts
@@ -1,0 +1,74 @@
+/**
+ * DocRepo — per-board uploaded documents + their retrieval chunks, over the
+ * `StorageEngine` port (document Q&A, F2 B4).
+ *
+ * A document's OCR'd markdown isn't stored whole; it lives as `chunks` (the
+ * retrieval unit). Chunks carry `boardId` (rebuild the board's search index on
+ * load) and `docId` (cascade + citation chunk→doc mapping). Deleting a document
+ * cascades its chunks in one transaction so nothing is orphaned.
+ */
+import type { ChunkRecord, DocumentRecord } from "./idb"
+import type { StorageEngine } from "./engine"
+
+
+/** A single-key range (inclusive both ends) — used for exact index lookups. */
+const eq = (value: string) => ({ lower: value, upper: value })
+
+
+export class DocRepo {
+  private readonly engine: StorageEngine
+
+
+  constructor(engine: StorageEngine) {
+    this.engine = engine
+  }
+
+
+  /** Insert or replace a document's metadata. */
+  async addDocument(doc: DocumentRecord): Promise<void> {
+    await this.engine.put("documents", doc)
+  }
+
+
+  /** Fetch one document's metadata. */
+  async getDocument(id: string): Promise<DocumentRecord | undefined> {
+    return this.engine.get<DocumentRecord>("documents", id)
+  }
+
+
+  /** All documents attached to a board, in insertion order. */
+  async listDocuments(boardId: string): Promise<DocumentRecord[]> {
+    return this.engine.list<DocumentRecord>("documents", { index: "by-board", range: eq(boardId) })
+  }
+
+
+  /** Persist a document's chunks (one transaction). */
+  async addChunks(chunks: ChunkRecord[]): Promise<void> {
+    if (chunks.length === 0) return
+    await this.engine.tx(["chunks"], async (t) => {
+      for (const c of chunks) await t.put("chunks", c)
+    })
+  }
+
+
+  /** Every chunk on a board (to rebuild the board's search index at load). */
+  async chunksForBoard(boardId: string): Promise<ChunkRecord[]> {
+    return this.engine.list<ChunkRecord>("chunks", { index: "by-board", range: eq(boardId) })
+  }
+
+
+  /** The chunks of one document. */
+  async chunksForDoc(docId: string): Promise<ChunkRecord[]> {
+    return this.engine.list<ChunkRecord>("chunks", { index: "by-doc", range: eq(docId) })
+  }
+
+
+  /** Delete a document and all its chunks atomically. */
+  async deleteDocument(docId: string): Promise<void> {
+    await this.engine.tx(["documents", "chunks"], async (t) => {
+      const chunks = await t.list<ChunkRecord>("chunks", { index: "by-doc", range: eq(docId) })
+      for (const c of chunks) await t.delete("chunks", c.chunkId)
+      await t.delete("documents", docId)
+    })
+  }
+}

--- a/webui/src/features/board/persist/local/engine.ts
+++ b/webui/src/features/board/persist/local/engine.ts
@@ -22,6 +22,8 @@ export type Collection =
   | "chat_messages"
   | "mini_app_state"
   | "sync_meta"
+  | "documents"
+  | "chunks"
 
 
 /** A primary or index key: a scalar, or a compound (array) key. */

--- a/webui/src/features/board/persist/local/idb.ts
+++ b/webui/src/features/board/persist/local/idb.ts
@@ -37,6 +37,27 @@ export type OplogRecord = { boardId: string; seq: number; batch: OpBatch; server
 export type SyncMetaRecord = { boardId: string; syncedSeq: number }
 
 
+/** An uploaded document's metadata (per board). Its markdown lives in its chunks. */
+export type DocumentRecord = {
+  id: string
+  boardId: string
+  title: string
+  pages: number
+  createdAt: number
+}
+
+
+/** One retrieval chunk of a document. `chunkId` is stable + prefix-matchable for
+ *  citations; `index` is its position within the doc. */
+export type ChunkRecord = {
+  chunkId: string
+  docId: string
+  boardId: string
+  index: number
+  text: string
+}
+
+
 interface Dim0DB extends DBSchema {
   snapshots: { key: string; value: SnapshotRecord }
   oplog: { key: [string, number]; value: OplogRecord }
@@ -51,6 +72,9 @@ interface Dim0DB extends DBSchema {
   mini_app_state: { key: string; value: { noteId: string; state: unknown } }
   // Sync cursor per board (offline outbox — how far the relay has acked).
   sync_meta: { key: string; value: SyncMetaRecord }
+  // Per-board uploaded documents + their retrieval chunks (document Q&A).
+  documents: { key: string; value: DocumentRecord; indexes: { "by-board": string } }
+  chunks: { key: string; value: ChunkRecord; indexes: { "by-board": string; "by-doc": string } }
 }
 
 
@@ -58,7 +82,7 @@ export type Dim0Database = IDBPDatabase<Dim0DB>
 
 
 const DB_NAME = "dim0"
-const DB_VERSION = 5
+const DB_VERSION = 6
 
 
 // Minimal loose shapes for the upgrade loop (see the cast note in `upgrade`).

--- a/webui/src/features/board/persist/local/schema.ts
+++ b/webui/src/features/board/persist/local/schema.ts
@@ -25,4 +25,7 @@ export const COLLECTIONS: Record<Collection, CollectionSchema> = {
   chat_messages: { keyPath: ["chatUid", "id"] },
   mini_app_state: { keyPath: "noteId" },
   sync_meta: { keyPath: "boardId" },
+  // Document Q&A (per-board): an uploaded doc's metadata + its retrieval chunks.
+  documents: { keyPath: "id", indexes: { "by-board": "boardId" } },
+  chunks: { keyPath: "chunkId", indexes: { "by-board": "boardId", "by-doc": "docId" } },
 }

--- a/webui/src/features/board/search/doc-index-ref.ts
+++ b/webui/src/features/board/search/doc-index-ref.ts
@@ -1,0 +1,22 @@
+import type { DocChunkIndex } from "./doc-index"
+
+
+/**
+ * Module-level reference to the active board's document-chunk index. Mirrors
+ * `search-index-ref` so code outside the React tree — the agent's `doc_search`
+ * tool and the answer's document Sources view (B7) — can reach the live index
+ * without prop-drilling.
+ *
+ * Registered by `useLocalDocIndex` on a local board mount, rebuilt after an
+ * upload, cleared on unmount. One board is active at a time, so a single slot
+ * suffices; callers must handle `null` (nothing mounted → no documents).
+ */
+let _index: DocChunkIndex | null = null
+
+
+export const setDocIndexRef = (index: DocChunkIndex | null): void => {
+  _index = index
+}
+
+
+export const getDocIndexRef = (): DocChunkIndex | null => _index

--- a/webui/src/features/board/search/doc-index.test.ts
+++ b/webui/src/features/board/search/doc-index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { DocChunkIndex, type ChunkDoc } from "./doc-index"
+
+
+const chunk = (chunkId: string, text: string, docId = "d1", docTitle = "Doc 1"): ChunkDoc => ({
+  chunkId,
+  docId,
+  docTitle,
+  text,
+})
+
+
+describe("DocChunkIndex", () => {
+  it("returns matching chunks with their doc metadata (for citations)", async () => {
+    const index = new DocChunkIndex()
+    await index.rebuild([
+      chunk("c0", "Napoleon was crowned Emperor in 1804.", "d1", "History"),
+      chunk("c1", "Photosynthesis converts light into chemical energy.", "d2", "Biology"),
+    ])
+    const hits = await index.query("emperor napoleon")
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0]).toMatchObject({ chunkId: "c0", docId: "d1", docTitle: "History" })
+    expect(hits[0].text).toContain("Napoleon")
+  })
+
+  it("counts indexed chunks and treats a blank query as no results", async () => {
+    const index = new DocChunkIndex()
+    await index.rebuild([chunk("c0", "alpha"), chunk("c1", "beta")])
+    expect(index.count()).toBe(2)
+    expect(await index.query("   ")).toEqual([])
+  })
+
+  it("rebuild replaces the previous contents", async () => {
+    const index = new DocChunkIndex()
+    await index.rebuild([chunk("c0", "alpha unique-old")])
+    await index.rebuild([chunk("c1", "beta unique-new")])
+    expect(index.count()).toBe(1)
+    expect(await index.query("unique-old")).toEqual([])
+    expect((await index.query("unique-new"))[0]?.chunkId).toBe("c1")
+  })
+
+  it("an empty index yields no hits", async () => {
+    expect(await new DocChunkIndex().query("anything")).toEqual([])
+  })
+})

--- a/webui/src/features/board/search/doc-index.ts
+++ b/webui/src/features/board/search/doc-index.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-board document-chunk search index (F2 B5) — a SEPARATE Orama BM25 index
+ * over uploaded-document chunks, distinct from the canvas-note index
+ * (`local-index.ts`) because docs have a different lifecycle.
+ *
+ * It's a derived read-model: rebuilt from `DocRepo.chunksForBoard(...)` at board
+ * load and after an upload. `text` is the searchable field; `docId`/`docTitle`/
+ * the chunk id ride along as stored fields so a hit can be cited back to its
+ * source document (chunk → doc). Full-text only — matches the no-RAG decision.
+ */
+import { count, create, insert, search } from "@orama/orama"
+
+
+const SCHEMA = { text: "string" } as const
+
+
+/** A chunk as fed to the index (title joined from its document by the caller). */
+export type ChunkDoc = { chunkId: string; docId: string; docTitle: string; text: string }
+
+
+/** A ranked search hit — the chunk plus the doc it belongs to (for citations). */
+export type ChunkHit = ChunkDoc
+
+
+const asText = (value: unknown): string => (typeof value === "string" ? value : "")
+
+
+export class DocChunkIndex {
+  private db = create({ schema: SCHEMA })
+
+
+  /** Drop and rebuild from a board's chunks (the derived-model load/refresh path). */
+  async rebuild(chunks: ChunkDoc[]): Promise<void> {
+    this.db = create({ schema: SCHEMA })
+    for (const c of chunks) {
+      await insert(this.db, { id: c.chunkId, text: c.text, docId: c.docId, docTitle: c.docTitle })
+    }
+  }
+
+
+  /** Ranked full-text query → the top matching chunks with their doc metadata. */
+  async query(term: string, limit = 6): Promise<ChunkHit[]> {
+    if (!term.trim()) return []
+    const res = await search(this.db, { term, limit })
+    return res.hits.map((h) => ({
+      chunkId: String(h.document.id),
+      docId: asText(h.document.docId),
+      docTitle: asText(h.document.docTitle),
+      text: asText(h.document.text),
+    }))
+  }
+
+
+  /** Number of indexed chunks (0 = no docs → the tool isn't offered). */
+  count(): number {
+    return count(this.db)
+  }
+}

--- a/webui/src/features/board/search/use-doc-index.test.ts
+++ b/webui/src/features/board/search/use-doc-index.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { resetIdb } from "@/test/canvas"
+import { getLocalStores } from "@/features/local-stores"
+import { DocChunkIndex } from "./doc-index"
+import { setDocIndexRef } from "./doc-index-ref"
+import { rebuildDocIndex, refreshDocIndex } from "./use-doc-index"
+
+
+beforeEach(() => resetIdb())
+
+
+const seed = async (): Promise<void> => {
+  const { docs } = await getLocalStores()
+  await docs.addDocument({ id: "d1", boardId: "b1", title: "Report", pages: 1, createdAt: 0 })
+  await docs.addChunks([
+    { chunkId: "d1#0", docId: "d1", boardId: "b1", index: 0, text: "Q3 revenue grew 20%." },
+    { chunkId: "d1#1", docId: "d1", boardId: "b1", index: 1, text: "Headcount stayed flat." },
+  ])
+  // A different board's doc must not leak into b1's index.
+  await docs.addDocument({ id: "d2", boardId: "b2", title: "Other", pages: 1, createdAt: 0 })
+  await docs.addChunks([{ chunkId: "d2#0", docId: "d2", boardId: "b2", index: 0, text: "revenue elsewhere" }])
+}
+
+
+describe("rebuildDocIndex", () => {
+  it("indexes a board's chunks joined to their document title (for citations)", async () => {
+    await seed()
+    const index = new DocChunkIndex()
+    await rebuildDocIndex(index, "b1")
+    expect(index.count()).toBe(2) // only b1's chunks
+    const hits = await index.query("revenue")
+    expect(hits[0]).toMatchObject({ chunkId: "d1#0", docId: "d1", docTitle: "Report" })
+  })
+
+  it("scopes strictly to the board (no cross-board leakage)", async () => {
+    await seed()
+    const index = new DocChunkIndex()
+    await rebuildDocIndex(index, "b1")
+    // "revenue elsewhere" (b2) must not be reachable through b1's index.
+    expect((await index.query("elsewhere"))).toEqual([])
+  })
+})
+
+
+describe("refreshDocIndex", () => {
+  it("rebuilds the active (ref) index for the board, ignoring when no index is mounted", async () => {
+    await refreshDocIndex("b1") // no ref set → no throw
+    await seed()
+    const index = new DocChunkIndex()
+    setDocIndexRef(index)
+    await refreshDocIndex("b1")
+    expect(index.count()).toBe(2)
+    setDocIndexRef(null)
+  })
+})

--- a/webui/src/features/board/search/use-doc-index.ts
+++ b/webui/src/features/board/search/use-doc-index.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react"
+import { getLocalStores } from "@/features/local-stores"
+import { DocChunkIndex } from "./doc-index"
+import { getDocIndexRef, setDocIndexRef } from "./doc-index-ref"
+
+
+/**
+ * Rebuild a doc-chunk index from a board's persisted documents + chunks, joining
+ * each chunk to its document title (for citations). Extracted so it's testable
+ * without React and reusable by both the mount hook and the post-upload refresh.
+ */
+export const rebuildDocIndex = async (index: DocChunkIndex, boardId: string): Promise<void> => {
+  const { docs } = await getLocalStores()
+  const [documents, chunks] = await Promise.all([
+    docs.listDocuments(boardId),
+    docs.chunksForBoard(boardId),
+  ])
+  const titleById = new Map(documents.map((d) => [d.id, d.title]))
+  await index.rebuild(
+    chunks.map((c) => ({
+      chunkId: c.chunkId,
+      docId: c.docId,
+      docTitle: titleById.get(c.docId) ?? "",
+      text: c.text,
+    })),
+  )
+}
+
+
+/** Rebuild the ACTIVE board's doc index (call after an upload). No-op if none is mounted. */
+export const refreshDocIndex = async (boardId: string): Promise<void> => {
+  const index = getDocIndexRef()
+  if (index) await rebuildDocIndex(index, boardId)
+}
+
+
+/**
+ * Own the local board's document-chunk index: create it once, build it from the
+ * board's persisted chunks on mount, publish it on the module ref (so
+ * `doc_search` + the sources view can reach it), and clear the ref on unmount.
+ * `enabled` gates it to local boards.
+ */
+export const useLocalDocIndex = (boardId: string, enabled: boolean): void => {
+  const ref = useRef<DocChunkIndex | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !boardId) return
+    const index = ref.current ?? new DocChunkIndex()
+    ref.current = index
+    setDocIndexRef(index)
+    void rebuildDocIndex(index, boardId).catch(() => undefined)
+    return () => setDocIndexRef(null)
+  }, [boardId, enabled])
+}

--- a/webui/src/features/local-stores.ts
+++ b/webui/src/features/local-stores.ts
@@ -11,6 +11,7 @@ import { BoardRegistry } from "@/features/board/persist/local/board-registry"
 import type { StorageEngine } from "@/features/board/persist/local/engine"
 import { ChatRepo } from "@/features/agent/store/chat-repo"
 import { MiniAppRepo } from "@/features/mini-app/mini-app-repo"
+import { DocRepo } from "@/features/board/persist/local/doc-repo"
 
 
 export type LocalStores = {
@@ -18,6 +19,7 @@ export type LocalStores = {
   boards: BoardRegistry
   chats: ChatRepo
   miniApps: MiniAppRepo
+  docs: DocRepo
 }
 
 
@@ -27,6 +29,7 @@ export const createLocalStores = (engine: StorageEngine): LocalStores => ({
   boards: new BoardRegistry({ engine }),
   chats: new ChatRepo(engine),
   miniApps: new MiniAppRepo(engine),
+  docs: new DocRepo(engine),
 })
 
 


### PR DESCRIPTION
Document Q&A for the local agent: upload a PDF, ask questions grounded in it. **Ingest online** (Mistral OCR → markdown, via `/ai/parse`), **query offline** (per-board Orama BM25 chunk retrieval). No pdfjs, no vector store — consistent with the existing no-RAG (full-text) decision.

Base: `offline-first-phase-a`.

### Locked design decisions
- Per-board documents; **separate** Orama doc-chunk index (distinct lifecycle from canvas nodes).
- **PDF-only** at launch → parse is always Mistral; the feature is inherently key/relay-gated.
- **Grey-out** the attach affordance when no parse-capable key (managed sign-in or BYOK Mistral) — modeled via a `parse` service kind in the resolver.
- Retrieval always per-board.
- Citations reuse the web "Sources" pill pattern → a per-answer **document sources list**; a source opens a lightweight **markdown viewer**.

### Build checklist
- [x] **B1** — `/ai/parse` endpoint (reuse `MistralParser` → `{markdown, pages}`; BYOK relay + meter; PDF-only)
- [ ] **B2** — client parse client (PDF → `/ai/parse` via the services transport; needs a `servicesUpload` multipart helper) + `parse` service kind in the resolver
- [ ] **B3** — markdown-aware chunker (heading/para + overlap, stable chunk ids)
- [ ] **B4** — IndexedDB `documents` + `chunks` stores, `DB_VERSION` bump, per-board repo, register in `local-stores`
- [ ] **B5** — Orama doc-chunk index (`chunkId, docId, docTitle, text`) + `doc_search` tool wired into the local `AGENT_TOOLS` (board-scoped)
- [ ] **B7** — citations: `doc_search` refs (`chunkId→docId`), cite-format system prompt, local `postProcessRefCitations` (chunk-prefix→doc), document Sources surface + markdown viewer
- [ ] **B6** — composer PDF-attach UI: grey-out w/o parse key, upload→parse→index progress
- [ ] **B8** — tests throughout

Est. ~830–1240 LoC total, Medium complexity. B7 (citation UX) is the design-heavy part — old runtime rewrote chunk citations into backend `/boards/.../documents/...` routes that don't exist offline (see discussion), so the local citation surface is net-new.
