### PR TITLE
feat(agent): confirm off-board tool calls (fetch/search/code) — FE-F3

### DIFF
--- a/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
+++ b/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { GlobeIcon, CodeInterpreterIcon } from "@/components/icons"
+import { GlobeIcon, CodeInterpreterIcon, BrowserSearchIcon } from "@/components/icons"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,6 +25,14 @@ const describe = (req: ToolConfirmRequest): { title: string; hint: string; previ
       Icon: GlobeIcon,
     }
   }
+  if (req.name === "web_search") {
+    return {
+      title: "Allow the assistant to search the web?",
+      hint: "It will send this query to a search provider. Content on your board could try to steer the query — check it says what you expect.",
+      preview: asString(req.args.query),
+      Icon: BrowserSearchIcon,
+    }
+  }
   return {
     title: "Allow the assistant to run this code?",
     hint: "It runs in a sandbox, but only allow code you understand — content on your board could try to make it exfiltrate data.",
@@ -35,8 +43,8 @@ const describe = (req: ToolConfirmRequest): { title: string; hint: string; previ
 
 
 /**
- * Confirmation for off-board agent tools (`fetch` / `code_interpreter`). Mounted
- * once on a local board; shows the exact URL/code and pauses the run until the
+ * Confirmation for off-board agent tools (`fetch` / `web_search` / `code_interpreter`).
+ * Mounted once on a local board; shows the exact URL/query/code and pauses the run until the
  * user allows or declines (see `useToolConfirm` + the agent loop's CONFIRM_TOOLS).
  * The preview is rendered as plain text — never HTML — so it can't inject markup.
  */

--- a/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
+++ b/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
@@ -1,0 +1,72 @@
+import { GlobeIcon, CodeInterpreterIcon } from "@/components/icons"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { useToolConfirm, type ToolConfirmRequest } from "@/features/agent/engine/tool-confirm-store"
+
+
+const asString = (value: unknown): string => (typeof value === "string" ? value : "")
+
+
+/** Human-facing copy + preview for a pending off-board tool request. */
+const describe = (req: ToolConfirmRequest): { title: string; hint: string; preview: string; Icon: typeof GlobeIcon } => {
+  if (req.name === "fetch") {
+    return {
+      title: "Allow the assistant to fetch a web page?",
+      hint: "It will send this request from your session. Only allow URLs you trust — a page or document on your board could try to smuggle your data into one.",
+      preview: asString(req.args.url),
+      Icon: GlobeIcon,
+    }
+  }
+  return {
+    title: "Allow the assistant to run this code?",
+    hint: "It runs in a sandbox, but only allow code you understand — content on your board could try to make it exfiltrate data.",
+    preview: asString(req.args.code),
+    Icon: CodeInterpreterIcon,
+  }
+}
+
+
+/**
+ * Confirmation for off-board agent tools (`fetch` / `code_interpreter`). Mounted
+ * once on a local board; shows the exact URL/code and pauses the run until the
+ * user allows or declines (see `useToolConfirm` + the agent loop's CONFIRM_TOOLS).
+ * The preview is rendered as plain text — never HTML — so it can't inject markup.
+ */
+export const ToolConfirmDialog = () => {
+  const pending = useToolConfirm((s) => s.pending)
+  const resolve = useToolConfirm((s) => s.resolve)
+  if (!pending) return null
+
+  const { title, hint, preview, Icon } = describe(pending)
+
+  return (
+    <AlertDialog open onOpenChange={(open) => !open && resolve(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <Icon className="size-4 shrink-0 text-primary" strokeWidth={2} />
+            {title}
+          </AlertDialogTitle>
+          <AlertDialogDescription>{hint}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {preview && (
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-muted/40 p-2 text-xs">
+            {preview}
+          </pre>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => resolve(false)}>Don't allow</AlertDialogCancel>
+          <AlertDialogAction onClick={() => resolve(true)}>Allow</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -197,6 +197,27 @@ describe("runAgent — off-board tool confirmation gate", () => {
     expect(ran.value).toBe(true)
   })
 
+  it("a throwing confirmer becomes a tool error, not a run abort", async () => {
+    const ran = { value: false }
+    const llm = new ScriptedLlm([toolTurn("fetch", { url: "https://x" }), { kind: "text", text: "recovered" }])
+    const events = await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("fetch", ran)],
+        llm,
+        ctx: {
+          store: freshStore("c"),
+          confirmTool: async () => {
+            throw new Error("boom")
+          },
+        },
+      }),
+    )
+    expect(ran.value).toBe(false)
+    expect(resultOf(events)).toMatchObject({ toolName: "fetch", result: { error: "boom" } })
+    expect(events.some((e) => e.type === "assistant_text" && e.text === "recovered")).toBe(true)
+  })
+
   it("does NOT prompt for non-gated tools (note tools auto-run)", async () => {
     const ran = { value: false }
     let prompted = false

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -129,6 +129,92 @@ describe("runAgent (scripted LLM)", () => {
 })
 
 
+describe("runAgent — off-board tool confirmation gate", () => {
+  const spyTool = (name: string, ran: { value: boolean }) =>
+    defineTool({
+      name,
+      description: name,
+      parameters: z.object({ url: z.string().optional(), code: z.string().optional() }),
+      run: async () => {
+        ran.value = true
+        return { ok: true }
+      },
+    })
+
+  const resultOf = (events: AgentEvent[]) => events.find((e) => e.type === "tool_result")
+
+  it("runs a gated tool when the user allows", async () => {
+    const ran = { value: false }
+    const seen: { name: string; args: Record<string, unknown> }[] = []
+    const llm = new ScriptedLlm([toolTurn("fetch", { url: "https://x" }), { kind: "text", text: "done" }])
+    const events = await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("fetch", ran)],
+        llm,
+        ctx: { store: freshStore("c"), confirmTool: async (r) => (seen.push(r), true) },
+      }),
+    )
+    expect(seen).toEqual([{ name: "fetch", args: { url: "https://x" } }])
+    expect(ran.value).toBe(true)
+    expect(resultOf(events)).toMatchObject({ result: { ok: true } })
+  })
+
+  it("declines a gated tool and feeds an error back to the model (tool not run)", async () => {
+    const ran = { value: false }
+    const llm = new ScriptedLlm([toolTurn("fetch", { url: "https://evil/x" }), { kind: "text", text: "ok without it" }])
+    const events = await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("fetch", ran)],
+        llm,
+        ctx: { store: freshStore("c"), confirmTool: async () => false },
+      }),
+    )
+    expect(ran.value).toBe(false)
+    expect(resultOf(events)).toMatchObject({ toolName: "fetch", result: { error: "declined by user" } })
+    expect(events.some((e) => e.type === "assistant_text" && e.text === "ok without it")).toBe(true)
+  })
+
+  it("gates code_interpreter too", async () => {
+    const ran = { value: false }
+    const llm = new ScriptedLlm([toolTurn("code_interpreter", { code: "fetch('x')" }), { kind: "text", text: "d" }])
+    await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("code_interpreter", ran)],
+        llm,
+        ctx: { store: freshStore("c"), confirmTool: async () => false },
+      }),
+    )
+    expect(ran.value).toBe(false)
+  })
+
+  it("runs a gated tool unprompted when no confirmTool is wired (headless/tests)", async () => {
+    const ran = { value: false }
+    const llm = new ScriptedLlm([toolTurn("fetch", { url: "https://x" }), { kind: "text", text: "d" }])
+    await drain(runAgent({ userMessage: "go", tools: [spyTool("fetch", ran)], llm, ctx: { store: freshStore("c") } }))
+    expect(ran.value).toBe(true)
+  })
+
+  it("does NOT prompt for non-gated tools (note tools auto-run)", async () => {
+    const ran = { value: false }
+    let prompted = false
+    const llm = new ScriptedLlm([toolTurn("noop", {}), { kind: "text", text: "d" }])
+    await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("noop", ran)],
+        llm,
+        ctx: { store: freshStore("c"), confirmTool: async () => ((prompted = true), true) },
+      }),
+    )
+    expect(prompted).toBe(false)
+    expect(ran.value).toBe(true)
+  })
+})
+
+
 describe("tools", () => {
   it("create_note then update_note changes title and body", async () => {
     const store = freshStore("c")

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -190,6 +190,20 @@ describe("runAgent — off-board tool confirmation gate", () => {
     expect(ran.value).toBe(false)
   })
 
+  it("gates web_search too", async () => {
+    const ran = { value: false }
+    const llm = new ScriptedLlm([toolTurn("web_search", { query: "secrets on the board" }), { kind: "text", text: "d" }])
+    await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spyTool("web_search", ran)],
+        llm,
+        ctx: { store: freshStore("c"), confirmTool: async () => false },
+      }),
+    )
+    expect(ran.value).toBe(false)
+  })
+
   it("runs a gated tool unprompted when no confirmTool is wired (headless/tests)", async () => {
     const ran = { value: false }
     const llm = new ScriptedLlm([toolTurn("fetch", { url: "https://x" }), { kind: "text", text: "d" }])

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -16,6 +16,17 @@ import { agentLog } from "./debug"
 export const DEFAULT_MAX_TURNS = 30
 
 
+/**
+ * Tools that reach OFF the board — network egress (`fetch`) and code execution
+ * (`code_interpreter`). When a confirmer is wired (see `ToolContext.confirmTool`)
+ * these require an explicit user OK before running, so a prompt-injected tool
+ * call (from a selected note / uploaded doc) can't silently exfiltrate board
+ * data or run attacker code. Note tools stay auto — they act on the user's own
+ * board and gating them would wreck the normal build flow.
+ */
+const CONFIRM_TOOLS = new Set(["fetch", "code_interpreter"])
+
+
 /** Convert a tool's Zod schema to a plain JSON Schema (dropping the `$schema` tag). */
 const toJsonSchema = (schema: z.ZodType): Record<string, unknown> => {
   const json = z.toJSONSchema(schema) as Record<string, unknown>
@@ -103,6 +114,14 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
       let output: unknown
       if (!tool) {
         output = { error: `unknown tool: ${call.name}` }
+      } else if (
+        CONFIRM_TOOLS.has(tool.name) &&
+        opts.ctx.confirmTool &&
+        !(await opts.ctx.confirmTool({ name: tool.name, args }))
+      ) {
+        // User declined this off-board action; feed a result back so the model
+        // can adapt (answer without it) rather than silently running it.
+        output = { error: "declined by user" }
       } else {
         try {
           output = await tool.run(args, opts.ctx)

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -114,17 +114,16 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
       let output: unknown
       if (!tool) {
         output = { error: `unknown tool: ${call.name}` }
-      } else if (
-        CONFIRM_TOOLS.has(tool.name) &&
-        opts.ctx.confirmTool &&
-        !(await opts.ctx.confirmTool({ name: tool.name, args }))
-      ) {
-        // User declined this off-board action; feed a result back so the model
-        // can adapt (answer without it) rather than silently running it.
-        output = { error: "declined by user" }
       } else {
+        // Confirm + run share one try/catch so neither a declined confirm nor a
+        // throwing confirmer/tool aborts the whole run — the error is fed back.
         try {
-          output = await tool.run(args, opts.ctx)
+          if (CONFIRM_TOOLS.has(tool.name) && opts.ctx.confirmTool && !(await opts.ctx.confirmTool({ name: tool.name, args }))) {
+            // Declined off-board action: feed a result back so the model adapts.
+            output = { error: "declined by user" }
+          } else {
+            output = await tool.run(args, opts.ctx)
+          }
         } catch (err) {
           output = { error: err instanceof Error ? err.message : String(err) }
         }

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -17,14 +17,14 @@ export const DEFAULT_MAX_TURNS = 30
 
 
 /**
- * Tools that reach OFF the board — network egress (`fetch`) and code execution
- * (`code_interpreter`). When a confirmer is wired (see `ToolContext.confirmTool`)
+ * Tools that reach OFF the board — network egress (`fetch`, `web_search`) and
+ * code execution (`code_interpreter`). When a confirmer is wired (see `ToolContext.confirmTool`)
  * these require an explicit user OK before running, so a prompt-injected tool
  * call (from a selected note / uploaded doc) can't silently exfiltrate board
  * data or run attacker code. Note tools stay auto — they act on the user's own
  * board and gating them would wreck the normal build flow.
  */
-const CONFIRM_TOOLS = new Set(["fetch", "code_interpreter"])
+const CONFIRM_TOOLS = new Set(["fetch", "code_interpreter", "web_search"])
 
 
 /** Convert a tool's Zod schema to a plain JSON Schema (dropping the `$schema` tag). */

--- a/webui/src/features/agent/engine/tool-confirm-store.test.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useToolConfirm } from "./tool-confirm-store"
+
+
+beforeEach(() => useToolConfirm.setState({ pending: null }))
+
+
+describe("useToolConfirm", () => {
+  it("parks a request as pending and resolves true on allow", async () => {
+    const p = useToolConfirm.getState().request({ name: "fetch", args: { url: "x" } })
+    expect(useToolConfirm.getState().pending?.name).toBe("fetch")
+    useToolConfirm.getState().resolve(true)
+    expect(await p).toBe(true)
+    expect(useToolConfirm.getState().pending).toBeNull()
+  })
+
+  it("resolves false on decline", async () => {
+    const p = useToolConfirm.getState().request({ name: "fetch", args: {} })
+    useToolConfirm.getState().resolve(false)
+    expect(await p).toBe(false)
+  })
+
+  it("auto-declines a second request while one is pending (no clobber of the first)", async () => {
+    const first = useToolConfirm.getState().request({ name: "fetch", args: { url: "a" } })
+    const second = useToolConfirm.getState().request({ name: "code_interpreter", args: {} })
+    expect(await second).toBe(false) // new request fails closed
+    expect(useToolConfirm.getState().pending?.name).toBe("fetch") // first prompt untouched
+    useToolConfirm.getState().resolve(true)
+    expect(await first).toBe(true)
+  })
+
+  it("resolve() is a no-op when nothing is pending", () => {
+    expect(() => useToolConfirm.getState().resolve(true)).not.toThrow()
+  })
+})

--- a/webui/src/features/agent/engine/tool-confirm-store.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.ts
@@ -5,7 +5,7 @@ import { create } from "zustand"
 export type ToolConfirmRequest = { name: string; args: Record<string, unknown> }
 
 
-type Pending = (ToolConfirmRequest & { id: number; resolve: (ok: boolean) => void }) | null
+type Pending = (ToolConfirmRequest & { resolve: (ok: boolean) => void }) | null
 
 
 type ToolConfirmState = {
@@ -17,9 +17,6 @@ type ToolConfirmState = {
 }
 
 
-let seq = 0
-
-
 /**
  * Bridges the agent loop's `confirmTool` gate (see agent-loop `CONFIRM_TOOLS`)
  * to a React confirm dialog: `request` parks a promise + the pending request so
@@ -28,15 +25,13 @@ let seq = 0
  */
 export const useToolConfirm = create<ToolConfirmState>((set, get) => ({
   pending: null,
-  request: (req) =>
-    new Promise<boolean>((resolve) => {
-      // Only one prompt at a time (the loop awaits each). If one is somehow
-      // already open, decline it before replacing so its promise never leaks.
-      const prev = get().pending
-      if (prev) prev.resolve(false)
-      seq += 1
-      set({ pending: { ...req, id: seq, resolve } })
-    }),
+  request: (req) => {
+    // One prompt at a time. If one is already open (a second/concurrent run),
+    // decline the NEW request rather than clobbering the prompt the user is
+    // deciding on — fail closed without disturbing the in-flight decision.
+    if (get().pending) return Promise.resolve(false)
+    return new Promise<boolean>((resolve) => set({ pending: { ...req, resolve } }))
+  },
   resolve: (ok) => {
     const p = get().pending
     if (!p) return

--- a/webui/src/features/agent/engine/tool-confirm-store.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand"
+
+
+/** A pending request to run an off-board tool, awaiting the user's decision. */
+export type ToolConfirmRequest = { name: string; args: Record<string, unknown> }
+
+
+type Pending = (ToolConfirmRequest & { id: number; resolve: (ok: boolean) => void }) | null
+
+
+type ToolConfirmState = {
+  pending: Pending
+  /** Ask the user to approve a tool run; resolves true (run) / false (decline). */
+  request: (req: ToolConfirmRequest) => Promise<boolean>
+  /** Settle the pending request (from the confirm UI). No-op if nothing pending. */
+  resolve: (ok: boolean) => void
+}
+
+
+let seq = 0
+
+
+/**
+ * Bridges the agent loop's `confirmTool` gate (see agent-loop `CONFIRM_TOOLS`)
+ * to a React confirm dialog: `request` parks a promise + the pending request so
+ * a mounted `<ToolConfirmDialog>` can render it, and `resolve` settles it. The
+ * loop `await`s the promise, so a run pauses on the prompt.
+ */
+export const useToolConfirm = create<ToolConfirmState>((set, get) => ({
+  pending: null,
+  request: (req) =>
+    new Promise<boolean>((resolve) => {
+      // Only one prompt at a time (the loop awaits each). If one is somehow
+      // already open, decline it before replacing so its promise never leaks.
+      const prev = get().pending
+      if (prev) prev.resolve(false)
+      seq += 1
+      set({ pending: { ...req, id: seq, resolve } })
+    }),
+  resolve: (ok) => {
+    const p = get().pending
+    if (!p) return
+    p.resolve(ok)
+    set({ pending: null })
+  },
+}))

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -68,6 +68,14 @@ export type ToolContext = {
   rootId?: string | null
   search?: LocalSearchIndex
   registry?: BoardRegistry
+  /**
+   * Optional gate for side-effecting / off-board tools (network egress, code
+   * execution). The loop calls it before running such a tool; resolve `true` to
+   * run, `false` to decline (the model gets a "declined" result and adapts).
+   * When absent (tests / headless), gated tools run unprompted — the gate is a
+   * UI concern wired only by the local submit path.
+   */
+  confirmTool?: (req: { name: string; args: Record<string, unknown> }) => Promise<boolean>
 }
 
 

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -19,6 +19,7 @@ import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
 import { rebuildDocIndex } from "@/features/board/search/use-doc-index"
 import { getLocalStores } from "@/features/local-stores"
 import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
+import { useToolConfirm } from "@/features/agent/engine/tool-confirm-store"
 import type { AgentEvent } from "@/features/agent/engine/types"
 import { planSystemPrompt } from "@/features/agent/prompts"
 import { useByokStore } from "@/features/agent/byok/byok-store"
@@ -194,7 +195,11 @@ export function useLocalSubmitPrompt(boardId: string) {
           ? `${system}\n\nThis board has uploaded documents. Use \`doc_search(query)\` — full-text over their contents — and for anything they could answer, call it FIRST, before answering from your own knowledge; ground the answer in the returned passages and cite each document by its exact title. (\`search_notes\` covers the board's own notes.)`
           : system
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
-        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search } })) {
+        // Gate off-board tools (network/code) behind a user confirmation, so a
+        // prompt-injected tool call can't silently exfiltrate or run code.
+        const confirmTool = (req: { name: string; args: Record<string, unknown> }) =>
+          useToolConfirm.getState().request(req)
+        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search, confirmTool } })) {
           // Streaming yields a cumulative assistant_text per token — replace the
           // previous snapshot in place instead of appending one event per token.
           const prev = events[events.length - 1]

--- a/webui/src/features/board/components/flow/floating-assistant/floating-assistant.tsx
+++ b/webui/src/features/board/components/flow/floating-assistant/floating-assistant.tsx
@@ -1,5 +1,4 @@
 import { ChatProvider } from "@/features/agent/hooks/chat-context"
-import { ToolConfirmDialog } from "@/features/agent/components/chat/tool-confirm-dialog"
 import { AnswerCard } from "./answer-card"
 import { FloatingIsland } from "./floating-island"
 
@@ -30,8 +29,6 @@ export const FloatingAssistant = ({
     <ChatProvider initialChatId={local ? boardId : currentChatId} local={local}>
       <FloatingIsland boardId={boardId} onOpenFullSheet={onOpenFullSheet} />
       <AnswerCard onOpenFullSheet={onOpenFullSheet} />
-      {/* Off-board tool (fetch/code) confirmation — only the local agent gates. */}
-      {local && <ToolConfirmDialog />}
     </ChatProvider>
   )
 }

--- a/webui/src/features/board/components/flow/floating-assistant/floating-assistant.tsx
+++ b/webui/src/features/board/components/flow/floating-assistant/floating-assistant.tsx
@@ -1,4 +1,5 @@
 import { ChatProvider } from "@/features/agent/hooks/chat-context"
+import { ToolConfirmDialog } from "@/features/agent/components/chat/tool-confirm-dialog"
 import { AnswerCard } from "./answer-card"
 import { FloatingIsland } from "./floating-island"
 
@@ -29,6 +30,8 @@ export const FloatingAssistant = ({
     <ChatProvider initialChatId={local ? boardId : currentChatId} local={local}>
       <FloatingIsland boardId={boardId} onOpenFullSheet={onOpenFullSheet} />
       <AnswerCard onOpenFullSheet={onOpenFullSheet} />
+      {/* Off-board tool (fetch/code) confirmation — only the local agent gates. */}
+      {local && <ToolConfirmDialog />}
     </ChatProvider>
   )
 }

--- a/webui/src/features/board/local/local-board-screen.tsx
+++ b/webui/src/features/board/local/local-board-screen.tsx
@@ -4,6 +4,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Button } from "@/components/ui/button"
 import { ArrowExpandIcon, SparklesIcon } from "@/components/icons"
 import { Chat } from "@/features/agent/components/chat-view"
+import { ToolConfirmDialog } from "@/features/agent/components/chat/tool-confirm-dialog"
 import { useLocalMessagesStore } from "@/features/agent/store/local-messages-store"
 import { HarnessCanvas } from "@/features/board/harness/canvas"
 import { LocalFolderBreadcrumb } from "@/features/board/local/local-folder-breadcrumb"
@@ -46,6 +47,11 @@ export function LocalBoardScreen() {
     <div className="absolute inset-0 h-full w-full overflow-hidden bg-background">
       <div className="relative h-full w-full">
         <HarnessCanvas local />
+
+        {/* Off-board tool (fetch/code) confirmation. Mounted at screen level
+            (not inside FloatingAssistant) so it stays present when the full
+            sheet is open — otherwise a gated call from the sheet hangs the run. */}
+        <ToolConfirmDialog />
 
         <LocalFolderBreadcrumb boardId={boardId} rootId={rootId ?? null} />
 


### PR DESCRIPTION
Closes **FE-F3** from the frontend security scan: the local agent dispatched every model-emitted tool call with no approval gate, so indirect prompt injection — a poisoned selected note, or an uploaded document surfaced via `doc_search` — could steer it into off-board calls (`fetch` / `web_search` / `code_interpreter`) that exfiltrate board data or run attacker code.

## Approach (chosen: gate all off-board tools)
- **`agent-loop.ts`** — `CONFIRM_TOOLS = {fetch, web_search, code_interpreter}` (all network egress + code execution). Before running one, `await ctx.confirmTool(...)` **inside the tool's `try/catch`**, so a declined call feeds `{ error: "declined by user" }` back (the model adapts, doesn't crash) and a *throwing* confirmer degrades to a tool error instead of aborting the run. When no confirmer is wired (tests/headless) it runs as before. **Note tools (`writeNote`/`editNote`/`link_notes`) stay auto** — they act on the user's own board; gating them would wreck the normal build flow.
- **`tool-confirm-store.ts`** (zustand) bridges the loop's `confirmTool` to a React dialog; the run pauses on the promise. One prompt at a time: a second concurrent request **fails closed** (auto-declines) rather than clobbering the decision the user is making on the first.
- **`ToolConfirmDialog`** shows the exact URL / query / code (rendered as **plain text, never HTML**) with **Allow / Don't allow**. Mounted at **`LocalBoardScreen`** level so it stays present when the full chat sheet is open — mounting it inside `FloatingAssistant` unmounted it with the island and hung any gated call made from the sheet.

## Why a confirmation, not a static allowlist
A general web-fetch tool can't have a fixed egress allowlist — users fetch arbitrary URLs legitimately. The confirmation *is* the egress control: the user sees the exact URL (and any board data smuggled into it) and approves.

## Verification
- `agent-loop.test.ts` — allow → tool runs; decline → blocked + error to model; `code_interpreter` and `web_search` gated; **throwing confirmer → tool error, run continues**; no-confirmer → runs unprompted; non-gated tools never prompt.
- `tool-confirm-store.test.ts` — request parks/resolves; **concurrent request auto-declines without clobbering the pending prompt**; `resolve()` is a no-op when nothing is pending.
- 361 agent tests pass; type-check + `make lint-ui` clean.

## Scope note
`web_search` is now gated too (all off-board tools prompt). FE-F4 (session token in JS-readable storage) is out of scope here — it needs the backend HttpOnly-cookie change.
