### PR TITLE
fix(ai): close managed-LLM metering bypasses + recover from tool errors

### DIFF
--- a/backend/test/unit/api/router/test_ai_llm_router.py
+++ b/backend/test/unit/api/router/test_ai_llm_router.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 
 import topix.api.router.ai as ai_module
 
-from topix.api.router.ai import meter_run, router
+from topix.api.router.ai import meter_run_managed, router
 from topix.api.utils.security import get_current_user_uid
 
 
@@ -30,7 +30,7 @@ def _client() -> TestClient:
         return "user-1"
 
     app.dependency_overrides[get_current_user_uid] = _uid
-    app.dependency_overrides[meter_run] = _no_meter
+    app.dependency_overrides[meter_run_managed] = _no_meter
     return TestClient(app)
 
 

--- a/backend/test/unit/api/router/test_ai_meter_run.py
+++ b/backend/test/unit/api/router/test_ai_meter_run.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 import topix.api.router.ai as ai_module
 
-from topix.api.router.ai import meter_run, optional_user_uid
+from topix.api.router.ai import meter_run, meter_run_managed, optional_user_uid
 
 
 class _FakeRedis:
@@ -26,12 +26,21 @@ class _FakeRedis:
         self.seen.add(key)
         return True
 
+    async def delete(self, key: str) -> None:
+        self.seen.discard(key)
+
     async def check_fixed_window_quota(self, key, limit, period, scope="tier_usage"):
         return (not self.ip_over, 60)
 
 
-def _app(monkeypatch, enforce, uid: str | None = "u1", redis: _FakeRedis | None = None) -> TestClient:
-    """App exposing a probe route guarded by meter_run, with enforce + auth stubbed."""
+def _app(
+    monkeypatch,
+    enforce,
+    uid: str | None = "u1",
+    redis: _FakeRedis | None = None,
+    dep=meter_run,
+) -> TestClient:
+    """App exposing a probe route guarded by `dep`, with enforce + auth stubbed."""
     app = FastAPI()
     app.redis_store = redis or _FakeRedis()
     monkeypatch.setattr(ai_module, "enforce_rate_limit", enforce)
@@ -42,7 +51,7 @@ def _app(monkeypatch, enforce, uid: str | None = "u1", redis: _FakeRedis | None 
     app.dependency_overrides[optional_user_uid] = _uid
 
     @app.post("/_probe")
-    async def _probe(_: None = Depends(meter_run)):
+    async def _probe(_: None = Depends(dep)):
         return {"ok": True}
 
     return TestClient(app)
@@ -133,4 +142,48 @@ def test_over_quota_first_call_returns_429(monkeypatch):
         raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, "slow down")
 
     res = _app(monkeypatch, enforce).post("/_probe", headers={"X-Run-Id": "run-x"})
+    assert res.status_code == 429
+
+
+def test_over_quota_retry_with_same_run_id_still_charges(monkeypatch):
+    """A rejected first call releases its dedup slot, so a retry re-enforces.
+
+    Regression: previously the slot was claimed before enforcement and never
+    released, so re-sending the same X-Run-Id after a 429 skipped the charge and
+    rode free for the key's TTL.
+    """
+    calls: list[str] = []
+
+    async def enforce(_request, uid):
+        calls.append(uid)
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, "slow down")
+
+    client = _app(monkeypatch, enforce)
+    first = client.post("/_probe", headers={"X-Run-Id": "run-x"})
+    retry = client.post("/_probe", headers={"X-Run-Id": "run-x"})
+    assert first.status_code == 429
+    assert retry.status_code == 429  # not a free 200
+    assert calls == ["u1", "u1"]  # re-enforced, not skipped
+
+
+def test_managed_only_ignores_provider_key_and_still_meters(monkeypatch):
+    """`meter_run_managed` (the LLM proxy) never honors X-Provider-Key.
+
+    Regression: a stray provider-key header used to take the BYOK skip branch and
+    bypass the quota — but the LLM endpoints run on our keys, so it must charge.
+    """
+    calls, enforce = _recorder()
+    client = _app(monkeypatch, enforce, dep=meter_run_managed)
+    res = client.post("/_probe", headers={"X-Run-Id": "run-1", "X-Provider-Key": "sk-user"})
+    assert res.status_code == 200
+    assert calls == ["u1"]  # metered despite the provider key
+
+
+def test_managed_only_over_quota_cannot_be_bypassed_by_provider_key(monkeypatch):
+    """An over-quota managed call is 429 even with an X-Provider-Key header."""
+    async def enforce(_request, _uid):
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, "slow down")
+
+    client = _app(monkeypatch, enforce, dep=meter_run_managed)
+    res = client.post("/_probe", headers={"X-Run-Id": "r", "X-Provider-Key": "sk-user"})
     assert res.status_code == 429

--- a/backend/topix/api/router/ai.py
+++ b/backend/topix/api/router/ai.py
@@ -128,8 +128,12 @@ async def _meter_run(
         except Exception:
             # Rejected (e.g. over quota): release the dedup slot so this run isn't
             # marked metered — otherwise a retry with the same id would skip the
-            # charge and ride free until the key's TTL expires.
-            await redis.delete(key)
+            # charge and ride free until the key's TTL expires. Best-effort, so a
+            # delete failure never masks the original rejection (the 429).
+            try:
+                await redis.delete(key)
+            except Exception:
+                pass
             raise
     else:
         await enforce_rate_limit(request, user_id)

--- a/backend/topix/api/router/ai.py
+++ b/backend/topix/api/router/ai.py
@@ -80,22 +80,29 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
-async def meter_run(
+async def _meter_run(
     request: Request,
-    user_id: Annotated[str | None, Depends(optional_user_uid)] = None,
-    x_run_id: Annotated[str | None, Header()] = None,
-    x_provider_key: Annotated[str | None, Header()] = None,
+    user_id: str | None,
+    x_run_id: str | None,
+    x_provider_key: str | None,
+    *,
+    allow_byok_relay: bool,
 ) -> None:
     """Meter one whole agent run against the plan's AI quota.
 
-    - A BYOK call (`X-Provider-Key`) runs on the user's own provider key: it's
-      never charged against our quota. It may be tokenless (local user), so it's
-      only guarded by a light per-IP cap.
+    - When `allow_byok_relay` is set (the external-tool endpoints that relay the
+      caller's key to the provider), a call carrying `X-Provider-Key` runs on the
+      user's own key: never charged against our quota, only guarded by a light
+      per-IP cap (it may be tokenless for a local user). The managed LLM proxy
+      passes `allow_byok_relay=False` — it always runs on OUR keys, so a stray
+      provider-key header must NOT skip metering.
     - A managed call requires auth. The FIRST managed call of a run (deduped by
       `X-Run-Id`) enforces the quota (429 when over); later calls in the run are
       free; a call with no run id is metered on its own ("one run = one unit").
+      The dedup slot is released if enforcement rejects, so a rejected first call
+      isn't recorded as already-metered (which would let a retry ride free).
     """
-    if x_provider_key:
+    if allow_byok_relay and x_provider_key:
         redis = getattr(request.app, "redis_store", None)
         if redis is not None:
             ok, _ = await redis.check_fixed_window_quota(
@@ -112,10 +119,46 @@ async def meter_run(
         )
     if x_run_id:
         redis = request.app.redis_store
-        first = await redis.set_if_absent(f"airun:{user_id}:{x_run_id}", RUN_TTL_SECONDS)
+        key = f"airun:{user_id}:{x_run_id}"
+        first = await redis.set_if_absent(key, RUN_TTL_SECONDS)
         if not first:
             return
-    await enforce_rate_limit(request, user_id)
+        try:
+            await enforce_rate_limit(request, user_id)
+        except Exception:
+            # Rejected (e.g. over quota): release the dedup slot so this run isn't
+            # marked metered — otherwise a retry with the same id would skip the
+            # charge and ride free until the key's TTL expires.
+            await redis.delete(key)
+            raise
+    else:
+        await enforce_rate_limit(request, user_id)
+
+
+async def meter_run(
+    request: Request,
+    user_id: Annotated[str | None, Depends(optional_user_uid)] = None,
+    x_run_id: Annotated[str | None, Header()] = None,
+    x_provider_key: Annotated[str | None, Header()] = None,
+) -> None:
+    """Meter a managed-or-BYOK-relay call (`/ai/search|code|fetch|parse`).
+
+    A relayed `X-Provider-Key` runs on the user's own key and skips our quota.
+    """
+    await _meter_run(request, user_id, x_run_id, x_provider_key, allow_byok_relay=True)
+
+
+async def meter_run_managed(
+    request: Request,
+    user_id: Annotated[str | None, Depends(optional_user_uid)] = None,
+    x_run_id: Annotated[str | None, Header()] = None,
+) -> None:
+    """Meter a managed-only call (`/ai/llm[/stream]`, which runs on OUR keys).
+
+    Unlike `meter_run` there is no `X-Provider-Key` escape hatch: these endpoints
+    never relay a caller key, so the run is always charged.
+    """
+    await _meter_run(request, user_id, x_run_id, None, allow_byok_relay=False)
 
 
 class AiLlmRequest(BaseModel):
@@ -200,7 +243,7 @@ async def ai_llm(
     request: Request,
     body: AiLlmRequest,
     user_id: Annotated[str, Depends(get_current_user_uid)],
-    _meter: Annotated[None, Depends(meter_run)],
+    _meter: Annotated[None, Depends(meter_run_managed)],
 ):
     """Forward one model turn with our keys. Returns `{choices:[{message}]}`."""
     entitlement = await resolve_entitlement_context(request, user_id)
@@ -236,7 +279,7 @@ async def ai_llm_stream(
     request: Request,
     body: AiLlmRequest,
     user_id: Annotated[str, Depends(get_current_user_uid)],
-    _meter: Annotated[None, Depends(meter_run)],
+    _meter: Annotated[None, Depends(meter_run_managed)],
 ):
     """Stream one model turn as NDJSON lines.
 

--- a/backend/topix/store/redis/store.py
+++ b/backend/topix/store/redis/store.py
@@ -48,6 +48,10 @@ class RedisStore:
         result = await self.redis.set(key, "1", nx=True, ex=ttl_seconds)
         return bool(result)
 
+    async def delete(self, key: str) -> None:
+        """Delete a key (used to release a run's dedup slot when metering is rejected)."""
+        await self.redis.delete(key)
+
     async def check_rate_limit(
         self,
         user_id: str,

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -6,7 +6,9 @@ import { BoardRegistry, newLocalBoard } from "@/features/board/persist/local/boa
 import { LocalSearchIndex } from "@/features/board/search/local-index"
 import { addNode, freshStore, resetIdb } from "@/test/canvas"
 import { ScriptedLlm, toolTurn } from "@/test/llm"
+import { z } from "zod"
 import { runAgent } from "./agent-loop"
+import { defineTool } from "./types"
 import type { AgentEvent, LlmClient, LlmMessage } from "./types"
 import { createNote, editNote, getNote, linkNotes, listBoards, localTools, searchNotes, updateNote, writeNote } from "./tools"
 import { learnGenerateMiniApp, skillTools } from "./skills"
@@ -49,6 +51,33 @@ describe("runAgent (scripted LLM)", () => {
     expect(pairs).toEqual(["n1->n2", "n2->n3"])
     expect(events.at(-1)).toEqual({ type: "done" })
     expect(events.some((e) => e.type === "assistant_text")).toBe(true)
+  })
+
+
+  it("reports a throwing tool as a tool error and keeps the run going", async () => {
+    const store = freshStore("c")
+    const exploding = defineTool({
+      name: "explode",
+      description: "always throws",
+      parameters: z.object({}),
+      run: async () => {
+        throw new Error("boom")
+      },
+    })
+    const llm = new ScriptedLlm([
+      toolTurn("explode", {}),
+      { kind: "text", text: "recovered without the tool" },
+    ])
+
+    const events = await drain(runAgent({ userMessage: "go", tools: [exploding], llm, ctx: { store } }))
+
+    expect(events.find((e) => e.type === "tool_result")).toMatchObject({
+      type: "tool_result",
+      toolName: "explode",
+      result: { error: "boom" },
+    })
+    expect(events.some((e) => e.type === "assistant_text" && e.text === "recovered without the tool")).toBe(true)
+    expect(events.at(-1)).toEqual({ type: "done" })
   })
 
 

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -97,7 +97,19 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
       const args = parseArgs(call.arguments)
       yield { type: "tool_start", toolName: call.name, args }
       const tool = opts.tools.find((t) => t.name === call.name)
-      const output = tool ? await tool.run(args, opts.ctx) : { error: `unknown tool: ${call.name}` }
+      // A tool that throws (e.g. a managed service returning 500) must not abort
+      // the whole run: feed the error back as the tool result so the model can
+      // recover or answer without it, matching the unknown-tool path.
+      let output: unknown
+      if (!tool) {
+        output = { error: `unknown tool: ${call.name}` }
+      } else {
+        try {
+          output = await tool.run(args, opts.ctx)
+        } catch (err) {
+          output = { error: err instanceof Error ? err.message : String(err) }
+        }
+      }
       agentLog.tool(call.name, args, output)
       yield { type: "tool_result", toolName: call.name, result: output }
       messages.push({ role: "tool", toolCallId: call.id, content: JSON.stringify(output) })


### PR DESCRIPTION
First remediation drop from the review of #154 — the two smallest, highest-value, lowest-risk fixes. Branches off `offline-first-phase-a`.

## Fixes

### 1. Metering bypass on the managed LLM proxy (Critical)
`/ai/llm[/stream]` run on **our** keys, but `meter_run` skipped metering whenever an `X-Provider-Key` header was present — so an authenticated user could add a junk header and get unlimited managed LLM for free. Split the dependency: `meter_run_managed` never honors a provider key, and both LLM endpoints use it. The tool endpoints (`/ai/search|code|fetch|parse`) keep `meter_run` (they legitimately relay the caller's key to the provider).

### 2. Over-quota bypass via run-id replay (High)
The `X-Run-Id` dedup slot was claimed **before** `enforce_rate_limit`, and never released on rejection — so an over-quota first call could be retried with the same run id to skip the charge and ride free for the key's TTL (3600s). Now the slot is released when enforcement rejects, so a retry re-enforces. (Best-effort release, so a Redis blip can't mask the original 429.)

### 3. Tool error no longer aborts the whole run (Medium)
A tool handler that threw (e.g. a managed service returning 500) propagated out of the agent loop and killed the turn. It's now caught and fed back as an `{ error }` tool result — matching the existing unknown-tool path — so the model can recover or answer without it.

## Tests
- Backend: 3 new regressions in `test_ai_meter_run.py` (managed meters despite a provider key; over-quota can't be bypassed by a provider key; over-quota retry re-enforces) + `test_ai_llm_router.py` updated to the new dependency. All `test_ai_*` router suites green.
- Webui: 1 new `agent-loop` test (throwing tool → error result, run continues). Agent-loop suites green.
- `tsc` + eslint + ruff clean.

## Known follow-ups (surfaced by `/code-review`, deliberately out of scope here)
- **Retry re-increments minute/day counters** — because `enforce_rate_limit` increments each rule on check and isn't atomic, a retried over-quota run re-bumps the earlier-passing windows. Low / self-healing (windows reset in <60s / <24h; the user stays 429'd regardless). Proper fix = make `enforce_rate_limit` roll back earlier increments when a later rule rejects (rate-limiter change, separate PR).
- **A persistently-dead tool can loop to `maxTurns`** — the catch-all means a hard tool outage costs up to ~30× billed completions if the model keeps retrying, vs. an immediate abort pre-fix. Bounding it (consecutive-failure cap) needs more agent-runtime change than is worth right now.
- **Concurrent same-run-id** — two concurrent first-calls of one run can let the loser return a free 200. Low; the client mints one id and calls sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
