### PR TITLE
fix(boards): close the adopt synced-board cap race (TOCTOU)

### DIFF
--- a/backend/test/unit/api/router/test_boards_adopt_router.py
+++ b/backend/test/unit/api/router/test_boards_adopt_router.py
@@ -27,6 +27,11 @@ class _AdoptStore:
         self.add_links_calls: list = []
         # Number of boards the caller already OWNS (for the synced-board cap).
         self._owned_count = owned_count
+        # When True, the atomic create reports the cap hit (simulates losing the race).
+        self.block_create = False
+        # When True, the atomic create reports a concurrent create already made the
+        # UID (the create-under-lock "exists" branch, invisible to the top-level check).
+        self.race_exists = False
 
     async def get_graph_metadata(self, graph_uid: str) -> Graph | None:
         return self.metadata.get(graph_uid)
@@ -38,6 +43,21 @@ class _AdoptStore:
         self.added_graphs.append((graph, user_uid))
         self.metadata[graph.uid] = graph
         self.roles[(graph.uid, user_uid)] = "owner"
+
+    async def create_graph_within_cap(self, graph: Graph, user_uid: str, cap: int | None) -> str:
+        # Mirrors the real atomic method's outcomes.
+        if self.race_exists:
+            # A concurrent adopter created the UID under the lock (owner = caller).
+            self.metadata[graph.uid] = graph
+            self.roles[(graph.uid, user_uid)] = "owner"
+            return "exists"
+        if self.block_create or (cap is not None and self._owned_count >= cap):
+            return "at_cap"
+        self.added_graphs.append((graph, user_uid))
+        self.metadata[graph.uid] = graph
+        self.roles[(graph.uid, user_uid)] = "owner"
+        self._owned_count += 1
+        return "created"
 
     async def list_graphs(self, user_uid: str):
         # (graph, role, owner_email) tuples; `_owned_count` owned rows.
@@ -176,3 +196,71 @@ def test_adopt_allows_paid_plan_over_free_limit(monkeypatch):
 
     assert res.status_code == 200
     assert res.json()["data"]["adopted"] is True
+
+
+def test_adopt_losing_the_cap_race_is_402_and_writes_nothing(monkeypatch):
+    """The atomic cap check is authoritative (not a pre-check), and create-first.
+
+    When `create_graph_within_cap` reports the cap hit (a concurrent adopt took the
+    last slot), adopt 402s, creates NO graph row, and — because content is rebuilt
+    only after a successful create — applies NO content either. So there's neither a
+    half-adopted empty board nor orphaned Qdrant content, and a retry heals cleanly.
+    """
+    monkeypatch.setattr(boards_module, "is_billing_active", lambda: True)
+    store = _AdoptStore(owned_count=0)
+    store.block_create = True  # atomic create reports the cap hit (lost the race)
+    client = _client(store, user_uid="owner-1", plan="free")
+
+    res = client.post("/boards/b:adopt", json={"ops": [_node_add("n1")]})
+    assert res.status_code == 402
+    assert store.added_graphs == []  # no board row created
+    assert store.add_notes_calls == []  # create-first: content never applied → no orphan
+
+    # Retry once the slot frees: no graph row exists → re-creates + applies cleanly.
+    store.block_create = False
+    res2 = client.post("/boards/b:adopt", json={"ops": [_node_add("n1")]})
+    assert res2.status_code == 200
+    assert res2.json()["data"]["adopted"] is True
+    assert len(store.added_graphs) == 1
+
+
+def test_adopt_concurrent_same_id_is_idempotent_not_500():
+    """A concurrent adopt of the same UID (create-under-lock 'exists') is a no-op.
+
+    The top-level metadata check sees nothing (the concurrent create hasn't been
+    observed yet), so adopt reaches create_graph_within_cap, which reports the UID
+    already exists. That must return an idempotent no-op — not blow up on the unique
+    constraint (the old behavior on a double-click).
+    """
+    store = _AdoptStore()
+    store.race_exists = True  # a concurrent adopter created the UID under the lock
+    client = _client(store, user_uid="owner-1")
+
+    res = client.post("/boards/b:adopt", json={"ops": [_node_add("n1")]})
+    assert res.status_code == 200
+    assert res.json()["data"] == {"graph_id": "b", "adopted": False, "applied": 0}
+    assert store.add_notes_calls == []  # the loser doesn't re-apply content
+
+
+def test_create_board_rejects_when_free_synced_limit_reached(monkeypatch):
+    """Creating a board via PUT /boards enforces the same cap as adopt (no bypass)."""
+    monkeypatch.setattr(boards_module, "is_billing_active", lambda: True)
+    store = _AdoptStore(owned_count=boards_module.FREE_SYNCED_BOARD_LIMIT)
+    client = _client(store, user_uid="owner-1", plan="free")
+
+    res = client.put("/boards")
+
+    assert res.status_code == 402
+    assert store.added_graphs == []  # never created
+
+
+def test_create_board_succeeds_under_cap():
+    """PUT /boards creates a board when under the cap (billing off → unlimited)."""
+    store = _AdoptStore(owned_count=0)
+    client = _client(store, user_uid="owner-1")
+
+    res = client.put("/boards")
+
+    assert res.status_code == 200
+    assert "graph_id" in res.json()["data"]
+    assert len(store.added_graphs) == 1

--- a/backend/topix/api/router/boards.py
+++ b/backend/topix/api/router/boards.py
@@ -53,34 +53,40 @@ async def create_graph(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_uid)]
 ):
-    """Create a new graph for the user."""
+    """Create a new synced board for the user, enforcing the plan's board cap.
+
+    Shares the atomic, race-free cap primitive with adopt so the free-tier limit
+    can't be bypassed by creating boards directly instead of promoting local ones.
+    """
     store: GraphStore = request.app.graph_store
 
+    cap = await _synced_board_cap(request, user_id)
     new_graph = Graph(user_uid=user_id)
-    await store.add_graph(graph=new_graph, user_uid=user_id)
+    outcome = await store.create_graph_within_cap(graph=new_graph, user_uid=user_id, cap=cap)
+    if outcome == "at_cap":
+        raise HTTPException(status_code=402, detail=_CAP_DETAIL)
+    # A fresh server-generated UID can't collide, so "created" is the only other
+    # outcome.
     return {"graph_id": new_graph.uid}
 
 
-async def _enforce_synced_board_limit(
-    request: Request, store: GraphStore, user_id: str
-) -> None:
-    """Raise 402 if the free plan's synced-board cap is already reached.
+_CAP_DETAIL = "Synced-board limit reached for your plan. Upgrade, or delete a synced board."
 
-    No-op in OSS mode (billing off) and for paid plans (unlimited). Counts only
-    boards the user OWNS — shared-with-me boards don't count against their cap.
+
+async def _synced_board_cap(request: Request, user_id: str) -> int | None:
+    """Resolve the caller's synced-board cap, or None when unlimited.
+
+    None in OSS mode (billing off) and for paid plans; the free plan's fixed cap
+    otherwise. The count of owned boards is done atomically at create time (see
+    `create_graph_within_cap`) — this only resolves the limit.
     """
     if not is_billing_active():
-        return
+        return None
     billing = await request.app.user_billing_store.get_user_billing(user_id)
     plan = effective_plan(billing.plan, billing.status) if billing else "free"
     if plan != "free":
-        return
-    owned = sum(1 for (_g, role, _e) in await store.list_graphs(user_id) if role == "owner")
-    if owned >= FREE_SYNCED_BOARD_LIMIT:
-        raise HTTPException(
-            status_code=402,
-            detail="Synced-board limit reached for your plan. Upgrade, or delete a synced board.",
-        )
+        return None
+    return FREE_SYNCED_BOARD_LIMIT
 
 
 @router.post("/{graph_id}:adopt/", include_in_schema=False)
@@ -114,12 +120,27 @@ async def adopt_graph(
             raise HTTPException(status_code=409, detail="board id already in use")
         return {"graph_id": graph_id, "adopted": False, "applied": 0}
 
-    # Enforce the synced-board cap at promotion (boards are one-way: no un-sync,
-    # so the cap can't be bypassed by demoting). Local boards stay unlimited.
-    await _enforce_synced_board_limit(request, store, user_id)
-
+    # Create the graph row FIRST, atomically enforcing the synced-board cap: a
+    # per-user advisory lock inside create_graph_within_cap makes the count+insert
+    # race-free (no two concurrent adopts can both slip past the cap) and detects a
+    # concurrent duplicate UID instead of hitting the unique constraint. Content is
+    # rebuilt only AFTER a successful create, so a rejected/duplicate adopt writes
+    # nothing to Qdrant that would need cleaning up.
+    cap = await _synced_board_cap(request, user_id)
     graph = Graph(uid=graph_id, label=body.label)
-    await store.add_graph(graph=graph, user_uid=user_id)
+    outcome = await store.create_graph_within_cap(graph=graph, user_uid=user_id, cap=cap)
+    if outcome == "at_cap":
+        raise HTTPException(status_code=402, detail=_CAP_DETAIL)
+    if outcome == "exists":
+        # A concurrent adopt of this UID won the race and owns the content rebuild;
+        # this call is an idempotent no-op. Confirm ownership though — a UID owned
+        # by someone else is a conflict, not a silent success.
+        role = await store.get_graph_role(graph_uid=graph_id, user_uid=user_id)
+        if role != "owner":
+            raise HTTPException(status_code=409, detail="board id already in use")
+        return {"graph_id": graph_id, "adopted": False, "applied": 0}
+
+    # Rebuild content on the freshly-created graph (idempotent Qdrant upserts).
     results = await apply_batch(
         graph_store=store,
         board_id=graph_id,

--- a/backend/topix/store/graph.py
+++ b/backend/topix/store/graph.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 
+from typing import Literal
+
 import asyncpg
 
 from qdrant_client.models import (
@@ -22,10 +24,12 @@ from topix.store.postgres.graph import (
     create_graph,
     delete_graph_by_uid,
     get_graph_by_uid,
+    get_graph_id_by_uid,
     update_graph_by_uid,
 )
 from topix.store.postgres.graph_user import (
     add_user_to_graph_by_uid,
+    count_owned_graphs_by_user_uid,
     get_graph_role_by_user_uid,
     get_owner_uid_by_graph_uid,
     list_graphs_by_user_uid,
@@ -685,6 +689,37 @@ class GraphStore:
         async with self._pg_pool.acquire() as conn:
             await create_graph(conn, graph)
             await add_user_to_graph_by_uid(conn, graph.uid, user_uid, "owner")
+
+    async def create_graph_within_cap(
+        self, graph: Graph, user_uid: str, cap: int | None
+    ) -> Literal["created", "at_cap", "exists"]:
+        """Create a user-owned graph, atomically enforcing an owned-board `cap`.
+
+        Runs under a per-user, transaction-scoped advisory lock so concurrent
+        creates for the same user serialize: the count-then-insert can't race past
+        `cap` (the TOCTOU that let two simultaneous adopts both slip past the
+        free-tier limit), and a duplicate UID from a concurrent adopt is detected
+        rather than hitting the unique constraint. The two inserts also become
+        atomic (previously `add_graph` ran them as separate statements).
+
+        Returns:
+          - "created": the graph + owner membership were inserted;
+          - "at_cap":  already at `cap`, nothing created (never when `cap` is None);
+          - "exists":  a concurrent create already inserted this UID, nothing created.
+
+        """
+        async with self._pg_pool.acquire() as conn:
+            async with conn.transaction():
+                # Per-user lock (auto-released at txn end): the checks + insert below
+                # can't interleave with another create for the same user.
+                await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", user_uid)
+                if await get_graph_id_by_uid(conn, graph.uid) is not None:
+                    return "exists"
+                if cap is not None and await count_owned_graphs_by_user_uid(conn, user_uid) >= cap:
+                    return "at_cap"
+                await create_graph(conn, graph)
+                await add_user_to_graph_by_uid(conn, graph.uid, user_uid, "owner")
+                return "created"
 
     async def update_graph(self, graph_uid: str, data: dict):
         """Update an existing graph."""

--- a/backend/topix/store/postgres/graph_user.py
+++ b/backend/topix/store/postgres/graph_user.py
@@ -39,6 +39,26 @@ async def add_user_to_graph_by_uid(
     return True
 
 
+async def count_owned_graphs_by_user_uid(
+    conn: asyncpg.Connection,
+    user_uid: str,
+) -> int:
+    """Count the non-deleted boards a user OWNS — the synced-board cap basis.
+
+    Mirrors `list_graphs_by_user_uid`'s owner rows (joins `graphs` to exclude
+    soft-deleted boards), so the cap counts exactly what the sidebar shows.
+    """
+    user_id = await get_user_id_by_uid(conn, user_uid)
+    if user_id is None:
+        return 0
+    query = (
+        "SELECT count(*) FROM graph_user gu "
+        "JOIN graphs g ON gu.graph_id = g.id "
+        "WHERE gu.user_id = $1 AND gu.role = 'owner' AND g.deleted_at IS NULL"
+    )
+    return await conn.fetchval(query, user_id)
+
+
 async def list_graphs_by_user_uid(
     conn: asyncpg.Connection,
     user_uid: str


### PR DESCRIPTION
Third remediation drop from the review of #154 — the synced-board cap. Branches off `offline-first-phase-a`.

## The bug (TOCTOU)
`adopt_graph` **counted** a user's owned boards and then **created** one in separate `await`s, with nothing serializing the two. Two concurrent `POST /boards/{id}:adopt` calls could both read "4 < 5" and both create → a free user ends up with 6 synced boards. Classic check-then-act race.

## The fix
New `GraphStore.create_graph_within_cap(graph, user_uid, cap)` — under a **per-user, transaction-scoped advisory lock** (`pg_advisory_xact_lock(hashtext(user_uid))`) it, atomically:
1. checks for a duplicate UID (returns `"exists"`),
2. counts owned, non-deleted boards; if `>= cap` returns `"at_cap"` (`cap=None` = unlimited),
3. else inserts the graph + owner membership and returns `"created"`.

So concurrent adopts for the same user serialize — the count can't be stale by the time the insert runs. (The two inserts also become atomic, which `add_graph` wasn't.)

`adopt_graph` now:
- creates the graph row **first** (the atomic capped create), then rebuilds content — so a rejected/duplicate adopt writes **nothing** to Qdrant that would need cleaning up;
- maps `"at_cap"` → 402, and `"exists"` → an idempotent no-op (after confirming ownership) instead of a unique-constraint **500** on a concurrent double-click.

`PUT /boards` (direct board creation) is routed through the **same** primitive, so the free-tier cap can't be bypassed by creating boards directly instead of promoting local ones.

## How this addresses the /code-review of the first cut
The initial version applied content *before* creating the graph row; review flagged that a lost cap race would then orphan the already-written Qdrant content (a slow leak), that the pre-check re-counted via the heavy `list_graphs` join, that a concurrent same-UID adopt 500s, and a dead `or 0`. This version:
- **create-first** → no orphaned content on a rejected/duplicate adopt (and the redundant pre-check is gone);
- **`"exists"` outcome** → concurrent same-UID adopt is an idempotent no-op, not a 500;
- cap enforced on the **shared** create primitive (adopt *and* PUT), not bolted onto one endpoint;
- dropped the dead `or 0`.

## Scope notes
- Cross-store reality: graph metadata is Postgres, content is Qdrant — no single transaction spans both, hence "create graph row, then rebuild content."
- The original finding's "partial failure" half is largely already mitigated: `apply_batch`/`_dispatch_bucket` catches per-bucket errors and marks ops un-applied rather than throwing, so a content hiccup doesn't crash adopt or (with create-first) leave orphaned content.

## Tests (`test_boards_adopt_router.py`, fake-store unit)
- existing behaviors preserved (create + rebuild, 409 non-owner, owner idempotent no-op, cap 402, paid unlimited);
- **new:** losing the atomic cap check → 402, no graph row, and **no content applied** (no orphan), retry heals; a concurrent same-UID adopt (`"exists"`) → idempotent no-op, not a 500; `PUT /boards` enforces the same cap (402 at limit; succeeds under it).

**Testability caveat:** the advisory lock's actual concurrency behavior needs a real Postgres and isn't exercised by the fake-store unit suite — the unit tests cover the endpoints' delegation, outcome handling, and ordering; the lock SQL is verified by hand. A Postgres integration test for the serialization is a reasonable follow-up.

Backend `test_boards_*` suites pass (20); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
