### PR TITLE
fix(board): recover un-acked ops on reconnect (no stranded edits, no re-apply)

### DIFF
--- a/webui/src/features/board/harness/sync/board-sync.test.ts
+++ b/webui/src/features/board/harness/sync/board-sync.test.ts
@@ -695,3 +695,124 @@ describe("relay idempotency", () => {
     expect(acks).toEqual([1, 1]) // both acked at the same seq
   })
 })
+
+
+describe("reconnect re-sends un-acked ops (supervised path, no disconnect)", () => {
+  // A hand-driven connection that records outbound `op` sends. reconnect() reuses
+  // the same conn (like the real WS supervisor reopening), so both sends land here.
+  const recordingClient = (id: string) => {
+    const engine = new InMemoryEngine()
+    const persistence = new BoardPersistence(BOARD, { engine })
+    const store = freshStore(id)
+    persistence.attach(store)
+    const sent: { client_seq: number; batch: OpBatch }[] = []
+    let deliver: ((m: InboundMessage) => void) | null = null
+    const conn: RelayConnection = {
+      send: (m) => {
+        if (m.kind === "op") sent.push({ client_seq: m.client_seq, batch: m.batch })
+      },
+      onMessage: (cb) => {
+        deliver = cb
+        return () => {
+          deliver = null
+        }
+      },
+      close: () => {},
+    }
+    const sync = attachBoardSync({
+      store,
+      persistence,
+      engine,
+      boardId: BOARD,
+      clientId: asClientId(id),
+      connect: (sinceSeq) => {
+        void sinceSeq
+        return conn
+      },
+      coalesceMs: 0,
+    })
+    return { engine, store, sync, sent, push: (m: InboundMessage) => deliver?.(m) }
+  }
+
+
+  it("re-pumps an un-acked op after a reconnect (was stranded until reload)", async () => {
+    const c = recordingClient("A")
+    addNode(c.store, "n1")
+    await c.sync.settle()
+    expect(c.sent).toHaveLength(1) // sent once, now in-flight; ack never arrives
+
+    // Real reconnect path — openConnection, NOT the test-only disconnect() that
+    // used to be the only thing clearing in-flight.
+    c.sync.reconnect()
+    await c.sync.settle()
+    expect(c.sent).toHaveLength(2) // the stranded op re-pumps (previously stuck at 1)
+
+    // A fresh ack on the re-send drains the outbox — proving it got through.
+    c.push({ kind: "op-applied", client_seq: c.sent[1].client_seq, seq: 1 })
+    await c.sync.settle()
+    expect(await new BoardOutbox(c.engine, BOARD).pending()).toHaveLength(0)
+    c.sync.detach()
+  })
+
+
+  it("re-sends a coalesced batch under its original id so the relay dedups it (no re-apply)", async () => {
+    // A dedup-aware fake relay: it applies a batch's ops only the first time it
+    // sees that envelope batch id (exactly what the real relay does — dedup by
+    // batch_id, collab.py), and its ack can be withheld to simulate a lost one.
+    const engine = new InMemoryEngine()
+    const persistence = new BoardPersistence(BOARD, { engine })
+    const store = freshStore("A")
+    persistence.attach(store)
+    const seen = new Set<string>()
+    let appliedOps = 0
+    let serverSeq = 0
+    let autoAck = true
+    let deliver: ((m: InboundMessage) => void) | null = null
+    const conn: RelayConnection = {
+      send: (m) => {
+        if (m.kind !== "op") return
+        serverSeq += 1
+        const id = String(m.batch.id)
+        if (!seen.has(id)) {
+          seen.add(id)
+          appliedOps += m.batch.ops.length // first sight → applied + broadcast
+        }
+        if (autoAck) deliver?.({ kind: "op-applied", client_seq: m.client_seq, seq: serverSeq })
+      },
+      onMessage: (cb) => {
+        deliver = cb
+        return () => {
+          deliver = null
+        }
+      },
+      close: () => {},
+    }
+    const sync = attachBoardSync({
+      store,
+      persistence,
+      engine,
+      boardId: BOARD,
+      clientId: asClientId("A"),
+      connect: () => conn,
+      coalesceMs: 75,
+    })
+    await sync.settle() // drain the initial connect pump (nothing pending yet)
+
+    // A coalesced burst reaches the relay (2 ops applied) but its ack is lost.
+    autoAck = false
+    addNode(store, "n1")
+    addNode(store, "n2")
+    await sync.settle()
+    expect(appliedOps).toBe(2) // both ops applied under one coalesced batch id
+
+    // Supervised reconnect re-sends the still-un-acked batch. Because it re-sends
+    // the SAME coalesced grouping (same envelope id), the relay dedups it — the
+    // earlier records are NOT re-applied (the bug this replaces asserted the
+    // opposite via an uncoalesced replay under ids the relay never recorded).
+    autoAck = true
+    sync.reconnect()
+    await sync.settle()
+    expect(appliedOps).toBe(2) // still 2 — nothing re-applied
+    sync.detach()
+  })
+})

--- a/webui/src/features/board/harness/sync/board-sync.ts
+++ b/webui/src/features/board/harness/sync/board-sync.ts
@@ -284,10 +284,24 @@ export const attachBoardSync = (opts: BoardSyncOptions): BoardSyncHandle => {
   }
 
   const openConnection = (): void => {
+    // Close any prior socket first: a direct reconnect() while one is still open
+    // would otherwise leak it and leave a second `handle` registered on it.
+    connection?.close()
+    // A fresh socket: anything sent on the previous connection but not yet acked
+    // is lost with it, so drop the in-flight tracking — those oplog records are
+    // still unacked and must become eligible to re-send, or they're stranded
+    // until a reload. This is the supervised-reconnect path, which (unlike the
+    // test-only `disconnect()`) never cleared in-flight before.
+    inFlight.clear()
     // `sinceSeq` at connect time lets the relay pick the welcome mode; no separate
     // hello-with-since_seq message (the real WS carries it as a query param).
     connection = opts.connect(lastServerSeq)
     connection.onMessage(handle)
+    // Replay coalesced (same grouping as the live send): a coalesced message's
+    // relay id is its LAST record's id, so re-sending the same set keeps that id
+    // and the relay dedups it. Re-sending records individually would give earlier
+    // records ids the relay never recorded → re-apply. (A superset re-send, if a
+    // new edit landed during the drop, still changes the id — see PR notes.)
     enqueue(pump)
   }
 


### PR DESCRIPTION
Second remediation drop from the review of #154 — the other verified data-loss blocker. Branches off `offline-first-phase-a`. All changes are in `board-sync.ts`.

## Fix 3 (High) — in-flight edits stranded on a real reconnect
A batch sent before a socket drop is tracked in `inFlight` and only removed on ack or by `inFlight.clear()` — which lived **only** in the test-only `disconnect()`. The production supervised path (`ReconnectSupervisor.onClose → handle.reconnect() → openConnection`) never cleared it, so an un-acked seq stayed in `inFlightSeqs`, was filtered out of `eligible` in `pump`, and the edit was **silently never delivered** to the server/peers until a full page reload. The existing reconnect tests passed only because they drive `disconnect()`.

**Fix:** clear `inFlight` in `openConnection`, so un-acked records become eligible again on every (re)connect. Also close any prior socket in `openConnection` so a direct `reconnect()` while one is still open can't leak it or leave a second `handle` registered.

## The replay stays coalesced (deliberately)
The relay dedups by envelope `batch_id` (`collab.py`), and a coalesced message's id is its **last** record's id (`mergeBatches`). So the reconnect replay re-sends the **same coalesced grouping** → same envelope id → the relay dedups it and does **not** re-apply. Re-sending the records individually would give the earlier records ids the relay never recorded, causing a re-apply + re-broadcast — so `pump` keeps coalescing on replay.

## Known residual (follow-up, benign server-side)
If a *new* edit lands between a lost ack and the reconnect, the re-coalesced batch's last-record id changes, so an already-applied prefix can be re-applied. This is bounded and benign on the server — `apply_batch` writes via Qdrant `upsert` (+ patch/delete), so a re-applied op is an idempotent re-write, not a duplicate. The fully-correct fix is relay-side idempotency by covered oplog-seq range (rather than by a single envelope id); tracked as a follow-up, out of scope for this client-side PR.

## Tests
Two regressions in `board-sync.test.ts`, both validated:
- **re-pumps an un-acked op** after a supervised reconnect (not the test-only `disconnect()`) and a fresh ack drains the outbox — **fails on the pre-fix base** (op stays stranded).
- **re-sends a coalesced batch under its original id so the relay dedups it (no re-apply)** — driven against a **dedup-aware fake relay** (applies a batch's ops only the first time it sees that envelope id, ack withheld to simulate a loss). Asserts the applied-op count stays flat across the reconnect; **fails against an uncoalesced replay** (the earlier draft), so it guards the chosen approach.

70 tests across the 8 sync + `use-board-sync-v2` suites pass; `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
