### PR TITLE
fix(board): sync_meta cascade + mid-stream chat guard + mini-app single-frontend detection

### DIFF
--- a/webui/mini-app-runtime/main.tsx
+++ b/webui/mini-app-runtime/main.tsx
@@ -17,6 +17,7 @@ import { ErrorBoundary } from "./error-boundary"
 import { CompileErrorCard, RuntimeErrorCard } from "./error-display"
 import { handleHostMessage, setHostInitialState } from "./rpc"
 import { MINI_APP_SCOPE_NAMES, MINI_APP_SCOPE_VALUES } from "./scope"
+import { isSingleFrontend } from "./single-frontend"
 import "./runtime.css"
 // Tailwind v4's browser build JIT-compiles utility classes at runtime
 // by scanning the live DOM. Critical for mini-apps: the agent's JSX is
@@ -45,11 +46,15 @@ const HOST_ORIGIN =
   (typeof window !== "undefined" ? window.__APP_CONFIG__?.hostOrigin : undefined) ||
   import.meta.env.VITE_HOST_ORIGIN
 
-// Single-frontend: no configured host origin → the runtime is served same-origin
-// and loaded into an opaque-origin sandbox. We trust the parent by SOURCE
-// (origin-independent; a sandboxed iframe can only be embedded by its parent)
-// and reply with "*". Cross-origin mode keeps the strict origin check.
-const SINGLE_FRONTEND = !HOST_ORIGIN
+// Single-frontend: served same-origin and loaded into an opaque-origin sandbox.
+// Detected from the opaque origin ("null") rather than a possibly-mismatched
+// injected host origin (see single-frontend.ts). We trust the parent by SOURCE
+// (origin-independent; a sandboxed iframe can only be embedded by its parent) and
+// reply with "*". Cross-origin mode keeps the strict origin check.
+const SINGLE_FRONTEND = isSingleFrontend(
+  HOST_ORIGIN,
+  typeof window !== "undefined" ? window.origin : undefined,
+)
 const REPLY_TARGET = SINGLE_FRONTEND ? "*" : (HOST_ORIGIN as string)
 
 

--- a/webui/mini-app-runtime/single-frontend.test.ts
+++ b/webui/mini-app-runtime/single-frontend.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { isSingleFrontend } from "./single-frontend"
+
+
+describe("isSingleFrontend", () => {
+  it("is true for an opaque sandbox origin even when a host origin is injected", () => {
+    // The default container: docker-entrypoint injects a non-empty VITE_HOST_ORIGIN,
+    // but the single-frontend iframe is opaque ("null") → must stay single-frontend
+    // (the regression: the injected origin used to force strict-origin mode).
+    expect(isSingleFrontend("http://localhost:3000", "null")).toBe(true)
+  })
+
+  it("is false in cross-origin mode (real runtime origin + configured host origin)", () => {
+    expect(isSingleFrontend("https://host.example", "https://runtime.example")).toBe(false)
+  })
+
+  it("is true when no host origin is configured (same-origin dev)", () => {
+    expect(isSingleFrontend(undefined, "http://localhost:5173")).toBe(true)
+    expect(isSingleFrontend("", "http://localhost:5173")).toBe(true)
+  })
+
+  it("falls back to cross-origin when a host origin is set but no window origin is known", () => {
+    expect(isSingleFrontend("https://host.example", undefined)).toBe(false)
+  })
+})

--- a/webui/mini-app-runtime/single-frontend.ts
+++ b/webui/mini-app-runtime/single-frontend.ts
@@ -1,0 +1,17 @@
+/**
+ * Decide whether the mini-app runtime is in single-frontend mode (served
+ * same-origin by the host and loaded into an opaque-origin sandbox) vs.
+ * cross-origin mode.
+ *
+ * The host opens the single-frontend iframe WITHOUT `allow-same-origin`, so its
+ * document origin is opaque — `window.origin` serializes to the string "null".
+ * We detect that directly instead of trusting an injected `hostOrigin`:
+ * `docker-entrypoint.sh` defaults `VITE_HOST_ORIGIN` to a non-empty value even in
+ * single-frontend containers, which used to flip the runtime into strict-origin
+ * mode and break the handshake (every mini-app timed out). Falling back to "no
+ * host origin configured" preserves the dev/same-origin case and SSR/tests.
+ */
+export const isSingleFrontend = (
+  hostOrigin: string | undefined,
+  origin: string | undefined,
+): boolean => origin === "null" || !hostOrigin

--- a/webui/src/features/agent/components/chat-view.tsx
+++ b/webui/src/features/agent/components/chat-view.tsx
@@ -5,6 +5,7 @@ import { ChatProvider, useChat } from "../hooks/chat-context"
 import { useActiveChatId } from "../hooks/use-chat-messages"
 import { useLocalMessagesStore } from "../store/local-messages-store"
 import { cn } from "@/lib/utils"
+import { toast } from "sonner"
 import { useMemo } from "react"
 import type { Chat as ChatEntity } from "../types/chat"
 import { Button } from "@/components/ui/button"
@@ -174,6 +175,22 @@ const ChatBody = ({
   const selectLocalChat = useLocalMessagesStore(s => s.selectChat)
   const newLocalChat = useLocalMessagesStore(s => s.newChat)
   const localChats = useLocalMessagesStore(s => s.chats)
+  const localMessages = useLocalMessagesStore(s => s.messages)
+  // A local turn streams into the in-memory store and only `persist`s when done.
+  // Switching/starting a chat mid-stream clears those messages, so the turn is
+  // never written (and any nodes it created are orphaned) — block it while live.
+  // `streaming` clears in runAgent's `finally`; a turn that never settles would
+  // keep this true (bounded by the turn-cancellation follow-up).
+  const localStreaming = local && localMessages.some(m => m.streaming)
+
+
+  // Guard the local chat-switch handlers while a turn streams; surface why so the
+  // blocked click isn't a silent no-op.
+  const blockedByStream = (): boolean => {
+    if (!localStreaming) return false
+    toast.info("Wait for the response to finish before switching chats.")
+    return true
+  }
   // Backend chat list is disabled in local mode (empty userId → no fetch).
   const { data: backendChats = [] } = useListChats({ graphUid: initialBoardId, userId: local ? "" : userId })
   const navigate = useNavigate()
@@ -223,6 +240,7 @@ const ChatBody = ({
 
   const handleNewChat = () => {
     if (local) {
+      if (blockedByStream()) return // don't discard the in-flight turn
       newLocalChat()
       return
     }
@@ -241,6 +259,7 @@ const ChatBody = ({
 
   const handleSelectChat = (id: string) => {
     if (local) {
+      if (blockedByStream()) return // don't discard the in-flight turn
       void selectLocalChat(id)
       return
     }

--- a/webui/src/features/board/persist/local/board-registry.test.ts
+++ b/webui/src/features/board/persist/local/board-registry.test.ts
@@ -80,6 +80,22 @@ for (const { label, make } of engineCases) describe(`BoardRegistry (${label})`, 
   })
 
 
+  it("deleteBoard cascades the sync cursor (sync_meta), sparing other boards", async () => {
+    // A stale sync_meta left behind is a silent data-loss trap: re-hydrating the
+    // same board id later would treat fresh edits as already-acked.
+    const reg = new BoardRegistry({ engine })
+    const board = newLocalBoard("Doomed", 1000)
+    await reg.createBoard(board)
+    await engine.put("sync_meta", { boardId: board.id, syncedSeq: 42 })
+    await engine.put("sync_meta", { boardId: "other-board", syncedSeq: 7 })
+
+    await reg.deleteBoard(board.id)
+
+    expect(await engine.get("sync_meta", board.id)).toBeUndefined()
+    expect(await engine.get("sync_meta", "other-board")).toBeDefined() // spared
+  })
+
+
   it("setSyncEngine flips the stored engine and bumps updatedAt; no-op if absent", async () => {
     const reg = new BoardRegistry({ engine })
     const board = newLocalBoard("Promotable", 1000)

--- a/webui/src/features/board/persist/local/board-registry.ts
+++ b/webui/src/features/board/persist/local/board-registry.ts
@@ -4,8 +4,11 @@
  * Stores `BoardMeta` (the local board index, incl. local-only boards) and
  * `BoardView` (camera/selection, per device) via the `StorageEngine` port. Board
  * *content* lives in the snapshot/oplog stores driven by `BoardPersistence`;
- * `deleteBoard` cascades across metadata, view, content AND the board's chats +
- * messages in one transaction, so a removed board leaves no orphans.
+ * `deleteBoard` cascades those in one transaction — metadata, view, snapshot +
+ * oplog, chats + messages, uploaded documents + chunks, and the sync cursor
+ * (`sync_meta`). One known gap: per-widget `mini_app_state` (keyed by noteId, no
+ * by-board index) is not yet cascaded — a storage leak tracked as a follow-up,
+ * not data loss.
  *
  * Engine ownership: if no engine is injected the registry opens and owns one
  * (self-contained lifecycle via `init`/`close`); when the composition root
@@ -22,7 +25,7 @@ export type BoardRegistryOptions = { engine?: StorageEngine; dbName?: string }
 
 // Every store a board's data spans — the cascade-delete transaction covers all.
 const BOARD_COLLECTIONS: Collection[] = [
-  "boards", "views", "snapshots", "oplog", "chats", "chat_messages", "documents", "chunks",
+  "boards", "views", "snapshots", "oplog", "chats", "chat_messages", "documents", "chunks", "sync_meta",
 ]
 
 
@@ -139,6 +142,11 @@ export class BoardRegistry {
       await t.delete("views", id)
       await t.delete("snapshots", id)
       await t.delete("oplog", { lower: [id, 0], upper: [id, Number.MAX_SAFE_INTEGER] })
+      // Cascade the sync cursor. Leaving it behind is a silent data-loss trap: if
+      // the same board id is later re-hydrated (a synced board deleted locally then
+      // re-opened), a stale `syncedSeq` makes fresh low-seq edits look already-acked
+      // (`outbox.pending()` skips seq <= cursor) → they're never sent to the relay.
+      await t.delete("sync_meta", id)
       // Cascade the board's chats and their message transcripts.
       const chats = await t.list<{ id: string }>("chats", { index: "by-board", range: { lower: id, upper: id } })
       for (const chat of chats) {


### PR DESCRIPTION
Fourth remediation drop from the review of #154 — three independent Medium fixes, small enough to ship together. Branches off `offline-first-phase-a`.

## 1. `deleteBoard` cascades `sync_meta` (finding #5) — silent data loss
Board deletion cascaded most stores but left `sync_meta` (the per-board sync cursor) behind. The trap: a *synced* board deleted locally while it still exists server-side, then re-hydrated under the same id — the stale `syncedSeq` (say 50) survives, so fresh edits at seq 1..N are `≤ 50` and `outbox.pending()` (which returns `seq > syncedSeq`) **never sends them**. Silent, permanent loss of post-re-sync edits. Fix: add `sync_meta` to the cascade transaction.

## 2. Chat switch/new no longer discards an in-flight local turn (finding #7)
A local turn streams into the in-memory messages store and only `persist`s when done. `handleNewChat` / `handleSelectChat` weren't gated on streaming, so starting or selecting a chat mid-turn cleared those messages → the turn's final `persist` bailed (`!chatUid`) → the whole Q&A was never written, and any nodes it created were orphaned on the canvas. Fix: both local handlers no-op while a local turn is streaming — with a toast so the blocked click isn't a silent no-op.

## 3. Mini-app single-frontend detection (finding #9) — handshake dead in the default container
The host and the iframe runtime decided "single-frontend mode" from different signals: the host from an opaque origin, the runtime from `VITE_HOST_ORIGIN`. `docker-entrypoint.sh` defaults `VITE_HOST_ORIGIN` to a non-empty `localhost:3000` even in single-frontend containers, so the runtime flipped into strict-origin mode, the postMessage origins mismatched, and **every mini-app timed out on the handshake**. Fix: the runtime now detects single-frontend from its actual opaque sandbox origin (`window.origin === "null"`) via a small pure helper (`single-frontend.ts`), falling back to "no host origin configured" for dev/SSR.

## Scope note
Finding #5 also mentions `mini_app_state` leaking orphaned rows on delete. Cascading it needs a `by-board` index, which means adding `boardId` to the record (a write-path signature change across all callers) + a `DB_VERSION` bump + a migration for existing rows — too big for this batch. Deferred as a follow-up; it's a minor storage leak, not data loss. This PR fixes the data-loss half (`sync_meta`), and the `deleteBoard` docstring now names the gap explicitly.

## `/code-review` response
Ran `/code-review`; two findings, both addressed here:
- **mini_app_state still orphaned** — confirmed and deferred (above); the docstring no longer over-claims "no orphans".
- **guard was a silent no-op / could lock forever on a hung turn** — added the toast for feedback; documented that `streaming` clears in `runAgent`'s `finally`, and a never-settling turn is bounded by the turn-cancellation follow-up (the tracked "no AbortController on the local turn" item).

## Tests
- **new:** `deleteBoard` cascades `sync_meta` and spares other boards (run against every storage engine; verified to **fail on the pre-fix base**).
- **new:** `isSingleFrontend` unit tests — opaque origin + injected host origin → single-frontend (the regression), cross-origin, same-origin dev, and the SSR fallback.
- The chat-switch guard is a small UI-logic change with no existing `chat-view` test harness; covered by type-check + inspection.

`webui` type-check + eslint clean; board-registry, mini-app, mini-app-runtime, and local-messages suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
