### PR TITLE
fix(board): confirm local delete + sidebar one-click enable-sync

### DIFF
--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -196,16 +196,21 @@ export function LocalBoardItem({
           Local rows have no chat action, so this is the single trailing icon —
           the menu-button's built-in pr-8 reserves its space, keeping the title
           truncation correct. */}
+      {/* Not `disabled` while syncing: a disabled button fires no hover/title, so
+          the "Enabling sync…" tooltip would never show. Re-entry is instead guarded
+          at the source (useEnableSync), so a click mid-sync is a safe no-op. */}
       <SidebarMenuAction
         showOnHover
-        disabled={syncing}
         onClick={(e) => {
           e.stopPropagation()
           onEnableSync()
         }}
         title={syncing ? "Enabling sync…" : "Enable sync — back up + share this board"}
         aria-label="Enable sync"
-        className="text-muted-foreground/50 hover:text-secondary-foreground disabled:opacity-50"
+        className={cn(
+          "text-muted-foreground/50 hover:text-secondary-foreground",
+          syncing && "opacity-50",
+        )}
       >
         <CloudSyncIcon className={cn("size-4", syncing && "animate-pulse")} strokeWidth={2} />
       </SidebarMenuAction>

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -192,6 +192,24 @@ export function LocalBoardItem({
         </ContextMenuContent>
       </ContextMenu>
 
+      {/* Visible one-click promote-to-sync (also in the context menu above).
+          Local rows have no chat action, so this is the single trailing icon —
+          the menu-button's built-in pr-8 reserves its space, keeping the title
+          truncation correct. */}
+      <SidebarMenuAction
+        showOnHover
+        disabled={syncing}
+        onClick={(e) => {
+          e.stopPropagation()
+          onEnableSync()
+        }}
+        title={syncing ? "Enabling sync…" : "Enable sync — back up + share this board"}
+        aria-label="Enable sync"
+        className="text-muted-foreground/50 hover:text-secondary-foreground disabled:opacity-50"
+      >
+        <CloudSyncIcon className={cn("size-4", syncing && "animate-pulse")} strokeWidth={2} />
+      </SidebarMenuAction>
+
       <ConfirmDeleteBoardAlert
         open={isConfirmOpen}
         onOpenChange={setIsConfirmOpen}

--- a/webui/src/features/board/harness/sync/enable-sync.ts
+++ b/webui/src/features/board/harness/sync/enable-sync.ts
@@ -22,6 +22,7 @@ export type EnableSyncResult =
   | { ok: true; boardId: string }
   | { ok: false; reason: "signed-out" }
   | { ok: false; reason: "limited" }
+  | { ok: false; reason: "in-flight" }
   | { ok: false; reason: "error"; error: unknown }
 
 

--- a/webui/src/features/board/local/local-dashboard.tsx
+++ b/webui/src/features/board/local/local-dashboard.tsx
@@ -4,6 +4,7 @@ import { UNTITLED_LABEL } from "@/features/board/const"
 import type { BoardMeta } from "@/features/board/model"
 import { formatDateForUI } from "@/features/board/utils/datetime"
 import { BoardKindBadge } from "@/features/board/components/board-kind-badge"
+import { ConfirmDeleteBoardAlert } from "@/components/sidebar/confirm-delete-board"
 
 
 // Local-board card + "new" tile, rendered by the unified BoardsHome dashboard's
@@ -29,6 +30,7 @@ export function LocalBoardCard({
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(board.title)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
   const date = board.updatedAt ?? board.createdAt
   const dateString = date ? formatDateForUI(new Date(date).toISOString()) : null
 
@@ -51,11 +53,22 @@ export function LocalBoardCard({
         className="absolute right-2 top-2 z-10 hidden rounded-md bg-background/80 p-1 text-muted-foreground shadow-sm hover:text-destructive group-hover:block"
         onClick={(e) => {
           e.stopPropagation()
-          onDelete()
+          setConfirmingDelete(true)
         }}
       >
         <CancelPlainIcon className="size-3.5" strokeWidth={2} />
       </button>
+
+      {/* A local board lives only in IndexedDB — deletion is irreversible with no
+          server copy, so confirm first (parity with the sidebar's local delete). */}
+      <ConfirmDeleteBoardAlert
+        open={confirmingDelete}
+        onOpenChange={setConfirmingDelete}
+        onConfirm={() => {
+          onDelete()
+          setConfirmingDelete(false)
+        }}
+      />
 
       {onEnableSync && (
         <button

--- a/webui/src/features/board/local/local-dashboard.tsx
+++ b/webui/src/features/board/local/local-dashboard.tsx
@@ -42,6 +42,7 @@ export function LocalBoardCard({
   }
 
   return (
+    <>
     <div
       className="group relative w-64 h-60 flex flex-col justify-between gap-1 p-1 overflow-hidden rounded-xl bg-accent hover:bg-muted text-card-foreground border border-transparent hover:border-secondary-foreground hover:ring-2 hover:ring-secondary-foreground/50 shadow-md hover:shadow-lg transition-all cursor-pointer"
       onClick={() => !editing && onOpen()}
@@ -58,17 +59,6 @@ export function LocalBoardCard({
       >
         <CancelPlainIcon className="size-3.5" strokeWidth={2} />
       </button>
-
-      {/* A local board lives only in IndexedDB — deletion is irreversible with no
-          server copy, so confirm first (parity with the sidebar's local delete). */}
-      <ConfirmDeleteBoardAlert
-        open={confirmingDelete}
-        onOpenChange={setConfirmingDelete}
-        onConfirm={() => {
-          onDelete()
-          setConfirmingDelete(false)
-        }}
-      />
 
       {onEnableSync && (
         <button
@@ -134,6 +124,21 @@ export function LocalBoardCard({
         </div>
       </div>
     </div>
+
+    {/* Rendered OUTSIDE the clickable card: the dialog is Radix-portaled, but
+        React replays synthetic events along the component tree, so a Cancel/Delete
+        click inside a dialog nested in the card would bubble to onClick={onOpen}
+        (opening the board on Cancel; navigating into the deleted route on Delete).
+        A local board lives only in IndexedDB — deletion is irreversible, so confirm. */}
+    <ConfirmDeleteBoardAlert
+      open={confirmingDelete}
+      onOpenChange={setConfirmingDelete}
+      onConfirm={() => {
+        onDelete()
+        setConfirmingDelete(false)
+      }}
+    />
+    </>
   )
 }
 

--- a/webui/src/features/board/local/use-enable-sync.ts
+++ b/webui/src/features/board/local/use-enable-sync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
@@ -32,6 +32,11 @@ export function useEnableSync() {
   const queryClient = useQueryClient()
   const { data: syncedBoards = [] } = useListBoards(userId)
   const [pendingId, setPendingId] = useState<string | null>(null)
+  // Synchronous re-entry guard: `pendingId` is React state (updates next render),
+  // so two rapid clicks (e.g. the sidebar cloud icon + the context-menu item)
+  // could both pass the `syncing` gate and promote the same board twice. A ref
+  // flips immediately, before the first `await`, closing that window.
+  const inFlight = useRef<Set<string>>(new Set())
 
   const run = useCallback(
     async (boardId: string, label?: string): Promise<EnableSyncResult> => {
@@ -51,6 +56,8 @@ export function useEnableSync() {
         )
         return { ok: false, reason: "limited" }
       }
+      if (inFlight.current.has(boardId)) return { ok: false, reason: "in-flight" }
+      inFlight.current.add(boardId)
       setPendingId(boardId)
       const stores = await getLocalStores()
       const persistence = new BoardPersistence(boardId, { engine: stores.engine })
@@ -72,6 +79,7 @@ export function useEnableSync() {
         }
         return result
       } finally {
+        inFlight.current.delete(boardId)
         persistence.close()
         setPendingId(null)
       }


### PR DESCRIPTION
Two of the local/synced UI mismatches from testing (the chat-icon parity is deferred until chats go local-first — see dev-docs/offline-first-chat-migration.md).

## 1. Dashboard: local board delete now confirms
`LocalBoardCard`'s ✕ called `onDelete()` immediately. A local board lives only in IndexedDB, so that's irreversible data loss with no server copy. It now opens `ConfirmDeleteBoardAlert` first — parity with the sidebar's local delete.

## 2. Sidebar: one-click enable-sync
Promote-to-sync was only in the right-click context menu. `LocalBoardItem` now shows a `CloudSyncIcon` action on hover (mirrors the dashboard card's cloud button). It's the single trailing action on a local row, so the menu-button's built-in `pr-8` reserves its space and the title truncation stays correct. The context-menu entry stays too.

## Not included
- **Chat icon on local rows** — deferred. The remote chat icon opens a backend-only per-board chat dialog that local boards can't populate; making it work is the chat-to-local-first migration, tracked separately.
- **Delete on remote board cards** — remote delete intentionally stays in the sidebar; left as-is.

Type-check + lint clean.