### PR TITLE
feat(board): distinct status icons for enable-sync vs synced

### DIFF
--- a/webui/src/components/icons/index.ts
+++ b/webui/src/components/icons/index.ts
@@ -27,6 +27,8 @@ export {
   ClaudeBrandIcon,
   CloseIcon,
   ClockIcon,
+  CloudArrowUpIcon,
+  CloudCheckIcon,
   CloudSyncIcon,
   CodeBlockIcon,
   CodeFileIcon,

--- a/webui/src/components/icons/registry.ts
+++ b/webui/src/components/icons/registry.ts
@@ -20,6 +20,8 @@ import {
   CirclesFourIcon as CirclesFourGlyphIcon,
   CircuitryIcon,
   ClockIcon as ClockGlyphIcon,
+  CloudArrowUpIcon as PhosphorCloudArrowUpIcon,
+  CloudCheckIcon as PhosphorCloudCheckIcon,
   CloudFogIcon,
   CloudIcon,
   CloudRainIcon,
@@ -267,6 +269,8 @@ export const SlidesIcon = createPhosphorIcon(PresentationChartIcon)
 export const StopPresentationIcon = createPhosphorIcon(StopCircleIcon)
 export const WarningIcon = createPhosphorIcon(WarningCircleIcon)
 export const CloudSyncIcon = createPhosphorIcon(CloudIcon)
+export const CloudArrowUpIcon = createPhosphorIcon(PhosphorCloudArrowUpIcon)
+export const CloudCheckIcon = createPhosphorIcon(PhosphorCloudCheckIcon)
 export const WeatherCloudIcon = createPhosphorIcon(CloudIcon)
 export const WeatherCloudDrizzleIcon = createPhosphorIcon(CloudFogIcon)
 export const WeatherCloudRainIcon = createPhosphorIcon(CloudRainIcon)

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -7,7 +7,7 @@ import { UNTITLED_LABEL } from "@/features/board/const"
 import { useNavigate, useRouterState } from "@tanstack/react-router"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "../ui/context-menu"
 import { Collapsible, CollapsibleContent } from "../ui/collapsible"
-import { BoardContextIcon, ChatHistoryIcon, ChevronRightIcon, CloudSyncIcon, DashboardAddIcon, DeleteIcon, EditIcon } from "@/components/icons"
+import { BoardContextIcon, ChatHistoryIcon, ChevronRightIcon, CloudArrowUpIcon, DashboardAddIcon, DeleteIcon, EditIcon } from "@/components/icons"
 import { ChatsDialog } from "./chats-dialog"
 import { ConfirmDeleteBoardAlert } from "./confirm-delete-board"
 import { BoardTreeNode } from "./board-tree-node"
@@ -176,7 +176,7 @@ export function LocalBoardItem({
             disabled={syncing}
             className="text-xs flex flex-row items-center"
           >
-            <CloudSyncIcon className="mr-2 size-4" strokeWidth={2} />
+            <CloudArrowUpIcon className="mr-2 size-4" strokeWidth={2} />
             <span>{syncing ? "Enabling sync…" : "Enable sync"}</span>
           </ContextMenuItem>
           <ContextMenuItem
@@ -212,7 +212,7 @@ export function LocalBoardItem({
           syncing && "opacity-50",
         )}
       >
-        <CloudSyncIcon className={cn("size-4", syncing && "animate-pulse")} strokeWidth={2} />
+        <CloudArrowUpIcon className={cn("size-4", syncing && "animate-pulse")} strokeWidth={2} />
       </SidebarMenuAction>
 
       <ConfirmDeleteBoardAlert

--- a/webui/src/features/board/components/board-kind-badge.tsx
+++ b/webui/src/features/board/components/board-kind-badge.tsx
@@ -1,4 +1,4 @@
-import { CloudSyncIcon, MonitorIcon } from "@/components/icons"
+import { CloudCheckIcon, MonitorIcon } from "@/components/icons"
 import type { BoardKind } from "@/features/board/model"
 
 
@@ -20,7 +20,7 @@ export function BoardKindBadge({ kind }: { kind: BoardKind }) {
       title={synced ? "Synced — backed up and shareable" : "On this device only"}
     >
       {synced ? (
-        <CloudSyncIcon className="size-3 shrink-0" strokeWidth={2} />
+        <CloudCheckIcon className="size-3 shrink-0" strokeWidth={2} />
       ) : (
         <MonitorIcon className="size-3 shrink-0" strokeWidth={2} />
       )}

--- a/webui/src/features/board/local/local-dashboard.tsx
+++ b/webui/src/features/board/local/local-dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { AddIcon, CancelPlainIcon, CloudSyncIcon } from "@/components/icons"
+import { AddIcon, CancelPlainIcon, CloudArrowUpIcon } from "@/components/icons"
 import { UNTITLED_LABEL } from "@/features/board/const"
 import type { BoardMeta } from "@/features/board/model"
 import { formatDateForUI } from "@/features/board/utils/datetime"
@@ -72,7 +72,7 @@ export function LocalBoardCard({
             onEnableSync()
           }}
         >
-          <CloudSyncIcon className="size-3.5" strokeWidth={2} />
+          <CloudArrowUpIcon className="size-3.5" strokeWidth={2} />
           {syncing ? "Syncing…" : "Enable sync"}
         </button>
       )}


### PR DESCRIPTION
`CloudSyncIcon` was doing double duty — the promote-to-sync affordance **and** the synced badge — so the two states looked identical. Split them:

- **Enable-sync (to-sync) → `CloudArrowUpIcon`** — sidebar hover action + context-menu item (`board.tsx`), and the dashboard local card's cloud button (`local-dashboard.tsx`).
- **Synced status → `CloudCheckIcon`** — `BoardKindBadge`, the single source for the synced badge on dashboard cards and in-board.

Registered both new icons in the icon registry (Phosphor imports aliased to avoid clashing with the local export names). `CloudSyncIcon` stays in the registry as an unused catalog entry.

Type-check + lint clean.