### PR TITLE
docs(repo): architecture/features/roadmap guide + domain-split CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,31 +5,36 @@
 - One commit should represent one logical change.
 
 ## Repo Map
-- `backend/`: API, assistant agents, prompts, model/service configs.
-- `webui/`: frontend app (routes, features, components, stores, styles).
-- `build/`: generated/build artifacts.
+- `backend/`: FastAPI service (package `topix`) — API, assistant agents, prompts, model/service configs.
+- `webui/`: frontend SPA — routes, features (`agent/` + `board/`), components, stores, styles.
+- `build/`: Docker Compose + `schema.sql`.
+- `docs/`: architecture, features, roadmap (see Docs map below).
+- Note: `@canvas-harness/*` is an npm **dependency**, not in-tree source.
+
+## Domain conventions
+Conventions live with the code they govern (loaded on demand when you work in that tree):
+- Frontend code style + FE orientation → `webui/CLAUDE.md`
+- Python conventions + backend orientation → `backend/CLAUDE.md`
+
+## Docs map (read on demand)
+- Code structure & key invariants → `docs/architecture.md`
+- What the product does, feature by feature → `docs/features.md`
+- In-flight work & known follow-ups → `docs/roadmap.md`
 
 ## Core Features
 - `webui` has two core domains:
-  - `agent/`: chat input flow, streaming lifecycle, tool-call rendering, assistant UX.
+  - `agent/`: chat input flow, streaming lifecycle, tool-call rendering, assistant UX. Two runtimes (browser engine + legacy server path).
   - `board/`: whiteboard workspace for visual note organization. Rendered by canvas-harness.
 - `board` lives under `webui/src/features/board/harness/`:
   - Mount: `harness/canvas/harness-canvas.tsx` — wires the lib `<Canvas>` to Dim0 state.
   - Convert layer (Dim0 Note/Link ↔ harness Node/Edge): `harness/convert/`.
   - Custom node-type views: `harness/node-types/`.
-  - Collab persistence: `harness/canvas/use-ws-collab.ts` ⇄ `backend/topix/collab/apply_ops.py`.
+  - Collab: `harness/sync/board-sync.ts` (v2 offline-first) / `harness/canvas/use-ws-collab.ts` (legacy) ⇄ `backend/topix/collab/`.
 
 ## Tech Stack
 - Frontend: React + TypeScript, Vite, Tailwind v4, Tanstack Router, Zustand, Phosphor icons.
 - Canvas engine: in-house `@canvas-harness/core` + `@canvas-harness/react` npm packages.
-- Backend: FastAPI (Python), Pydantic, Postgres, WebSocket collab.
-
-## Frontend Code Style
-- Use TypeScript for frontend code (`.ts` / `.tsx`), not plain JavaScript.
-- Do not use semicolons.
-- Do not use `export default` for React/components; use named exports.
-- Do not use `any`; prefer explicit types, `unknown`, generics, or narrow unions.
-- Use 2 blank lines between top-level declarations; use 1 blank line inside blocks.
+- Backend: FastAPI (Python), Pydantic, Postgres, Qdrant, Redis, WebSocket collab.
 
 ## Docstrings
 - Add a short, comprehensible docstring for new or modified functions, methods, and classes.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,17 @@
+# backend — Python conventions
+
+Applies to `backend/**` (package `topix`). Repo-wide rules (commits) are in the root `CLAUDE.md`; architecture is in `docs/architecture.md`.
+
+## Conventions
+
+- Python ≥ 3.13, managed with `uv`. FastAPI + Pydantic v2, asyncpg.
+- Lint/format: ruff + black (line length 150). Run ruff before pushing.
+- Add a concise docstring to new/modified functions, methods, and classes (intent + key inputs/outputs, 1–3 lines).
+- Tests: `pytest`; unit tests under `backend/test/unit/` (no live DBs). `make test-backend` is unit-only — integration needs live Postgres/Qdrant/Redis.
+
+## Orientation (detail in `docs/architecture.md`)
+
+- **Cross-store split:** Postgres = metadata + durable logs; Qdrant = ALL graph content (one collection, `type` is a payload field); Redis = tickets / seq / quotas. **No transaction spans Postgres and Qdrant.**
+- **Collab is the only edit path:** human WS ops and the in-process agent (`collab/agent_bridge.py`) both allocate a seq from the oplog, apply to `GraphStore`, and broadcast a `peer-op`. Seq authority is the oplog, not `room.seq`.
+- Two agent execution models coexist: the server-side OpenAI-Agents agent (`agents/`) and the thin `/ai/*` proxies for the browser engine (`api/router/ai.py`).
+- Models resolve via `config/catalog.py` over `backend/topix/models.yml` (one YAML entry per model; first route whose provider key is present wins). Billing off → plan resolves to `plus`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,67 @@
+# Dim0 — Architecture
+
+How the codebase fits together — the non-obvious wiring and invariants, not a file listing (you can `ls`). For what the product does see [`features.md`](./features.md); for in-flight work see [`roadmap.md`](./roadmap.md). Read-on-demand reference — verify against code before relying on a detail.
+
+## Product in one line
+
+Dim0 ("The Thinking Canvas") is a self-hostable infinite real-time canvas where notes, mini-apps, code sandboxes, and documents live as nodes, and a board-aware AI agent reads the canvas and writes results back as editable nodes.
+
+## Repo layout
+
+- `backend/` — FastAPI service. Package name is **`topix`** (the former product name; still the module path, DB name, and Docker command).
+- `webui/` — React 19 + TypeScript SPA. Two core domains: `features/agent/` (chat/agent) and `features/board/` (canvas).
+- `build/` — Docker Compose, `schema.sql`, published-image compose.
+- `docs/`, `scripts/`, `Makefile`, `VERSION` (single semver synced by `scripts/sync_version.py`).
+- `@canvas-harness/{core,react,sync-broadcast}` is an **npm dependency** (maintained separately), **not in-tree source**.
+
+## Two mental models to hold
+
+### 1. Two agent execution paths (mid-cutover)
+
+The same chat UI drives one of two runtimes, chosen by `local` on ChatContext (`local = !canCollab`):
+
+- **Server-side agent (legacy, retires in "G5"):** `POST /chats/{id}/messages` → `AssistantManager`/`Plan` on the OpenAI-Agents SDK, runs in-process on OUR keys, writes to boards via `AgentBoardBridge`. Entries `backend/topix/agents/run.py`, `agents/assistant/manager.py`.
+- **Browser engine (current, BYOK-or-managed):** the tool-calling loop runs in the browser (`webui/src/features/agent/engine/agent-loop.ts`) and mutates the live canvas store directly. External capabilities go through thin metered proxies `/ai/llm[/stream]`, `/ai/search`, `/ai/code`, `/ai/fetch`, `/ai/parse` (`backend/topix/api/router/ai.py`).
+
+Both coexist today, but the direction is one runtime: **everything moves to the browser engine and the server-side agent is retired entirely** (the backend keeps only the `/ai/*` proxies). See roadmap "North star".
+
+### 2. Two persistence planes (backend REST vs offline-first)
+
+- **Backend/REST plane:** full Dim0 `Note`/`Link` domain model, round-tripped to canvas-harness `Node`/`Edge` through `webui/src/features/board/harness/convert/`.
+- **Offline-first plane:** the harness scene *is* the model — geometry/content/style are native harness fields, Dim0 domain fields ride in `node.data`; persistence is identity (no convert layer). `webui/src/features/board/model/`.
+
+Don't conflate them.
+
+## Backend
+
+- **Composition root** `backend/topix/api/app.py` — `create_app`/`lifespan` wire ONE shared Postgres pool (per-store pools used to exhaust PG under burst), all stores, the collab `RoomRegistry` (single-worker v1), and `AgentBoardBridge`. `apply_schema` runs idempotently every boot (additive migrations, no manual step). OpenAPI docs are stage-gated to non-prod. CORS is `*` + credentials (worth flagging).
+- **Cross-store split (load-bearing):**
+  - **Postgres** = relational metadata + durable logs: `graphs` (= boards), `graph_user` (membership/roles), chats, users, billing, share links, `board_oplog`, `note_revisions`, `mini_app_state`. Schema: `build/schema.sql`.
+  - **Qdrant** = ALL graph content in one collection (`topix`): notes, links, documents, chunks, chat messages, subscriptions — `type` is a payload field, not separate collections. `backend/topix/store/qdrant/store.py`.
+  - **Redis** = ephemeral: WS tickets, the per-board `seq` counter, rate-limit/quota windows.
+  - **No transaction spans Postgres + Qdrant.** e.g. adopt creates the PG graph row and separately writes Qdrant content; partial failures can diverge. Chunk cleanup on note delete is fire-and-forget.
+- **Collab engine** (`backend/topix/collab/`; WS handler in `api/router/collab.py`). Invariant: **collab is the only edit path** — every mutation (human WS op or in-process agent) flows through allocate-seq → apply-to-`GraphStore` → broadcast `peer-op`.
+  - Seq authority is the **oplog** (`store/collab_oplog.py`: Redis `INCR` seeded from PG `MAX(seq)`), **not** `room.seq` (a warm cache). Survives restart, so client `serverSeq` ordering holds.
+  - WS auth uses a single-use Redis ticket (a WS upgrade can't carry a bearer). Welcome modes by `since_seq`: snapshot / catch-up / live. Reconnecting clients replay their outbox; the relay **dedups by `batch.id`** and re-acks at the original seq.
+  - `apply_ops.py` persists `node.*`/`edge.*`; `group.*`/`frame.reorder` are relayed to peers but NOT persisted. Wire colors are theme-adapted and ignored — canonical colors come from `data._storedColors`.
+  - `agent_bridge.py`: the server agent appears as room client "agent" (`is_system`) without holding a slot; no-ops the broadcast when no room is open (next opener gets it via snapshot).
+- **Model catalog** `backend/topix/config/catalog.py` over `backend/topix/models.yml`: providers + ordered routes per model; resolution picks the first route whose provider key is present (`available_llms` / `resolve_code`). Adding a model = one YAML entry. `backend/topix/services.yml` does the same for non-LLM services. (`llm_models.yml` is dead — see roadmap.)
+- **Metering / tiering** `api/utils/rate_limit/`: `enforce_rate_limit` resolves plan → minute/day/billing-cycle quota windows. When billing is OFF (self-host), the plan resolves to `plus` — everything unlocked.
+- **Mini-app validation** `backend/topix/mini_app/compile.py`: agent JSX is transpile-validated via a sucrase subprocess, **never evaluated server-side** (evaluating would expose Node globals — an RCE surface).
+
+## Frontend
+
+- **Shell / routing** `webui/src/routes/index.ts` (one file, TanStack code-based). **Local-first "open front door":** `/`, `/local`, `/local/$boardId`, `/share/$token` are intentionally UNGUARDED and make zero backend calls when signed out. Signed-out sentinel is `userId === "root"` (non-empty) — gate on `isSignedIn()`, never `!!userId`. Board surface routes (`/boards/$id/sheets/$noteId`, `/mini-apps/$noteId`, …) are children of `/boards/$id` with `component: () => null` so the board stays mounted while a surface opens.
+- **Board harness** `features/board/harness/canvas/harness-canvas.tsx` — one canvas-harness store per board, created once and re-hydrated by scope. Behavior turns on three axes: `local` (device vs backend), `syncEngine` (`legacy`|`v2`, synced boards only), `rootId` (which folder layer is projected). `_storedColors` is the color source of truth across convert + both collab clients.
+- **Offline-first sync** `features/board/harness/sync/board-sync.ts` (v2 coordinator) + `persist/local/` (IndexedDB `dim0` DB). The outbox *is* the oplog tail past a `syncedSeq` cursor. Rebase LWW: undo unacked local batches → apply remote → replay local. `deleteBoard` cascades its stores incl. `sync_meta` (a stale cursor is a silent edit-loss trap). Legacy `use-ws-collab.ts` still serves untouched synced boards.
+- **Agent → canvas** `features/board/harness/agent/`: agent tool outputs land as `origin:"remote"` batches (bypass the undo stack + debounced save, since the server already has them). Human edits are `origin:"local"`/`"history"`.
+- **Metering (client):** one `X-Run-Id` is minted per user message (`use-local-submit-prompt.ts`) and threaded through every managed `/ai/*` call, so a whole multi-tool run meters as one unit; the server charges once per run id.
+- **BYOK vs managed:** LLM keys go **direct to the provider** from the browser (never our servers); search/code/parse keys are **relayed per-request** as `X-Provider-Key` (used, not stored). Keys live in `localStorage` (`features/agent/byok/byok-store.ts`).
+
+## Build targets
+
+1. Web bundle + PWA (`webui/vite.config.ts` — icon code-splitting, offline SPA fallback).
+2. Standalone mini-app runtime inlined to one HTML (`webui/vite.mini-app.config.ts`, `webui/mini-app-runtime/`) — sucrase-compiled agent JSX in a sandboxed iframe (single-frontend opaque-origin by default; cross-origin via `VITE_MINI_APP_ORIGIN`).
+3. Tauri desktop (`webui/src-tauri/`, early — version pinned `0.1.0`).
+
+Self-host via Docker Compose: `make up` (from source) or `make pull && make run` (published images `winlp4ever/dim0-{backend,webui}`). Needs at least one LLM provider key (`OPENAI_API_KEY` or `OPENROUTER_API_KEY`); `LINKUP_API_KEY` powers web search (see `.env.sample`).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,39 @@
+# Dim0 — Features
+
+What the product does, one entry per feature, with the code entry point. Wiring/invariants are in [`architecture.md`](./architecture.md).
+
+## Infinite canvas (board)
+
+The core surface: an infinite, zoomable whiteboard of typed nodes rendered by the in-house `@canvas-harness` engine. Node types beyond notes: **folder** (nested boards — double-click navigates into a sub-layer via `root_id`), **sheet** (long-form TipTap docs), **code-sandbox**, **mini-app**, **document**, and legacy **widget**. Rich surfaces open in a modal host with their own URL. Entry: `webui/src/features/board/harness/`.
+
+## Board-aware AI agent
+
+A chat agent that reads the current board (and selection) and writes results back as editable nodes/links. Multi-step tool use: create/edit/link notes, web search, fetch a URL, run code, search memory, generate mini-apps, mindmap/diagram/summarize/quiz. Two runtimes (see architecture): the browser engine (current) and the server-side OpenAI-Agents agent (legacy). Entries: `webui/src/features/agent/engine/agent-loop.ts`, `backend/topix/agents/assistant/`.
+
+## Real-time collaboration & sharing
+
+Multiplayer boards over WebSocket with live cursors/presence; server-sequenced last-writer-wins. Share links (`member`/`viewer`, upgrade-only, reusable until revoked) with a pre-auth preview landing. Entries: `backend/topix/api/router/collab.py`, `backend/topix/sharing/`, `webui/src/features/board/harness/sync/`.
+
+## Offline-first / local boards
+
+Boards work with no account, persist to IndexedDB, and are fully usable offline (`/local`). "Enable sync" promotes a local board to a synced one **in place** (same id) via `POST /boards/{id}:adopt`, without losing edits made during promotion. Entries: `webui/src/features/board/persist/local/`, `harness/sync/enable-sync.ts`.
+
+## Mini-apps
+
+The agent authors real interactive React (JSX) that runs as a node: sucrase-compiled and mounted in a **sandboxed iframe**, with a minimal `postMessage` RPC (`initialState`/`saveState`/`toast`). Security is the iframe sandbox + origin split, not the compiler. Entries: `webui/mini-app-runtime/` (iframe), `webui/src/features/mini-app/` (host), `backend/topix/mini_app/compile.py` (validation).
+
+## Document Q&A
+
+Upload a PDF, ask grounded questions. OCR'd online (Mistral via `/ai/parse`), then chunked + indexed **offline** (per-board Orama BM25, no vector store), retrieved by a `doc_search` tool with per-answer citations. Entries: `webui/src/features/agent/engine/doc-{parse,chunk,search}.ts`, `features/board/search/doc-index.ts`.
+
+## Multi-model, BYOK-or-managed
+
+Bring your own key (OpenAI, or OpenRouter → Claude/Gemini/etc.) or use managed models on our keys with per-plan tiers and `auto` routing. Each capability (LLM/search/code/fetch/parse) resolves independently to BYOK, managed, or off. Entries: `webui/src/features/agent/engine/services/`, `backend/topix/api/router/ai.py`.
+
+## Built-in widgets, newsfeed, code sandbox
+
+Non-agent widgets (weather, stock/trading charts). A newsletter/subscription "newsfeed" feature (topic tracking) separate from boards. Daytona-backed code execution (`python`/`javascript`, network-blocked, ephemeral). Entries: `webui/src/features/widgets/`, `newsfeed/`, `backend/topix/agents/assistant/code.py`.
+
+## Accounts, billing, self-host
+
+Email + Google sign-in, email verification, password reset. Three tiers `free | basic | plus` (JWT `plan` claim), Stripe-backed, flag-gated (`BILLING_ENABLED`, default off → self-host unlocks `plus`). MIT-licensed, self-hostable via Docker (needs at least one LLM provider key; see `.env.sample`). Entries: `webui/src/features/signin/`, `user-settings/`, `backend/topix/api/router/{users,billing,subscriptions}.py`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,40 @@
+# Dim0 — Roadmap & known follow-ups
+
+In-flight work, phased plans, and durable engineering follow-ups. Sourced from code markers, recent PR reviews, and design drafts — this **drifts**; verify against the codebase. Terminology is in [`architecture.md`](./architecture.md).
+
+## In-flight cutovers / migrations
+
+**North star — one agent runtime, in the browser.** The agent is migrating *entirely* to the client-side (local) engine; the server-side OpenAI-Agents runtime is being retired. End state: every chat runs the in-browser tool-calling loop against BYOK-or-managed models, and the backend keeps only the thin metered `/ai/*` proxies — no in-process agent, no `AssistantManager`/`Plan`, no server-side board writes via `AgentBoardBridge`. This is the single largest planned change in the agent domain.
+
+- **Retire the backend agent runtime ("G5"):** the major step toward the north star — delete the server-side agent path (`POST /chats/{id}/messages`, `backend/topix/agents/` incl. `agents/assistant/`) and the browser code that drives it (`features/agent/api/send-message.ts`, `hooks/use-submit-prompt.ts`), plus the LEGACY chat-store fields it needs (`webSearchEngine`, `enabledTools`, `useDeepResearch`). Deep Research is backend-only and goes with it. The `navigate`→`fetch` tool/service rename is a mid-flight step (translated client-side today). Markers across `features/agent/store/chat-store.ts`, `api/send-message.ts`. After this, `local` on ChatContext is effectively always true and the branch collapses.
+- **react-flow → canvas-harness:** the board migrated to the in-house engine; `@xyflow/react` and legacy converters (`utils/graph.ts`, deprecated `types/note.ts` fields) linger.
+- **Legacy WS client → v2 offline-first sync:** `use-ws-collab.ts` (and its duplicated normalize/enrich/dedupe helpers) is retired once every synced board is `v2`; then the transient `BoardMeta.syncEngine` field and the `dim0SyncV2` localStorage override go away.
+
+## Collaboration phases (not built)
+
+- **Phase 3 multi-worker:** `RoomRegistry` is single-worker v1; multi-worker needs Redis room-pinning + per-peer outbox queues (sends currently block the room under `room.lock`). Soft edit-locks are also Phase 3.
+- Welcome holds `room.lock` across the snapshot DB read (<500ms); a buffered-peer-op optimization is deferred.
+- Bulk/import writes (the NLP parsing pipeline) bypass the `peer-op` broadcast — a live board won't see an import until reload.
+- Anonymous (signed-out) share access is Phase 2+.
+
+## Durable engineering follow-ups (from recent fixes/reviews)
+
+- **`mini_app_state` not cascaded on `deleteBoard`** — needs a `by-board` index (record + write-path change + DB version bump). Storage leak, not data loss.
+- **`enforce_rate_limit` isn't atomic** — it increments each window before a later rule rejects, so a rejected-then-retried run re-increments the minute/day counters. Fix: roll back on a later-rule reject.
+- **Relay dedup is by envelope `batch.id`** — a coalesced re-send whose membership changed can re-apply an already-applied prefix. Proper fix: idempotency by covered oplog seq-range. (Benign today because the Qdrant apply is an idempotent upsert.)
+- **Adopt cap advisory lock** is unit-tested only via a fake store; add a Postgres integration test for the real concurrency.
+- **No cross-store (Postgres↔Qdrant) atomicity**; chunk cleanup on node delete is fire-and-forget (transient orphans).
+- **No local-turn `AbortController`** — a hung turn can't be cancelled and blocks chat switching; adding it also retires the mid-stream-guard edge.
+- `TODO(folder)` cluster in `store/graph.py`: no `parent_id` validation (existence / same-graph / cycle) on create/update; soft-deleted descendants aren't excluded from the descendant BFS.
+- Mini-app **CSP / network-egress hardening ("Phase 4")** is deployment-delivered, not yet in the repo.
+- HLC logical clock deferred to "Lift 2" (v1 relies on relay ordering). Local search-index persistence to IndexedDB is deferred. A desktop SQLite storage engine is pre-wired but not built.
+
+## Product
+
+- **Free tier is intentionally limited** while running on a small budget ("plan to make it more usable over time"). **Basic tier** shipped (v0.3.58: model gating + freemium limits + canvas counters).
+- Tauri desktop build exists but is early (version pinned `0.1.0`, `csp:null`).
+
+## Dead code / cleanup candidates
+
+- `backend/topix/llm_models.yml` — superseded by `models.yml`; referenced by no Python.
+- `datatypes/note/note.py` `emoji` field (→ `icon_data`); `agents/notes/tools.py` `create_note` tool (→ `write_note`); the `html-widget` skill (→ mini-app); `features/agent/local/use-local-agent.ts` (→ `use-local-submit-prompt.ts`).

--- a/webui/CLAUDE.md
+++ b/webui/CLAUDE.md
@@ -1,0 +1,23 @@
+# webui — Frontend conventions
+
+Applies to `webui/**`. Repo-wide rules (commits, docstrings) are in the root `CLAUDE.md`; architecture is in `docs/architecture.md`.
+
+## Code style
+
+- TypeScript only (`.ts` / `.tsx`), never plain JavaScript.
+- No semicolons.
+- No `export default` for React/components — use named exports.
+- No `any` — prefer explicit types, `unknown`, generics, or narrow unions.
+- 2 blank lines between top-level declarations; 1 blank line inside blocks.
+- Run `npm run check-all` (type-check + eslint) before pushing.
+
+## Stack
+
+React 19, Vite 7, Tailwind v4, TanStack Router + Query, Zustand, Phosphor icons. The canvas engine is the `@canvas-harness/*` npm dependency (not in-tree). Client search via Orama; IndexedDB via `idb`.
+
+## Orientation (detail in `docs/architecture.md`)
+
+- Two agent runtimes behind one chat UI, chosen by `local`: the browser engine (`features/agent/engine/`) and the legacy server path (`features/agent/api/send-message.ts`, retires in G5).
+- Board = the canvas-harness mount at `features/board/harness/canvas/harness-canvas.tsx`; Dim0 `Note`/`Link` ↔ harness `Node`/`Edge` in `harness/convert/`; offline-first persistence in `features/board/persist/local/`.
+- `_storedColors` (not `node.style`) is the color source of truth.
+- Signed-out sentinel is `userId === "root"` (non-empty) — gate on `isSignedIn()`, never `!!userId`.


### PR DESCRIPTION
Adds short, concise, read-on-demand reference docs so humans and AI (Claude Code specifically) can orient in this large repo — code structure, features, and roadmap — and restructures the instruction files along Claude Code's documented conventions. Branches off `main`.

## What & why (grounded in Claude Code guidance)
The key principle: `CLAUDE.md` is *always-loaded working memory* (keep it lean, <200 lines, pointers not pasted content); structure/features/roadmap are *reference material* that should be **read on demand**, not inlined and not `@import`-ed (which would load them into every session's context).

**New reference docs** (plain markdown → serve humans in the repo and Claude via on-demand Read):
- `docs/architecture.md` — the non-obvious wiring and invariants: the two agent execution paths (browser engine vs server OpenAI-Agents, mid-"G5"-cutover), the two persistence planes (REST convert layer vs offline-first identity), the Postgres/Qdrant/Redis cross-store split, "collab is the only edit path", the oplog seq authority + dedup-by-batch-id, client `X-Run-Id` metering, BYOK-vs-managed key flow, build targets.
- `docs/features.md` — one tight entry per feature (canvas, agent, collab/sharing, offline-first, mini-apps, doc Q&A, multi-model BYOK, widgets/newsfeed/sandbox, billing/self-host) with its code entry point.
- `docs/roadmap.md` — in-flight cutovers/migrations, unbuilt collab phases, durable engineering follow-ups (incl. the ones surfaced in recent PR reviews), product notes, and dead-code cleanup candidates.

**Instruction-file restructure (per the monorepo pattern):**
- Root `CLAUDE.md` stays lean and gains a "Docs map (read on demand)" pointer section + a "Domain conventions" pointer. Corrected the repo map (`@canvas-harness/*` is an npm dependency, not in-tree source).
- Frontend code style moved to `webui/CLAUDE.md`; Python conventions added in `backend/CLAUDE.md`. Claude Code loads each on demand when working in that tree, so the always-loaded root file shrinks.

## How it was written
Not from memory — five parallel read-only surveys across the whole repo (backend agents+API, backend collab+store+data-model, frontend agent engine, frontend board harness, frontend shell+infra+stack), cross-checked against the code. Docs deliberately omit anything derivable from a file tree and focus on the *why* and the seams.

## Notes
- No code changes; markdown only.
- Reference docs use plain-path pointers (not `@import`) so they never bloat the base session context.
- `docs/roadmap.md` will drift — it's explicitly labeled "verify against the codebase".
- Optional follow-up (not done here): the repo has an untracked local `AGENTS.md` mirroring the old CLAUDE.md; if you want other agent tools to share these instructions, track `AGENTS.md` and make `CLAUDE.md` start with `@AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
