### PR TITLE
fix(board): correct local↔synced board state after enabling sync

### DIFF
--- a/webui/src/components/sidebar/app-sidebar.tsx
+++ b/webui/src/components/sidebar/app-sidebar.tsx
@@ -15,7 +15,7 @@ import { isSignedIn } from '@/lib/auth'
 import { useListBoards } from '@/features/board/api/list-boards'
 import { useLocalBoards } from '@/features/board/local/use-local-boards'
 import { useEnableSync } from '@/features/board/local/use-enable-sync'
-import { partitionBoards } from '@/features/board/screens/partition-boards'
+import { selectOnDeviceBoards } from '@/features/board/screens/partition-boards'
 import { ChatMenuItem, NewChatItem } from './chat'
 import { BoardItem, DashboardMenuItem, LocalBoardItem, NewLocalBoardItem } from './board'
 import { ChatsDialog } from './chats-dialog'
@@ -95,13 +95,13 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
   }
 
   // Only truly-local boards belong here; a promoted board appears in the SYNCED
-  // group (from the backend list) instead. Reuse the dashboard's partition so
-  // both surfaces dedupe identically: a board is dropped from LOCAL once it is
-  // either flagged kind=synced OR already present in the backend list (covers
-  // the window before the local kind flip lands — otherwise it shows twice).
+  // group (from the backend list) instead. Share the dashboard's on-device rule
+  // so both surfaces dedupe identically (see selectOnDeviceBoards): dropped once
+  // present in the backend list, and a synced replica shows only for its
+  // signed-in owner (never leaks to another session).
   const localOnly = useMemo(
-    () => partitionBoards(localBoards, boards).onDevice,
-    [localBoards, boards],
+    () => selectOnDeviceBoards(localBoards, boards, userId),
+    [localBoards, boards, userId],
   )
 
   const localBoardItems = useMemo(

--- a/webui/src/components/sidebar/app-sidebar.tsx
+++ b/webui/src/components/sidebar/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { isSignedIn } from '@/lib/auth'
 import { useListBoards } from '@/features/board/api/list-boards'
 import { useLocalBoards } from '@/features/board/local/use-local-boards'
 import { useEnableSync } from '@/features/board/local/use-enable-sync'
+import { partitionBoards } from '@/features/board/screens/partition-boards'
 import { ChatMenuItem, NewChatItem } from './chat'
 import { BoardItem, DashboardMenuItem, LocalBoardItem, NewLocalBoardItem } from './board'
 import { ChatsDialog } from './chats-dialog'
@@ -93,14 +94,14 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
     if (meta) openLocal(meta.id)
   }
 
-  // Only truly-local boards belong here; a promoted board flips to kind=synced
-  // and appears in the SYNCED group (from the backend list) instead.
+  // Only truly-local boards belong here; a promoted board appears in the SYNCED
+  // group (from the backend list) instead. Reuse the dashboard's partition so
+  // both surfaces dedupe identically: a board is dropped from LOCAL once it is
+  // either flagged kind=synced OR already present in the backend list (covers
+  // the window before the local kind flip lands — otherwise it shows twice).
   const localOnly = useMemo(
-    () =>
-      localBoards
-        .filter((b) => b.kind === "local-only")
-        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)),
-    [localBoards],
+    () => partitionBoards(localBoards, boards).onDevice,
+    [localBoards, boards],
   )
 
   const localBoardItems = useMemo(

--- a/webui/src/components/sidebar/sidebar-label.tsx
+++ b/webui/src/components/sidebar/sidebar-label.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useParams, useRouterState, useSearch, useNavigate } from "@tanstack/react-router"
 import { useListChats } from "@/features/agent/api/list-chats"
 import { useListBoards } from "@/features/board/api/list-boards"
+import { useLocalBoards } from "@/features/board/local/use-local-boards"
 import { useUpdateBoard } from "@/features/board/api/update-board"
 import { useUpdateChat } from "@/features/agent/api/update-chat"
 import { LabelEditor } from "./label-editor"
@@ -25,10 +26,12 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
   // route params
   const chatParams  = useParams({ from: "/chats/$id", shouldThrow: false })
   const boardParams = useParams({ from: "/boards/$id", shouldThrow: false })
+  const localBoardParams = useParams({ from: "/local/$boardId", shouldThrow: false })
   const sheetParams = useParams({ from: SheetUrl, shouldThrow: false })
   const subscriptionParams = useParams({ from: "/subscriptions/$id", shouldThrow: false })
   const chatId  = chatParams?.id
   const boardId = boardParams?.id
+  const localBoardId = localBoardParams?.boardId
   const boardRootId = useSearch({
     from: "/boards/$id",
     select: (s: { root_id?: string }) => s.root_id,
@@ -57,6 +60,7 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
   const active = useMemo(() => {
     if (sheetBoardId && sheetNoteId) return { view: "sheet" as const, id: sheetNoteId, boardId: sheetBoardId }
     if (boardId) return { view: "board" as const, id: boardId }
+    if (localBoardId) return { view: "local-board" as const, id: localBoardId }
     if (chatId)  return { view: "chat"  as const, id: chatId }
     if (subscriptionId) return { view: "subscriptions" as const, id: subscriptionId }
     if (isHome) return { view: "home" as const, id: undefined }
@@ -66,11 +70,14 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
     if (isSettings) return { view: "settings" as const, id: undefined }
     if (isSettingsBilling) return { view: "settings-billing" as const, id: undefined }
     return { view: "unknown" as const, id: undefined }
-  }, [boardId, chatId, subscriptionId, isNewChat, isDashboard, isSubscriptionsRoot, isHome, sheetBoardId, sheetNoteId, isSettings, isSettingsBilling])
+  }, [boardId, localBoardId, chatId, subscriptionId, isNewChat, isDashboard, isSubscriptionsRoot, isHome, sheetBoardId, sheetNoteId, isSettings, isSettingsBilling])
 
   // data
   const { data: chatList }  = useListChats({ graphUid: null, userId })
   const { data: boardList } = useListBoards(userId)
+  // Local boards live in IndexedDB (name is `title`, not the remote `label`);
+  // read the title for the header and rename in place on this device.
+  const { boards: localBoards, renameBoard: renameLocalBoard } = useLocalBoards()
   const { data: subscriptionList } = useListSubscriptions()
   const { updateBoard } = useUpdateBoard()
   const { updateChat }  = useUpdateChat()
@@ -101,6 +108,11 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
       setLabel(b?.label ?? boardLabel ?? "")
       return
     }
+    if (active.view === "local-board" && active.id) {
+      const b = localBoards.find((x) => x.id === active.id)
+      setLabel(b?.title ?? "")
+      return
+    }
     if (active.view === "chat" && active.id) {
       const c = chatList?.find((x) => x.uid === active.id)
       setLabel(c?.label ?? "")
@@ -129,13 +141,16 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
       return
     }
     setLabel("")
-  }, [active.view, active.id, boardList, boardLabel, chatList, subscriptionList, sheetNodeLabel, fetchedSheet])
+  }, [active.view, active.id, boardList, boardLabel, localBoards, chatList, subscriptionList, sheetNodeLabel, fetchedSheet])
 
   const handleSaveEdit = (newLabel: string) => {
     setLabel(newLabel)
     if (active.view === "board" && active.id) {
       setBoardLabel(newLabel)
       updateBoard({ boardId: active.id, graphData: { label: newLabel } })
+    }
+    if (active.view === "local-board" && active.id) {
+      void renameLocalBoard(active.id, newLabel)
     }
     if (active.view === "chat" && active.id) {
       updateChat({ chatId: active.id, chatData: { label: newLabel } })
@@ -271,6 +286,20 @@ export const SidebarLabel = ({ mobileContextOnly = false }: { mobileContextOnly?
             {label.trim() || UNTITLED_LABEL}
           </span>
         )}
+      </div>
+    )
+  }
+
+  // LOCAL BOARD — always editable (it's this device's own board; name is `title`)
+  if (active.view === "local-board" && active.id) {
+    return (
+      <div className={`${wrapClass} flex-1 min-w-0`}>
+        <LabelEditor
+          key={`local-board:${active.id}`}
+          initialLabel={label}
+          onSave={handleSaveEdit}
+          className='min-w-0'
+        />
       </div>
     )
   }

--- a/webui/src/features/board/local/use-local-boards.ts
+++ b/webui/src/features/board/local/use-local-boards.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { create } from "zustand"
 import type { BoardMeta } from "@/features/board/model"
 import { newLocalBoard } from "@/features/board/persist/local/board-registry"
 import type { BoardRegistry } from "@/features/board/persist/local/board-registry"
@@ -6,11 +7,26 @@ import { requestPersistentStorage } from "@/features/board/persist/local/persist
 import { getLocalStores } from "@/features/local-stores"
 
 
-/** List/create/delete local-only boards via the shared BoardRegistry — offline, no account. */
+/**
+ * Shared revision counter, bumped on every local-board mutation. Each
+ * `useLocalBoards` instance subscribes and re-reads on change, so a create /
+ * delete / rename from one mount (e.g. the top-left header) is reflected in the
+ * others (sidebar LOCAL list, dashboard cards) without a remount — the registry
+ * itself has no change notification, and the instances hold independent state.
+ */
+const useLocalBoardsRevision = create<{ rev: number; bump: () => void }>((set) => ({
+  rev: 0,
+  bump: () => set((s) => ({ rev: s.rev + 1 })),
+}))
+
+
+/** List/create/delete/rename local-only boards via the shared BoardRegistry — offline, no account. */
 export function useLocalBoards() {
   const [boards, setBoards] = useState<BoardMeta[]>([])
   const [ready, setReady] = useState(false)
   const registryRef = useRef<BoardRegistry | null>(null)
+  const rev = useLocalBoardsRevision((s) => s.rev)
+  const bump = useLocalBoardsRevision((s) => s.bump)
 
   useEffect(() => {
     void requestPersistentStorage()
@@ -32,6 +48,13 @@ export function useLocalBoards() {
     }
   }, [])
 
+  // Re-read whenever any instance mutates (shared revision bump). No-op on the
+  // first render (rev 0) — the registry isn't open yet; the mount effect loads.
+  useEffect(() => {
+    const registry = registryRef.current
+    if (registry) void registry.listBoards().then(setBoards)
+  }, [rev])
+
   const refresh = useCallback(async () => {
     const registry = registryRef.current
     if (registry) setBoards(await registry.listBoards())
@@ -43,10 +66,10 @@ export function useLocalBoards() {
       if (!registry) return null
       const meta = newLocalBoard(title.trim() || "Untitled board", Date.now())
       await registry.createBoard(meta)
-      await refresh()
+      bump()
       return meta
     },
-    [refresh],
+    [bump],
   )
 
   const deleteBoard = useCallback(
@@ -54,9 +77,9 @@ export function useLocalBoards() {
       const registry = registryRef.current
       if (!registry) return
       await registry.deleteBoard(id)
-      await refresh()
+      bump()
     },
-    [refresh],
+    [bump],
   )
 
   const renameBoard = useCallback(
@@ -64,9 +87,9 @@ export function useLocalBoards() {
       const registry = registryRef.current
       if (!registry) return
       await registry.renameBoard(id, title.trim() || "Untitled board")
-      await refresh()
+      bump()
     },
-    [refresh],
+    [bump],
   )
 
   return { boards, ready, createBoard, deleteBoard, renameBoard, refresh }

--- a/webui/src/features/board/screens/boards-home.tsx
+++ b/webui/src/features/board/screens/boards-home.tsx
@@ -34,8 +34,8 @@ export function BoardsHome({
   const { enableSync, pendingId } = useEnableSync()
 
   const { onDevice, synced } = useMemo(
-    () => partitionBoards(localBoards, syncedBoards),
-    [localBoards, syncedBoards],
+    () => partitionBoards(localBoards, syncedBoards, userId),
+    [localBoards, syncedBoards, userId],
   )
 
   const openLocal = (id: string): void => {

--- a/webui/src/features/board/screens/partition-boards.test.ts
+++ b/webui/src/features/board/screens/partition-boards.test.ts
@@ -43,6 +43,26 @@ describe("partitionBoards", () => {
     expect(syncedOut.map((b) => b.uid)).toEqual(["shared"])
   })
 
+  it("keeps a promoted (kind=synced) replica off-device even when signed out", () => {
+    // Logout clears the remote list; the leftover synced replica must NOT
+    // resurface under "on device" — it belongs to a user account.
+    const { onDevice } = partitionBoards(
+      [local("a", 1), local("promoted", 2, "synced")],
+      undefined,
+    )
+    expect(onDevice.map((b) => b.id)).toEqual(["a"])
+  })
+
+  it("drops a local-only board already in the synced list (kind flip not yet landed)", () => {
+    // Backend adopted the board but the local kind flip hasn't committed;
+    // the id/uid match must still keep it out of on-device (no transient double).
+    const { onDevice } = partitionBoards(
+      [local("pending", 1, "local-only")],
+      [synced("pending", "2024-01-01T00:00:00Z")],
+    )
+    expect(onDevice).toEqual([])
+  })
+
   it("sorts each group newest first (local by epoch ms, synced by ISO date)", () => {
     const { onDevice, synced: syncedOut } = partitionBoards(
       [local("old", 100), local("new", 200)],

--- a/webui/src/features/board/screens/partition-boards.test.ts
+++ b/webui/src/features/board/screens/partition-boards.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest"
 import type { BoardMeta } from "@/features/board/model"
 import type { BoardListItem } from "@/features/board/api/list-boards"
-import { partitionBoards } from "./partition-boards"
+import { partitionBoards, selectOnDeviceBoards } from "./partition-boards"
 
 
-const local = (id: string, createdAt: number, kind: BoardMeta["kind"] = "local-only"): BoardMeta => ({
+const USER = "user-1"
+const ROOT = "root" // the signed-out sentinel (see isSignedIn)
+
+
+const local = (
+  id: string,
+  createdAt: number,
+  kind: BoardMeta["kind"] = "local-only",
+  ownerId?: string,
+): BoardMeta => ({
   id,
   title: id,
   kind,
+  ownerId,
   visibility: "private",
   createdAt,
   updatedAt: createdAt,
@@ -25,10 +35,11 @@ const synced = (uid: string, createdAt: string): BoardListItem => ({
 
 
 describe("partitionBoards", () => {
-  it("puts every local board on-device when synced is undefined (signed out)", () => {
+  it("puts local-only boards on-device when synced is undefined (signed out)", () => {
     const { onDevice, synced: syncedOut } = partitionBoards(
       [local("a", 1), local("b", 2)],
       undefined,
+      ROOT,
     )
     expect(onDevice.map((b) => b.id)).toEqual(["b", "a"])
     expect(syncedOut).toEqual([])
@@ -36,43 +47,72 @@ describe("partitionBoards", () => {
 
   it("dedupes: a board in both lists shows only under synced (keyed by id)", () => {
     const { onDevice, synced: syncedOut } = partitionBoards(
-      [local("a", 1), local("shared", 2, "synced")],
+      [local("a", 1), local("shared", 2, "synced", USER)],
       [synced("shared", "2024-01-01T00:00:00Z")],
+      USER,
     )
     expect(onDevice.map((b) => b.id)).toEqual(["a"])
     expect(syncedOut.map((b) => b.uid)).toEqual(["shared"])
-  })
-
-  it("keeps a promoted (kind=synced) replica off-device even when signed out", () => {
-    // Logout clears the remote list; the leftover synced replica must NOT
-    // resurface under "on device" — it belongs to a user account.
-    const { onDevice } = partitionBoards(
-      [local("a", 1), local("promoted", 2, "synced")],
-      undefined,
-    )
-    expect(onDevice.map((b) => b.id)).toEqual(["a"])
-  })
-
-  it("drops a local-only board already in the synced list (kind flip not yet landed)", () => {
-    // Backend adopted the board but the local kind flip hasn't committed;
-    // the id/uid match must still keep it out of on-device (no transient double).
-    const { onDevice } = partitionBoards(
-      [local("pending", 1, "local-only")],
-      [synced("pending", "2024-01-01T00:00:00Z")],
-    )
-    expect(onDevice).toEqual([])
   })
 
   it("sorts each group newest first (local by epoch ms, synced by ISO date)", () => {
     const { onDevice, synced: syncedOut } = partitionBoards(
       [local("old", 100), local("new", 200)],
       [synced("s-old", "2023-01-01T00:00:00Z"), synced("s-new", "2025-01-01T00:00:00Z")],
+      USER,
     )
     expect(onDevice.map((b) => b.id)).toEqual(["new", "old"])
     expect(syncedOut.map((b) => b.uid)).toEqual(["s-new", "s-old"])
   })
 
   it("handles both empty", () => {
-    expect(partitionBoards([], [])).toEqual({ onDevice: [], synced: [] })
+    expect(partitionBoards([], [], ROOT)).toEqual({ onDevice: [], synced: [] })
+  })
+})
+
+
+describe("selectOnDeviceBoards", () => {
+  it("hides a promoted (kind=synced) replica when signed out — no cross-session leak", () => {
+    // Logout clears the remote list; the leftover synced replica belongs to a
+    // user account and must NOT resurface under "on device".
+    const onDevice = selectOnDeviceBoards(
+      [local("a", 1), local("promoted", 2, "synced", USER)],
+      undefined,
+      ROOT,
+    )
+    expect(onDevice.map((b) => b.id)).toEqual(["a"])
+  })
+
+  it("keeps the owner's synced replica reachable offline (remote list empty)", () => {
+    // Signed in but the backend list is empty/errored (offline): the owner's own
+    // promoted board must stay visible via its local replica, not vanish.
+    const onDevice = selectOnDeviceBoards(
+      [local("mine", 1, "synced", USER)],
+      undefined,
+      USER,
+    )
+    expect(onDevice.map((b) => b.id)).toEqual(["mine"])
+  })
+
+  it("hides a synced replica owned by a different account", () => {
+    // Same device, a different user signed in: a replica owned by someone else
+    // must not show, even though we're signed in.
+    const onDevice = selectOnDeviceBoards(
+      [local("theirs", 1, "synced", "user-2")],
+      undefined,
+      USER,
+    )
+    expect(onDevice).toEqual([])
+  })
+
+  it("drops a board already in the synced list (kind flip not yet landed)", () => {
+    // Backend adopted the board but the local kind flip hasn't committed; the
+    // id/uid match keeps it off-device so it never shows twice.
+    const onDevice = selectOnDeviceBoards(
+      [local("pending", 1, "local-only")],
+      [synced("pending", "2024-01-01T00:00:00Z")],
+      USER,
+    )
+    expect(onDevice).toEqual([])
   })
 })

--- a/webui/src/features/board/screens/partition-boards.ts
+++ b/webui/src/features/board/screens/partition-boards.ts
@@ -1,5 +1,6 @@
 import type { BoardMeta } from "@/features/board/model"
 import type { BoardListItem } from "@/features/board/api/list-boards"
+import { isSignedIn } from "@/lib/auth"
 
 
 export type PartitionedBoards = {
@@ -9,31 +10,51 @@ export type PartitionedBoards = {
 
 
 /**
- * Split the two board sources into the dashboard's groups, newest first.
+ * The local boards that belong under "On this device", newest first.
  *
- * A promoted board lives in BOTH the local registry (its replica, now flagged
- * `kind: "synced"` and owned by a user) and the backend list; it must render
- * once, under "Synced". "On this device" is therefore local-only boards whose
- * id is NOT in the synced list — two independent guards:
- *  - `kind === "local-only"` keeps a promoted replica out even when the synced
- *    list is empty (signed out, or a different account) — otherwise a board that
- *    belongs to a user account leaks into the logged-out local view.
- *  - the id/uid exclusion covers the window where the backend already adopted the
- *    board but the local `kind` flip hasn't landed yet (avoids a transient double).
+ * A board is dropped if its id is already in the backend `synced` list — it
+ * renders once, under "Synced" (this also covers the window right after promotion
+ * where the backend has adopted the board but the local `kind` flip hasn't landed,
+ * so it never shows twice). Of the rest:
+ *  - `local-only` boards always belong here (truly device-local, no account).
+ *  - a `synced` replica belongs here ONLY for its signed-in owner — the offline /
+ *    pre-refetch fallback that keeps a promoted board reachable without a
+ *    connection. It is hidden when signed out or under a different account, so a
+ *    board that belongs to a user account never leaks into another session.
+ *
+ * `synced` may be undefined (signed out / not yet loaded). `userId` is the auth
+ * sentinel — `"root"` when signed out (see `isSignedIn`).
+ */
+export const selectOnDeviceBoards = (
+  local: BoardMeta[],
+  synced: BoardListItem[] | undefined,
+  userId: string,
+): BoardMeta[] => {
+  const syncedIds = new Set((synced ?? []).map((b) => b.uid))
+  const signedIn = isSignedIn(userId)
+  return local
+    .filter((b) => {
+      if (syncedIds.has(b.id)) return false
+      if (b.kind === "local-only") return true
+      return signedIn && b.ownerId === userId
+    })
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+}
+
+
+/**
+ * Split the two board sources into the dashboard's groups, newest first.
+ * See `selectOnDeviceBoards` for the on-device membership rule.
  */
 export const partitionBoards = (
   local: BoardMeta[],
   synced: BoardListItem[] | undefined,
+  userId: string,
 ): PartitionedBoards => {
-  const syncedList = synced ?? []
-  const syncedIds = new Set(syncedList.map((b) => b.uid))
-  const onDevice = local
-    .filter((b) => b.kind === "local-only" && !syncedIds.has(b.id))
-    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
-  const sortedSynced = [...syncedList].sort(
+  const sortedSynced = [...(synced ?? [])].sort(
     (a, b) => syncedTime(b) - syncedTime(a),
   )
-  return { onDevice, synced: sortedSynced }
+  return { onDevice: selectOnDeviceBoards(local, synced, userId), synced: sortedSynced }
 }
 
 

--- a/webui/src/features/board/screens/partition-boards.ts
+++ b/webui/src/features/board/screens/partition-boards.ts
@@ -11,11 +11,15 @@ export type PartitionedBoards = {
 /**
  * Split the two board sources into the dashboard's groups, newest first.
  *
- * A promoted board lives in BOTH the local registry (its replica) and the
- * backend list; it must render once, under "Synced". So any local board whose
- * id appears in the synced list is dropped from "On this device" — the synced
- * list is authoritative for it. `synced` may be undefined (signed out / not yet
- * loaded), in which case every local board shows on-device.
+ * A promoted board lives in BOTH the local registry (its replica, now flagged
+ * `kind: "synced"` and owned by a user) and the backend list; it must render
+ * once, under "Synced". "On this device" is therefore local-only boards whose
+ * id is NOT in the synced list — two independent guards:
+ *  - `kind === "local-only"` keeps a promoted replica out even when the synced
+ *    list is empty (signed out, or a different account) — otherwise a board that
+ *    belongs to a user account leaks into the logged-out local view.
+ *  - the id/uid exclusion covers the window where the backend already adopted the
+ *    board but the local `kind` flip hasn't landed yet (avoids a transient double).
  */
 export const partitionBoards = (
   local: BoardMeta[],
@@ -24,7 +28,7 @@ export const partitionBoards = (
   const syncedList = synced ?? []
   const syncedIds = new Set(syncedList.map((b) => b.uid))
   const onDevice = local
-    .filter((b) => !syncedIds.has(b.id))
+    .filter((b) => b.kind === "local-only" && !syncedIds.has(b.id))
     .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
   const sortedSynced = [...syncedList].sort(
     (a, b) => syncedTime(b) - syncedTime(a),


### PR DESCRIPTION
Fixes three UI bugs that surface after **enabling sync** (promoting a local board to a synced/remote board).

## Root cause
Enabling sync promotes the board **in place**: `markSynced` flips the local IndexedDB record `kind: "local-only" → "synced"`, keeps the same id, and never deletes it. Three surfaces then disagreed on how to tell "this board is now remote", each using a different signal:

| Bug | Surface | Why |
|---|---|---|
| Board listed **twice** (local + synced) | `app-sidebar.tsx` | LOCAL group deduped only on the local `kind` flag — no id cross-check against the backend list — so the board lingered in LOCAL until the flip landed (and permanently if promote returned `ok:false` *after* the server already adopted). |
| Local board **name missing / can't rename** in the top-left header | `sidebar-label.tsx` | No route branch for `/local/$boardId` → `active.view === "unknown"` → `return null`. (Local name is `BoardMeta.title`; remote is `label`.) |
| Promoted board **leaks into the logged-out "on device" view** | `partition-boards.ts` | On-device was filtered by *live remote-list membership*. Logout empties the remote list, so the leftover `kind:"synced"` record — owned by a user account — resurfaced. |

## Fix — one consistent rule
**On-device / LOCAL = local boards that are `kind === "local-only"` AND not present in the remote list.** Two independent guards: the `kind` check keeps a promoted replica out even when the remote list is empty (logout / other account); the id∩uid check covers the window before the local flip commits (no transient double).

- `partition-boards.ts` — apply both predicates; the sidebar now reuses `partitionBoards(...).onDevice` so both surfaces dedupe identically.
- `sidebar-label.tsx` — add a `local-board` view: read `BoardMeta.title` for the header and rename in place via `renameBoard` (always editable — it's this device's own board).

## Verification
- `partition-boards.test.ts` — added cases for the logout leak (promoted replica stays off-device when signed out) and the pre-flip window (local-only board already in the synced list is dropped).
- 426 board + sidebar tests pass; type-check + `make lint-ui` clean.

## Not in scope
The promoted record lingering in IndexedDB after logout is a storage concern, not a display leak (it no longer renders anywhere for a non-owner). The deeper `enableSync` atomicity gap (server adopt succeeds but the local `kind` flip doesn't) no longer affects display, since the id-dedup handles it — left as a follow-up.
