### PR TITLE
fix(webui): close markdown XSS (sanitizer + link scheme allowlist + escaped citations)

### DIFF
--- a/webui/src/components/markdown/markdown-link.test.tsx
+++ b/webui/src/components/markdown/markdown-link.test.tsx
@@ -54,3 +54,57 @@ describe("MarkdownLink — #doc- citation", () => {
     expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
   })
 })
+
+
+describe("MarkdownLink — href scheme allowlist", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+
+  const render = (href: string) =>
+    act(() => root.render(<MarkdownLink href={href}>link</MarkdownLink>))
+
+  const hrefOf = () => container.querySelector("a")?.getAttribute("href") ?? null
+
+  it.each([
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    " javascript:alert(1)",
+    "java\tscript:alert(1)",
+    "java\nscript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "blob:https://example.com/abc",
+    "file:///etc/passwd",
+  ])("neutralizes the dangerous href %j (no href attribute emitted)", (href) => {
+    render(href)
+    expect(hrefOf()).toBeNull()
+  })
+
+  it.each([
+    "https://example.com/",
+    "http://example.com/",
+    "//example.com/",
+    "mailto:hi@example.com",
+    "/boards/b1/n/n1",
+    "#section",
+    "?q=1",
+    "relative/path",
+  ])("preserves the legitimate href %j", (href) => {
+    render(href)
+    expect(hrefOf()).toBe(href)
+  })
+})

--- a/webui/src/components/markdown/markdown-link.test.tsx
+++ b/webui/src/components/markdown/markdown-link.test.tsx
@@ -99,6 +99,8 @@ describe("MarkdownLink — href scheme allowlist", () => {
     "http://example.com/",
     "//example.com/",
     "mailto:hi@example.com",
+    "tel:+15551234567",
+    "sms:+15551234567",
     "/boards/b1/n/n1",
     "#section",
     "?q=1",

--- a/webui/src/components/markdown/markdown-link.tsx
+++ b/webui/src/components/markdown/markdown-link.tsx
@@ -11,7 +11,9 @@ const DOC_HREF_PREFIX = "#doc-"
 // Schemes we allow on a rendered <a href>. Everything else (javascript:,
 // data:, vbscript:, blob:, file:, …) is treated as unsafe and neutralized.
 // page:// and #doc- are handled by dedicated branches before this gate.
-const SAFE_SCHEMES = new Set(["http:", "https:", "mailto:"])
+// Kept in sync with sanitize-schema's href protocols. tel/sms are legitimate
+// contact links; xmpp/irc(s) are in the sanitizer's default href allowlist.
+const SAFE_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:", "sms:", "xmpp:", "irc:", "ircs:"])
 
 /**
  * Decide whether a markdown href is safe to assign to an anchor.

--- a/webui/src/components/markdown/markdown-link.tsx
+++ b/webui/src/components/markdown/markdown-link.tsx
@@ -8,6 +8,28 @@ const boardLinkRe = /^\/boards\/([^/]+)\/([^/]+)\/([^/]+)$/
 const PAGE_HREF_PREFIX = "page://"
 const DOC_HREF_PREFIX = "#doc-"
 
+// Schemes we allow on a rendered <a href>. Everything else (javascript:,
+// data:, vbscript:, blob:, file:, …) is treated as unsafe and neutralized.
+// page:// and #doc- are handled by dedicated branches before this gate.
+const SAFE_SCHEMES = new Set(["http:", "https:", "mailto:"])
+
+/**
+ * Decide whether a markdown href is safe to assign to an anchor.
+ * Schemeless hrefs — relative paths, `#hash`, `?query`, and
+ * protocol-relative `//host` — inherit the current origin and are safe.
+ * A href with an explicit scheme is safe only when that scheme is in the
+ * allowlist. Robust to obfuscation: leading/trailing whitespace, control
+ * chars, mixed case, and whitespace embedded in the scheme (browsers strip
+ * tabs/newlines, so "java\tscript:" resolves to javascript:).
+ */
+const isSafeHref = (href: string): boolean => {
+  // eslint-disable-next-line no-control-regex -- deliberately strips control/whitespace chars a browser ignores inside a scheme (defeats "java\tscript:" obfuscation)
+  const cleaned = href.replace(/[\u0000-\u0020\u007f-\u009f]/g, "")
+  const scheme = cleaned.match(/^([a-z][a-z0-9+.-]*):/i)
+  if (!scheme) return true
+  return SAFE_SCHEMES.has(`${scheme[1].toLowerCase()}:`)
+}
+
 type MarkdownLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   children?: React.ReactNode
 }
@@ -86,7 +108,11 @@ export function MarkdownLink({ children, href, ...rest }: MarkdownLinkProps) {
     })
   }
 
-  const isExternal = !!href && /^(https?:)?\/\//.test(href)
+  // Scheme allowlist gate (defense at the sink): only assign the href when
+  // its scheme is safe, so javascript:/data:/vbscript:/… never reach the DOM.
+  const safeHref = href && isSafeHref(href) ? href : undefined
+
+  const isExternal = !!safeHref && /^(https?:)?\/\//.test(safeHref)
   const target = isExternal ? "_blank" : rest.target
   const rel = isExternal ? "noreferrer" : rest.rel
 
@@ -97,7 +123,7 @@ export function MarkdownLink({ children, href, ...rest }: MarkdownLinkProps) {
 
   return (
     <a
-      href={href}
+      href={safeHref}
       target={target}
       rel={rel}
       className={clName}

--- a/webui/src/components/markdown/markdown-view.tsx
+++ b/webui/src/components/markdown/markdown-view.tsx
@@ -22,6 +22,8 @@ import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import rehypeRaw from "rehype-raw"
+import rehypeSanitize from "rehype-sanitize"
+import { SANITIZE_SCHEMA } from "./sanitize-schema"
 
 
 const DISPLAY_MATH_RE = /\\\[([\s\S]+?)\\\]/g
@@ -244,6 +246,13 @@ const REHYPE_PLUGINS = [
   // remark-math nodes).
   rehypeRaw,
   rehypeKatex,
+  // rehype-sanitize runs LAST so it scrubs both rehype-raw's parsed raw HTML
+  // (untrusted agent/newsfeed/citation content) and rehype-katex's generated
+  // output, stripping scripts, event handlers, and dangerous URLs/embeds. The
+  // extended schema (see sanitize-schema) preserves KaTeX, highlight marks,
+  // tag chips, toggles and page-ref links. Without it, raw HTML would reach
+  // the DOM unsanitized (stored/DOM XSS).
+  [rehypeSanitize, SANITIZE_SCHEMA],
 ] as const
 
 const STREAMDOWN_PLUGINS_STATIC = { code: codePlugin } as const

--- a/webui/src/components/markdown/markdown-view.tsx
+++ b/webui/src/components/markdown/markdown-view.tsx
@@ -23,7 +23,7 @@ import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import rehypeRaw from "rehype-raw"
 import rehypeSanitize from "rehype-sanitize"
-import { SANITIZE_SCHEMA } from "./sanitize-schema"
+import { SANITIZE_SCHEMA, rehypeSafeStyle } from "./sanitize-schema"
 
 
 const DISPLAY_MATH_RE = /\\\[([\s\S]+?)\\\]/g
@@ -253,6 +253,10 @@ const REHYPE_PLUGINS = [
   // tag chips, toggles and page-ref links. Without it, raw HTML would reach
   // the DOM unsanitized (stored/DOM XSS).
   [rehypeSanitize, SANITIZE_SCHEMA],
+  // rehype-sanitize allowlists `style` but can't inspect CSS values; this
+  // scrubs inline styles (drops fixed/absolute positioning, z-index, url())
+  // so untrusted CSS can't paint clickjacking overlays or beacon out.
+  rehypeSafeStyle,
 ] as const
 
 const STREAMDOWN_PLUGINS_STATIC = { code: codePlugin } as const

--- a/webui/src/components/markdown/sanitize-schema.test.ts
+++ b/webui/src/components/markdown/sanitize-schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { fromHtml } from "hast-util-from-html"
+import { toHtml } from "hast-util-to-html"
+import { sanitize } from "hast-util-sanitize"
+import { SANITIZE_SCHEMA } from "./sanitize-schema"
+
+
+// Exercise the schema the way rehype-sanitize applies it (see markdown-view.tsx):
+// parse raw HTML → sanitize with SANITIZE_SCHEMA → serialize.
+const clean = (html: string): string => toHtml(sanitize(fromHtml(html, { fragment: true }), SANITIZE_SCHEMA))
+
+
+describe("SANITIZE_SCHEMA — strips XSS vectors", () => {
+  it("removes <script>", () => {
+    expect(clean("<script>alert(1)</script>")).not.toContain("<script")
+  })
+
+  it("removes <iframe> (incl. javascript: src)", () => {
+    const out = clean('<iframe src="javascript:alert(1)"></iframe>')
+    expect(out).not.toContain("<iframe")
+    expect(out).not.toContain("javascript:")
+  })
+
+  it("removes <object>/<embed>/<form>", () => {
+    const out = clean("<object></object><embed><form></form>")
+    expect(out).not.toContain("<object")
+    expect(out).not.toContain("<embed")
+    expect(out).not.toContain("<form")
+  })
+
+  it("strips inline event handlers but can keep the element", () => {
+    const out = clean('<img src="x" onerror="alert(1)">')
+    expect(out).not.toContain("onerror")
+    expect(out).not.toContain("alert(1)")
+  })
+
+  it("strips a javascript: href on an anchor (keeps the text)", () => {
+    const out = clean('<a href="javascript:alert(1)">click</a>')
+    expect(out).not.toContain("javascript:")
+    expect(out).toContain("click")
+  })
+
+  it("strips a data: URI on an image", () => {
+    expect(clean('<img src="data:text/html,<script>alert(1)</script>">')).not.toContain("data:")
+  })
+})
+
+
+describe("SANITIZE_SCHEMA — preserves the viewer's intended rich output", () => {
+  it("keeps highlight <mark> with its data-color", () => {
+    const out = clean('<mark data-color="blue">key</mark>')
+    expect(out).toContain("<mark")
+    expect(out).toContain("data-color")
+    expect(out).toContain("key")
+  })
+
+  it("keeps <details>/<summary> toggles", () => {
+    const out = clean("<details><summary>more</summary>body</details>")
+    expect(out).toContain("<details")
+    expect(out).toContain("<summary")
+  })
+
+  it("keeps KaTeX MathML output (<math> subtree)", () => {
+    const out = clean("<math><semantics><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></semantics></math>")
+    expect(out).toContain("<math")
+    expect(out).toContain("<mi")
+  })
+
+  it("keeps KaTeX HTML spans with class + inline layout style", () => {
+    const out = clean('<span class="katex" style="height:0.8em" aria-hidden="true">x</span>')
+    expect(out).toContain("<span")
+    expect(out).toContain('class="katex"')
+    expect(out).toContain("height:0.8em")
+  })
+
+  it("keeps ordinary links + images on safe schemes", () => {
+    expect(clean('<a href="https://example.com/">x</a>')).toContain("https://example.com/")
+    expect(clean('<img src="https://example.com/a.png">')).toContain("https://example.com/a.png")
+  })
+})

--- a/webui/src/components/markdown/sanitize-schema.test.ts
+++ b/webui/src/components/markdown/sanitize-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import { fromHtml } from "hast-util-from-html"
 import { toHtml } from "hast-util-to-html"
 import { sanitize } from "hast-util-sanitize"
-import { SANITIZE_SCHEMA } from "./sanitize-schema"
+import { SANITIZE_SCHEMA, cleanStyle, rehypeSafeStyle } from "./sanitize-schema"
 
 
 // Exercise the schema the way rehype-sanitize applies it (see markdown-view.tsx):
@@ -40,8 +40,65 @@ describe("SANITIZE_SCHEMA — strips XSS vectors", () => {
     expect(out).toContain("click")
   })
 
-  it("strips a data: URI on an image", () => {
-    expect(clean('<img src="data:text/html,<script>alert(1)</script>">')).not.toContain("data:")
+})
+
+
+describe("SANITIZE_SCHEMA — no over-stripping of legitimate content", () => {
+  it("keeps a data:image URI on an <img> (inert — an image cannot execute)", () => {
+    expect(clean('<img src="data:image/png;base64,iVBORw0KGgo=">')).toContain("data:image/png")
+  })
+
+  it("does not rewrite in-document anchor ids (clobberPrefix empty)", () => {
+    const out = clean('<h2 id="summary">Summary</h2>')
+    expect(out).toContain('id="summary"')
+    expect(out).not.toContain("user-content")
+  })
+
+  it("keeps tel:/sms: hrefs (contact links)", () => {
+    expect(clean('<a href="tel:+15551234567">call</a>')).toContain("tel:+15551234567")
+    expect(clean('<a href="sms:+15551234567">text</a>')).toContain("sms:+15551234567")
+  })
+})
+
+
+describe("cleanStyle — scrubs CSS-injection vectors, keeps layout", () => {
+  it("drops fixed/absolute/sticky positioning and z-index (clickjacking overlay)", () => {
+    expect(cleanStyle("position:fixed;inset:0;z-index:9999;background:#000")).not.toMatch(/fixed|z-index/)
+    expect(cleanStyle("position:absolute;z-index:5")).toBe("")
+    expect(cleanStyle("position:sticky")).toBe("")
+  })
+
+  it("drops url() and expression() values (off-site beacons)", () => {
+    expect(cleanStyle("background:url(https://evil/x)")).toBe("")
+    expect(cleanStyle("width:1px;background:url(x)")).toBe("width:1px")
+  })
+
+  it("keeps KaTeX/highlight layout styles (incl. position:relative)", () => {
+    const out = cleanStyle("height:0.8em;vertical-align:-0.19em")
+    expect(out).toContain("height:0.8em")
+    expect(out).toContain("vertical-align:-0.19em")
+    expect(cleanStyle("position:relative;top:2px")).toContain("position:relative")
+    expect(cleanStyle("color:#ff0000")).toBe("color:#ff0000")
+  })
+})
+
+
+describe("rehypeSafeStyle — plugin scrubs style attributes in the tree", () => {
+  const run = (html: string): string => {
+    const tree = fromHtml(html, { fragment: true })
+    rehypeSafeStyle()(tree)
+    return toHtml(tree)
+  }
+
+  it("neutralizes a full-viewport overlay span but keeps the element + text", () => {
+    const out = run('<span style="position:fixed;inset:0;z-index:9999;background:#000">Sign in</span>')
+    expect(out).not.toContain("fixed")
+    expect(out).not.toContain("z-index")
+    expect(out).toContain("Sign in")
+  })
+
+  it("leaves a KaTeX-style span's inline layout intact", () => {
+    expect(run('<span style="height:0.8em">x</span>')).toContain("height:0.8em")
   })
 })
 

--- a/webui/src/components/markdown/sanitize-schema.ts
+++ b/webui/src/components/markdown/sanitize-schema.ts
@@ -1,4 +1,5 @@
 import type { Schema } from "hast-util-sanitize"
+import type { Root, Element } from "hast"
 import { defaultSchema } from "rehype-sanitize"
 
 
@@ -42,11 +43,17 @@ const MATH_SVG_ATTRS = [
  */
 export const SANITIZE_SCHEMA: Schema = {
   ...defaultSchema,
+  // defaultSchema rewrites id/name to `user-content-*` (DOM-clobber defense),
+  // but it does NOT rewrite matching href fragments — which breaks in-document
+  // anchors and GFM footnotes. Empty prefix keeps ids intact so navigation
+  // still works; script injection is already blocked by the sanitizer above.
+  clobberPrefix: "",
   tagNames: [...(defaultSchema.tagNames ?? []), "mark", ...MATHML_TAGS, ...SVG_TAGS],
   attributes: {
     ...defaultSchema.attributes,
     // Highlight marks carry a validated color: `data-color` themes the named
     // palette, an inline `style` themes custom hex values (see remark-highlight).
+    // `style` values are additionally scrubbed by rehypeSafeStyle (below).
     mark: ["dataColor", "style"],
     // KaTeX HTML spans and `#tag` chips rely on class names + inline layout
     // styles; `aria-hidden` marks KaTeX's visual (non-AT) subtree.
@@ -55,7 +62,62 @@ export const SANITIZE_SCHEMA: Schema = {
   },
   protocols: {
     ...defaultSchema.protocols,
-    // `page://<id>` links render as inline PageRefChips, never real anchors.
-    href: [...(defaultSchema.protocols?.href ?? []), "page"],
+    // `page://` renders as an inline PageRefChip; tel/sms are legitimate contact
+    // links (kept in sync with markdown-link's SAFE_SCHEMES).
+    href: [...(defaultSchema.protocols?.href ?? []), "page", "tel", "sms"],
+    // `data:` on <img> is inert (an image can't execute HTML/JS, incl.
+    // data:image/svg+xml loaded as an image) — re-allow it so legitimate inline
+    // base64 images render. Other data: sinks (iframe/object/a) stay stripped
+    // because those tags/attrs aren't allowlisted.
+    src: [...(defaultSchema.protocols?.src ?? []), "data"],
   },
+}
+
+
+// CSS declarations that enable clickjacking overlays or off-site beacons even
+// without script execution. hast-util-sanitize does NOT sanitize CSS, so we
+// scrub inline `style` after sanitization: drop out-of-flow positioning
+// (fixed/absolute/sticky), stacking (z-index), and url() / expression() values,
+// while preserving the in-flow layout styles KaTeX and highlight marks need.
+const isDangerousDecl = (prop: string, value: string): boolean =>
+  value.includes("url(") ||
+  value.includes("expression(") ||
+  prop === "z-index" ||
+  (prop === "position" && /\b(?:fixed|absolute|sticky)\b/.test(value))
+
+
+/** Keep only safe declarations of an inline `style` string. */
+export const cleanStyle = (style: string): string =>
+  style
+    .split(";")
+    .map((d) => d.trim())
+    .filter(Boolean)
+    .filter((d) => {
+      const i = d.indexOf(":")
+      if (i === -1) return false
+      const prop = d.slice(0, i).trim().toLowerCase()
+      const value = d.slice(i + 1).trim().toLowerCase()
+      return !isDangerousDecl(prop, value)
+    })
+    .join("; ")
+
+
+/**
+ * rehype plugin (runs AFTER rehype-sanitize): scrub the inline `style` attribute
+ * on every element, since the sanitizer allowlists `style` but can't inspect CSS
+ * values. Closes CSS-only injection (full-viewport overlays, url() beacons).
+ */
+export const rehypeSafeStyle = () => (tree: Root): Root => {
+  const walk = (node: Root | Element): void => {
+    if (node.type === "element" && typeof node.properties.style === "string") {
+      const cleaned = cleanStyle(node.properties.style)
+      if (cleaned) node.properties.style = cleaned
+      else delete node.properties.style
+    }
+    for (const child of node.children) {
+      if (child.type === "element") walk(child)
+    }
+  }
+  walk(tree)
+  return tree
 }

--- a/webui/src/components/markdown/sanitize-schema.ts
+++ b/webui/src/components/markdown/sanitize-schema.ts
@@ -1,0 +1,61 @@
+import type { Schema } from "hast-util-sanitize"
+import { defaultSchema } from "rehype-sanitize"
+
+
+// MathML elements emitted by rehype-katex for the accessible (screen-reader)
+// math tree. Allowlisted so KaTeX output survives sanitization.
+const MATHML_TAGS = [
+  "math", "semantics", "annotation", "mrow", "mi", "mo", "mn", "ms", "mtext",
+  "mspace", "mfrac", "mroot", "msqrt", "msup", "msub", "msubsup", "mover",
+  "munder", "munderover", "mtable", "mtr", "mtd", "mlabeledtr", "mpadded",
+  "mphantom", "menclose", "mstyle", "mglyph", "merror", "maction",
+]
+
+
+// SVG elements KaTeX emits for stretchy delimiters, sqrt rules and arrows.
+const SVG_TAGS = ["svg", "path", "line", "g", "rect", "defs", "use"]
+
+
+// Inert geometric / presentational attributes used by KaTeX's MathML and SVG
+// output. None are script-bearing; event-handler and URL attributes are
+// intentionally excluded so the sanitizer still strips them.
+const MATH_SVG_ATTRS = [
+  "className", "style", "ariaHidden", "xmlns", "encoding", "mathvariant",
+  "displaystyle", "scriptlevel", "stretchy", "fence", "accent", "accentunder",
+  "columnalign", "columnspacing", "rowalign", "rowspacing", "linethickness",
+  "lspace", "rspace", "voffset", "width", "height", "depth", "minsize",
+  "maxsize", "mathcolor", "mathbackground", "notation", "separator", "form",
+  "largeop", "movablelimits", "symmetric", "viewBox", "preserveAspectRatio",
+  "d", "fill", "stroke", "strokeWidth", "transform", "x", "y", "x1", "y1",
+  "x2", "y2", "points",
+]
+
+
+/**
+ * Sanitization schema for the markdown viewer.
+ *
+ * Extends hast-util-sanitize's GitHub-style `defaultSchema` so raw HTML parsed
+ * by rehype-raw is stripped of script/handler/URL-based XSS vectors while the
+ * viewer's intended rich output keeps rendering: KaTeX math (rehype-katex's
+ * MathML + styled HTML spans), highlight `<mark>` chips, `#tag` `<span>` chips,
+ * `<details>`/`<summary>` toggles and `page://` reference links.
+ */
+export const SANITIZE_SCHEMA: Schema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), "mark", ...MATHML_TAGS, ...SVG_TAGS],
+  attributes: {
+    ...defaultSchema.attributes,
+    // Highlight marks carry a validated color: `data-color` themes the named
+    // palette, an inline `style` themes custom hex values (see remark-highlight).
+    mark: ["dataColor", "style"],
+    // KaTeX HTML spans and `#tag` chips rely on class names + inline layout
+    // styles; `aria-hidden` marks KaTeX's visual (non-AT) subtree.
+    span: ["className", "style", "ariaHidden"],
+    ...Object.fromEntries([...MATHML_TAGS, ...SVG_TAGS].map((tag) => [tag, MATH_SVG_ATTRS])),
+  },
+  protocols: {
+    ...defaultSchema.protocols,
+    // `page://<id>` links render as inline PageRefChips, never real anchors.
+    href: [...(defaultSchema.protocols?.href ?? []), "page"],
+  },
+}

--- a/webui/src/features/agent/utils/doc-sources.test.ts
+++ b/webui/src/features/agent/utils/doc-sources.test.ts
@@ -125,6 +125,21 @@ describe("linkifyDocTitles", () => {
     )
   })
 
+  it("neutralizes HTML metacharacters in the emitted label (no raw HTML injection)", () => {
+    // A malicious file name carrying raw HTML must render as literal text, not
+    // reach the markdown renderer as active markup.
+    const title = "<img src=x onerror=alert(1)>.pdf"
+    const out = linkifyDocTitles(`cite ${title} now`, [src("A", title)], MID)
+    expect(out).toBe("cite [&lt;img src=x onerror=alert(1)&gt;.pdf](#doc-m1-A) now")
+    expect(out).not.toContain("<img")
+  })
+
+  it("leaves a plain title's label untouched (no spurious entity encoding)", () => {
+    expect(linkifyDocTitles("see Q3 Report.pdf here", [src("A", "Q3 Report.pdf")], MID)).toBe(
+      "see [Q3 Report.pdf](#doc-m1-A) here",
+    )
+  })
+
   it("links a title at the very start of the text (leading boundary via ^)", () => {
     expect(linkifyDocTitles("notes.pdf is the source", [src("A", "notes.pdf")], MID)).toBe(
       "[notes.pdf](#doc-m1-A) is the source",

--- a/webui/src/features/agent/utils/doc-sources.ts
+++ b/webui/src/features/agent/utils/doc-sources.ts
@@ -47,10 +47,19 @@ export const extractDocSources = (answer: AgentResponse): DocSource[] => {
 const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 
 
-// Backslash-escape markdown-active chars so a filename like "a*b_.pdf" renders
-// as literal text inside the emitted `[label](…)` instead of turning into
-// emphasis / code. "[" and "]" are handled by skipping such titles entirely.
-const escapeMarkdownLabel = (s: string): string => s.replace(/[\\`*_]/g, "\\$&")
+// Neutralize a title before it becomes the label of an emitted `[label](…)`.
+// Two passes: (1) backslash-escape markdown-active chars so "a*b_.pdf" renders
+// as literal text instead of emphasis / code; (2) HTML-entity-encode & < >
+// so a title carrying raw HTML (e.g. "<img src=x onerror=…>.pdf" from an
+// attacker-controlled file name) renders as literal text rather than reaching
+// MarkdownView's raw-HTML pipeline as active markup. "[" and "]" are handled by
+// skipping such titles entirely. `&` is encoded first so `<`/`>` don't double-encode.
+const escapeMarkdownLabel = (s: string): string =>
+  s
+    .replace(/[\\`*_]/g, "\\$&")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
 
 
 /**


### PR DESCRIPTION
Closes three client-side XSS findings from the frontend security scan of `webui/`. These harden the exact rendering path the document-Q&A work relies on (agent answers, note/document content, and cite-by-title citations).

## Fixes

**FE-F1 (HIGH) — markdown renderer parsed raw HTML with no sanitizer.**
`MarkdownView` supplied its own `REHYPE_PLUGINS`, which replaced Streamdown's hardened default (`rehype-sanitize` + `rehype-harden`) while keeping `rehype-raw` + `allowDangerousHtml` on — so untrusted content could inject raw HTML on the app origin (no-click via `<iframe src="javascript:…">`), reading `localStorage` (auth tokens + BYOK keys). Adds `rehype-sanitize` as the last rehype pass with a KaTeX- and theme-preserving schema (`sanitize-schema.ts`): keeps MathML/SVG KaTeX output, highlight `<mark>`, `#tag` spans, `<details>`/`<summary>`, and `page://` links; strips scripts, event handlers, and dangerous URL schemes. New focused schema test.

**FE-F2 (MED) — markdown links had no scheme allowlist.**
The generic-link branch rendered `<a href>` unchecked, so `javascript:`/`data:`/`vbscript:` URLs were clickable and executed on the app origin. Gated through `isSafeHref` (http/https/mailto + schemeless/relative/hash/protocol-relative); anything else renders inert (no `href`). Robust to whitespace/case/control-char obfuscation.

**FE-F6 (LOW) — cite-by-title linkifier didn't HTML-escape titles.**
`escapeMarkdownLabel` escaped markdown-active chars but not `& < >`, so an attacker-controlled document filename (e.g. `<img onerror=…>.pdf`) wove raw HTML into agent-answer markdown. Now HTML-entity-encodes `&` then `<` then `>` after the markdown escaping. Defense-in-depth alongside FE-F1.

## Verification
- 379 tests pass (markdown + agent), including the new sanitize-schema test and the patches' own tests.
- `make lint-ui` clean (type-check + eslint).

## Behavior change to note
The sanitizer means `data:`/`blob:` image or link URLs inside **rendered markdown** no longer display (that is the fix). Mini-apps/widgets render separately and are unaffected. Worth confirming nothing legitimately relied on `data:` image URIs in agent/note markdown.

## Not in scope (tracked separately)
FE-F3 (agent tool auto-run approval gate — design decision), FE-F4 (auth tokens in localStorage — needs a backend HttpOnly cookie), FE-F5 (widget-document CSP — patch ready).
