### PR TITLE
feat(agent): structured tool-result contract + no-reprompt confirm gate

### DIFF
--- a/webui/src/components/ui/switch.tsx
+++ b/webui/src/components/ui/switch.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils"
+
+
+type SwitchProps = {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  /** Accessible name when there's no visible <label> wired to the control. */
+  label?: string
+  disabled?: boolean
+  className?: string
+}
+
+
+/**
+ * Minimal accessible toggle switch (`role="switch"`). Controlled: the parent
+ * owns `checked` and updates it in `onCheckedChange`. Hand-rolled rather than
+ * pulling in `@radix-ui/react-switch` — it's a single button with no menu/focus
+ * machinery to warrant the dependency.
+ */
+export const Switch = ({ checked, onCheckedChange, label, disabled = false, className }: SwitchProps) => (
+  <button
+    type="button"
+    role="switch"
+    aria-checked={checked}
+    aria-label={label}
+    disabled={disabled}
+    onClick={() => onCheckedChange(!checked)}
+    className={cn(
+      "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors",
+      "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-secondary-foreground/15",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      checked ? "bg-primary" : "bg-muted-foreground/30",
+      className,
+    )}
+  >
+    <span
+      className={cn(
+        "inline-block size-4 rounded-full bg-background shadow-sm transition-transform",
+        checked ? "translate-x-4" : "translate-x-0.5",
+      )}
+    />
+  </button>
+)

--- a/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
+++ b/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
@@ -1,7 +1,7 @@
 import { GlobeIcon, CodeInterpreterIcon, BrowserSearchIcon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -56,7 +56,7 @@ export const ToolConfirmDialog = () => {
   const { title, hint, preview, Icon } = describe(pending)
 
   return (
-    <AlertDialog open onOpenChange={(open) => !open && resolve(false)}>
+    <AlertDialog open onOpenChange={(open) => !open && resolve("deny")}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="flex items-center gap-2">
@@ -71,8 +71,11 @@ export const ToolConfirmDialog = () => {
           </pre>
         )}
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={() => resolve(false)}>Don't allow</AlertDialogCancel>
-          <AlertDialogAction onClick={() => resolve(true)}>Allow</AlertDialogAction>
+          <AlertDialogCancel onClick={() => resolve("deny")}>Don't allow</AlertDialogCancel>
+          {/* "Allow once" gates the next call again; "Allow for this request"
+              auto-approves further calls to this tool for the rest of the run. */}
+          <Button variant="outline" onClick={() => resolve("once")}>Allow once</Button>
+          <Button onClick={() => resolve("always")}>Allow for this request</Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
+++ b/webui/src/features/agent/components/chat/tool-confirm-dialog.tsx
@@ -44,9 +44,11 @@ const describe = (req: ToolConfirmRequest): { title: string; hint: string; previ
 
 /**
  * Confirmation for off-board agent tools (`fetch` / `web_search` / `code_interpreter`).
- * Mounted once on a local board; shows the exact URL/query/code and pauses the run until the
- * user allows or declines (see `useToolConfirm` + the agent loop's CONFIRM_TOOLS).
- * The preview is rendered as plain text — never HTML — so it can't inject markup.
+ * Mounted at the board level whenever the browser engine runs (LocalBoardScreen
+ * for local boards, BoardView for synced ones); shows the exact URL/query/code
+ * and pauses the run until the user decides (see `useToolConfirm` + the agent
+ * loop's CONFIRM_TOOLS). The preview is plain text — never HTML — so it can't
+ * inject markup.
  */
 export const ToolConfirmDialog = () => {
   const pending = useToolConfirm((s) => s.pending)

--- a/webui/src/features/agent/components/chat/tool-step-row.tsx
+++ b/webui/src/features/agent/components/chat/tool-step-row.tsx
@@ -261,6 +261,7 @@ export const ToolStepRow = ({
   }
 
   const isLoading = isStreaming && step.state === "started"
+  const isFailed = step.state === "failed"
   const spanMessageClass = "text-sm text-card-foreground whitespace-pre-line"
   const StepIcon = ToolNameIcon[step.name] ?? DEFAULT_TOOL_ICON
   const iconClass = "size-4"
@@ -289,15 +290,15 @@ export const ToolStepRow = ({
             {isLoading ? (
               <CircleNotchIcon className={cn(iconClass, 'shrink-0 text-secondary-foreground animate-spin')} strokeWidth={2} />
             ) : (
-              <StepIcon className={cn(iconClass, 'shrink-0 text-secondary-foreground')} strokeWidth={2} />
+              <StepIcon className={cn(iconClass, 'shrink-0', isFailed ? 'text-destructive' : 'text-secondary-foreground')} strokeWidth={2} />
             )}
             {message !== "" ? (
               <div className='flex-1 min-w-0 flex flex-col'>
-                <h4 className={cn('text-sm font-medium font-mono leading-5 transition-colors', isLoading ? 'text-muted-foreground' : 'text-foreground')}>{title}</h4>
-                <span className={spanMessageClass}>{message}</span>
+                <h4 className={cn('text-sm font-medium font-mono leading-5 transition-colors', isLoading ? 'text-muted-foreground' : isFailed ? 'text-destructive' : 'text-foreground')}>{title}</h4>
+                <span className={cn(spanMessageClass, isFailed && 'text-destructive')}>{message}</span>
               </div>
             ) : (
-              <h4 className={cn('flex-1 min-w-0 truncate text-sm font-medium font-mono leading-5 transition-colors', isLoading ? 'text-muted-foreground' : 'text-foreground')}>{title}</h4>
+              <h4 className={cn('flex-1 min-w-0 truncate text-sm font-medium font-mono leading-5 transition-colors', isLoading ? 'text-muted-foreground' : isFailed ? 'text-destructive' : 'text-foreground')}>{title}</h4>
             )}
             {canExpand && (
               <button

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -7,7 +7,7 @@ import { LocalSearchIndex } from "@/features/board/search/local-index"
 import { addNode, freshStore, resetIdb } from "@/test/canvas"
 import { ScriptedLlm, toolTurn } from "@/test/llm"
 import { z } from "zod"
-import { executeToolCall, runAgent } from "./agent-loop"
+import { executeToolCall, newConfirmGate, runAgent } from "./agent-loop"
 import { defineTool } from "./types"
 import type { AgentEvent, LlmClient, LlmMessage, Tool, ToolContext } from "./types"
 import { createNote, editNote, getNote, linkNotes, listBoards, localTools, searchNotes, updateNote, writeNote } from "./tools"
@@ -152,7 +152,7 @@ describe("runAgent — off-board tool confirmation gate", () => {
         userMessage: "go",
         tools: [spyTool("fetch", ran)],
         llm,
-        ctx: { store: freshStore("c"), confirmTool: async (r) => (seen.push(r), true) },
+        ctx: { store: freshStore("c"), confirmTool: async (r) => (seen.push(r), "once") },
       }),
     )
     expect(seen).toEqual([{ name: "fetch", args: { url: "https://x" } }])
@@ -168,7 +168,7 @@ describe("runAgent — off-board tool confirmation gate", () => {
         userMessage: "go",
         tools: [spyTool("fetch", ran)],
         llm,
-        ctx: { store: freshStore("c"), confirmTool: async () => false },
+        ctx: { store: freshStore("c"), confirmTool: async () => "deny" },
       }),
     )
     expect(ran.value).toBe(false)
@@ -187,7 +187,7 @@ describe("runAgent — off-board tool confirmation gate", () => {
         userMessage: "go",
         tools: [spyTool("code_interpreter", ran)],
         llm,
-        ctx: { store: freshStore("c"), confirmTool: async () => false },
+        ctx: { store: freshStore("c"), confirmTool: async () => "deny" },
       }),
     )
     expect(ran.value).toBe(false)
@@ -201,7 +201,7 @@ describe("runAgent — off-board tool confirmation gate", () => {
         userMessage: "go",
         tools: [spyTool("web_search", ran)],
         llm,
-        ctx: { store: freshStore("c"), confirmTool: async () => false },
+        ctx: { store: freshStore("c"), confirmTool: async () => "deny" },
       }),
     )
     expect(ran.value).toBe(false)
@@ -247,7 +247,7 @@ describe("runAgent — off-board tool confirmation gate", () => {
         userMessage: "go",
         tools: [spyTool("noop", ran)],
         llm,
-        ctx: { store: freshStore("c"), confirmTool: async () => ((prompted = true), true) },
+        ctx: { store: freshStore("c"), confirmTool: async () => ((prompted = true), "once") },
       }),
     )
     expect(prompted).toBe(false)
@@ -406,7 +406,7 @@ describe("executeToolCall (tool execution choke point)", () => {
     ({ store: freshStore("c"), rootId: null, confirmTool })
 
   it("returns an unknown_tool failure when the tool isn't in the set", async () => {
-    const out = await executeToolCall("nope", {}, [stubTool("fetch")], ctxWith(), new Set())
+    const out = await executeToolCall("nope", {}, [stubTool("fetch")], ctxWith(), newConfirmGate())
     expect(out).toMatchObject({ ok: false, error: "unknown_tool", tool: "nope" })
   })
 
@@ -414,37 +414,54 @@ describe("executeToolCall (tool execution choke point)", () => {
     let asked = false
     const out = await executeToolCall(
       "create_note", {}, [stubTool("create_note", async () => ({ id: "n1" }))],
-      ctxWith(async () => ((asked = true), true)), new Set(),
+      ctxWith(async () => ((asked = true), "once")), newConfirmGate(),
     )
     expect(asked).toBe(false)
     expect(out).toEqual({ id: "n1" })
   })
 
-  it("runs a gated tool when approved", async () => {
-    const out = await executeToolCall("fetch", { url: "x" }, [stubTool("fetch")], ctxWith(async () => true), new Set())
+  it("runs a gated tool on allow-once but does NOT auto-approve the next call", async () => {
+    const gate = newConfirmGate()
+    const out = await executeToolCall("fetch", { url: "x" }, [stubTool("fetch")], ctxWith(async () => "once"), gate)
     expect(out).toEqual({ ok: true })
+    expect(gate.approved.has("fetch")).toBe(false) // "once" is not remembered
   })
 
   it("returns user_declined and records the tool when refused", async () => {
-    const declined = new Set<string>()
-    const out = await executeToolCall("fetch", {}, [stubTool("fetch")], ctxWith(async () => false), declined)
+    const gate = newConfirmGate()
+    const out = await executeToolCall("fetch", {}, [stubTool("fetch")], ctxWith(async () => "deny"), gate)
     expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
-    expect(declined.has("fetch")).toBe(true)
+    expect(gate.declined.has("fetch")).toBe(true)
   })
 
   it("does NOT re-prompt a tool already declined this run (fail closed, no dialog spam)", async () => {
-    const declined = new Set<string>(["fetch"])
+    const gate = { declined: new Set(["fetch"]), approved: new Set<string>() }
     let asked = false
     const out = await executeToolCall(
-      "fetch", {}, [stubTool("fetch")], ctxWith(async () => ((asked = true), true)), declined,
+      "fetch", {}, [stubTool("fetch")], ctxWith(async () => ((asked = true), "once")), gate,
     )
     expect(asked).toBe(false) // the confirmer was never consulted the second time
     expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
   })
 
+  it("'allow for this request' records approval and skips the prompt on the next call", async () => {
+    const gate = newConfirmGate()
+    let prompts = 0
+    const tool = [stubTool("web_search")]
+    const ctx = ctxWith(async () => (prompts += 1, "always"))
+
+    const first = await executeToolCall("web_search", { query: "a" }, tool, ctx, gate)
+    expect(first).toEqual({ ok: true })
+    expect(gate.approved.has("web_search")).toBe(true)
+
+    const second = await executeToolCall("web_search", { query: "b" }, tool, ctx, gate)
+    expect(second).toEqual({ ok: true })
+    expect(prompts).toBe(1) // approved for the run — the second call didn't prompt
+  })
+
   it("normalizes a thrown tool into a tool_error (never propagates)", async () => {
     const out = await executeToolCall(
-      "fetch", {}, [stubTool("fetch", async () => { throw new Error("kaboom") })], ctxWith(async () => true), new Set(),
+      "fetch", {}, [stubTool("fetch", async () => { throw new Error("kaboom") })], ctxWith(async () => "once"), newConfirmGate(),
     )
     expect(out).toMatchObject({ ok: false, error: "tool_error", tool: "fetch" })
     expect((out as { message: string }).message).toContain("kaboom")
@@ -452,7 +469,7 @@ describe("executeToolCall (tool execution choke point)", () => {
 
   it("gates run without a confirmer wired (headless): the tool runs", async () => {
     let ran = false
-    await executeToolCall("fetch", {}, [stubTool("fetch", async () => ((ran = true), { ok: true }))], ctxWith(), new Set())
+    await executeToolCall("fetch", {}, [stubTool("fetch", async () => ((ran = true), { ok: true }))], ctxWith(), newConfirmGate())
     expect(ran).toBe(true)
   })
 })
@@ -479,7 +496,7 @@ describe("runAgent — declined off-board tool is not re-prompted across turns",
         userMessage: "go",
         tools: [spy],
         llm,
-        ctx: { store: freshStore("c"), rootId: null, confirmTool: async () => (prompts += 1, false) },
+        ctx: { store: freshStore("c"), rootId: null, confirmTool: async () => (prompts += 1, "deny") },
       }),
     )
     expect(prompts).toBe(1) // dialog shown once, not on the retry
@@ -488,5 +505,31 @@ describe("runAgent — declined off-board tool is not re-prompted across turns",
       (e) => e.type === "tool_result" && (e.result as { error?: string }).error === "user_declined",
     )
     expect(declines).toHaveLength(2) // both attempts get a clean declined result
+  })
+
+  it("prompts once on 'allow for this request', then runs later calls unprompted", async () => {
+    let prompts = 0
+    const ran = { value: 0 }
+    const spy = defineTool({
+      name: "web_search",
+      description: "web_search",
+      parameters: z.object({ query: z.string().optional() }),
+      run: async () => ((ran.value += 1), { ok: true }),
+    })
+    const llm = new ScriptedLlm([
+      toolTurn("web_search", { query: "a" }),
+      toolTurn("web_search", { query: "b" }),
+      { kind: "text", text: "done" },
+    ])
+    await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spy],
+        llm,
+        ctx: { store: freshStore("c"), rootId: null, confirmTool: async () => (prompts += 1, "always") },
+      }),
+    )
+    expect(prompts).toBe(1) // approved for the request — only the first call prompted
+    expect(ran.value).toBe(2) // both searches ran
   })
 })

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -9,6 +9,7 @@ import { ScriptedLlm, toolTurn } from "@/test/llm"
 import { z } from "zod"
 import { executeToolCall, newConfirmGate, runAgent } from "./agent-loop"
 import { isToolFailure } from "./tool-result"
+import { resolveConfirmDecision } from "./tool-confirm-store"
 import { defineTool } from "./types"
 import type { AgentEvent, LlmClient, LlmMessage, Tool, ToolContext } from "./types"
 import { createNote, editNote, getNote, linkNotes, listBoards, localTools, searchNotes, updateNote, writeNote } from "./tools"
@@ -510,6 +511,45 @@ describe("executeToolCall (tool execution choke point)", () => {
     let ran = false
     await executeToolCall("fetch", {}, [stubTool("fetch", async () => ((ran = true), { ok: true }))], ctxWith(), newConfirmGate())
     expect(ran).toBe(true)
+  })
+
+  it("'allow for this request' is per-tool — approving one gated tool doesn't approve another", async () => {
+    const gate = newConfirmGate()
+    const tools = [stubTool("web_search"), stubTool("fetch")]
+    let fetchPrompts = 0
+    const ctx = ctxWith(async (r) => (r.name === "fetch" ? (fetchPrompts += 1) : 0, "always"))
+
+    await executeToolCall("web_search", { query: "a" }, tools, ctx, gate)
+    expect(gate.approved.has("web_search")).toBe(true)
+
+    // A different gated tool still prompts despite web_search being approved.
+    await executeToolCall("fetch", { url: "u" }, tools, ctx, gate)
+    expect(fetchPrompts).toBe(1)
+    expect(gate.approved.has("fetch")).toBe(true)
+  })
+
+  it("a persistent grant revoked mid-run re-prompts on the next call (real wiring)", async () => {
+    // Exercises the confirmTool wiring use-local-submit-prompt uses: the grant
+    // (isAutoAllowed) and dialog are both read per call, so a revoke applies next.
+    const gate = newConfirmGate()
+    const tools = [stubTool("web_search")]
+    let granted = true
+    let dialogPrompts = 0
+    const ctx = ctxWith(() =>
+      resolveConfirmDecision("web_search", () => granted, async () => (dialogPrompts += 1, "deny")),
+    )
+
+    // Granted → runs via "once", never opens the dialog, never sticks in approved.
+    const first = await executeToolCall("web_search", { query: "a" }, tools, ctx, gate)
+    expect(first).toEqual({ ok: true })
+    expect(dialogPrompts).toBe(0)
+    expect(gate.approved.has("web_search")).toBe(false)
+
+    // Revoke mid-run → next call defers to the dialog and is declined.
+    granted = false
+    const second = await executeToolCall("web_search", { query: "b" }, tools, ctx, gate)
+    expect(dialogPrompts).toBe(1)
+    expect(second).toMatchObject({ ok: false, error: "user_declined" })
   })
 })
 

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -431,17 +431,39 @@ describe("executeToolCall (tool execution choke point)", () => {
     const gate = newConfirmGate()
     const out = await executeToolCall("fetch", {}, [stubTool("fetch")], ctxWith(async () => "deny"), gate)
     expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
-    expect(gate.declined.has("fetch")).toBe(true)
+    // Recorded by CALL key (name + args), not the bare tool name.
+    expect(gate.declined.has("fetch:{}")).toBe(true)
+    expect(gate.declined.has("fetch")).toBe(false)
   })
 
-  it("does NOT re-prompt a tool already declined this run (fail closed, no dialog spam)", async () => {
-    const gate = { declined: new Set(["fetch"]), approved: new Set<string>() }
-    let asked = false
-    const out = await executeToolCall(
-      "fetch", {}, [stubTool("fetch")], ctxWith(async () => ((asked = true), "once")), gate,
-    )
-    expect(asked).toBe(false) // the confirmer was never consulted the second time
-    expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
+  it("re-declines the SAME call without re-prompting, but a DIFFERENT call still prompts", async () => {
+    const gate = newConfirmGate()
+    let prompts = 0
+    const tools = [stubTool("web_search")]
+    const ctx = ctxWith(async () => (prompts += 1, "deny"))
+
+    // Deny query "a".
+    await executeToolCall("web_search", { query: "a" }, tools, ctx, gate)
+    expect(prompts).toBe(1)
+
+    // Same call again → auto-declined, no new prompt.
+    const repeat = await executeToolCall("web_search", { query: "a" }, tools, ctx, gate)
+    expect(prompts).toBe(1)
+    expect(repeat).toMatchObject({ ok: false, error: "user_declined", tool: "web_search" })
+
+    // A DIFFERENT query is a different call → prompts again (the bug fix).
+    await executeToolCall("web_search", { query: "b" }, tools, ctx, gate)
+    expect(prompts).toBe(2)
+  })
+
+  it("keys the decline by args order-independently (same args, different key order)", async () => {
+    const gate = newConfirmGate()
+    let prompts = 0
+    const tools = [stubTool("fetch")]
+    const ctx = ctxWith(async () => (prompts += 1, "deny"))
+    await executeToolCall("fetch", { url: "x", note: "n" }, tools, ctx, gate)
+    await executeToolCall("fetch", { note: "n", url: "x" }, tools, ctx, gate) // reordered
+    expect(prompts).toBe(1) // recognized as the same call
   })
 
   it("'allow for this request' records approval and skips the prompt on the next call", async () => {
@@ -476,35 +498,68 @@ describe("executeToolCall (tool execution choke point)", () => {
 
 
 describe("runAgent — declined off-board tool is not re-prompted across turns", () => {
-  it("prompts once, then auto-declines a retry of the same tool in the same run", async () => {
-    let prompts = 0
-    const ran = { value: false }
-    const spy = defineTool({
+  const searchSpy = (ran: { value: number }) =>
+    defineTool({
       name: "web_search",
       description: "web_search",
       parameters: z.object({ query: z.string().optional() }),
-      run: async () => ((ran.value = true), { ok: true }),
+      run: async () => ((ran.value += 1), { ok: true }),
     })
-    // The model tries web_search, is declined, then stubbornly tries it again.
+
+  it("prompts once then auto-declines a retry of the IDENTICAL call (nag protection)", async () => {
+    let prompts = 0
+    const ran = { value: 0 }
     const llm = new ScriptedLlm([
       toolTurn("web_search", { query: "a" }),
-      toolTurn("web_search", { query: "b" }),
+      toolTurn("web_search", { query: "a" }), // same query — stubborn retry
       { kind: "text", text: "fine, answering without it" },
     ])
     const events = await drain(
       runAgent({
         userMessage: "go",
-        tools: [spy],
+        tools: [searchSpy(ran)],
         llm,
         ctx: { store: freshStore("c"), rootId: null, confirmTool: async () => (prompts += 1, "deny") },
       }),
     )
-    expect(prompts).toBe(1) // dialog shown once, not on the retry
-    expect(ran.value).toBe(false)
+    expect(prompts).toBe(1) // identical retry didn't re-prompt
+    expect(ran.value).toBe(0)
     const declines = events.filter(
       (e) => e.type === "tool_result" && (e.result as { error?: string }).error === "user_declined",
     )
-    expect(declines).toHaveLength(2) // both attempts get a clean declined result
+    expect(declines).toHaveLength(2)
+  })
+
+  it("prompts again for a DIFFERENT query — declining one search doesn't ban the next", async () => {
+    // The reported bug: allow #1, deny #2, and #3 (a distinct query) was
+    // auto-declined. Each distinct search must get its own prompt.
+    const prompts: string[] = []
+    const ran = { value: 0 }
+    const llm = new ScriptedLlm([
+      toolTurn("web_search", { query: "a" }),
+      toolTurn("web_search", { query: "b" }),
+      toolTurn("web_search", { query: "c" }),
+      { kind: "text", text: "done" },
+    ])
+    await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [searchSpy(ran)],
+        llm,
+        ctx: {
+          store: freshStore("c"),
+          rootId: null,
+          // allow "a", deny "b", allow "c"
+          confirmTool: async (r) => {
+            const q = String((r.args as { query?: string }).query)
+            prompts.push(q)
+            return q === "b" ? "deny" : "once"
+          },
+        },
+      }),
+    )
+    expect(prompts).toEqual(["a", "b", "c"]) // every distinct query prompted
+    expect(ran.value).toBe(2) // "a" and "c" ran; "b" was declined
   })
 
   it("prompts once on 'allow for this request', then runs later calls unprompted", async () => {

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -7,9 +7,9 @@ import { LocalSearchIndex } from "@/features/board/search/local-index"
 import { addNode, freshStore, resetIdb } from "@/test/canvas"
 import { ScriptedLlm, toolTurn } from "@/test/llm"
 import { z } from "zod"
-import { runAgent } from "./agent-loop"
+import { executeToolCall, runAgent } from "./agent-loop"
 import { defineTool } from "./types"
-import type { AgentEvent, LlmClient, LlmMessage } from "./types"
+import type { AgentEvent, LlmClient, LlmMessage, Tool, ToolContext } from "./types"
 import { createNote, editNote, getNote, linkNotes, listBoards, localTools, searchNotes, updateNote, writeNote } from "./tools"
 import { learnGenerateMiniApp, skillTools } from "./skills"
 
@@ -74,7 +74,7 @@ describe("runAgent (scripted LLM)", () => {
     expect(events.find((e) => e.type === "tool_result")).toMatchObject({
       type: "tool_result",
       toolName: "explode",
-      result: { error: "boom" },
+      result: { ok: false, error: "tool_error", tool: "explode", message: expect.stringContaining("boom") },
     })
     expect(events.some((e) => e.type === "assistant_text" && e.text === "recovered without the tool")).toBe(true)
     expect(events.at(-1)).toEqual({ type: "done" })
@@ -124,7 +124,7 @@ describe("runAgent (scripted LLM)", () => {
     const llm = new ScriptedLlm([toolTurn("nope", {}), { kind: "text", text: "done" }])
     const events = await drain(runAgent({ userMessage: "x", tools: localTools, llm, ctx: { store } }))
     const result = events.find((e) => e.type === "tool_result")
-    expect(result).toMatchObject({ result: { error: "unknown tool: nope" } })
+    expect(result).toMatchObject({ result: { ok: false, error: "unknown_tool", tool: "nope" } })
   })
 })
 
@@ -172,7 +172,10 @@ describe("runAgent — off-board tool confirmation gate", () => {
       }),
     )
     expect(ran.value).toBe(false)
-    expect(resultOf(events)).toMatchObject({ toolName: "fetch", result: { error: "declined by user" } })
+    expect(resultOf(events)).toMatchObject({
+      toolName: "fetch",
+      result: { ok: false, error: "user_declined", tool: "fetch", message: expect.stringContaining("declined") },
+    })
     expect(events.some((e) => e.type === "assistant_text" && e.text === "ok without it")).toBe(true)
   })
 
@@ -228,7 +231,10 @@ describe("runAgent — off-board tool confirmation gate", () => {
       }),
     )
     expect(ran.value).toBe(false)
-    expect(resultOf(events)).toMatchObject({ toolName: "fetch", result: { error: "boom" } })
+    expect(resultOf(events)).toMatchObject({
+      toolName: "fetch",
+      result: { ok: false, error: "tool_error", tool: "fetch", message: expect.stringContaining("boom") },
+    })
     expect(events.some((e) => e.type === "assistant_text" && e.text === "recovered")).toBe(true)
   })
 
@@ -388,5 +394,99 @@ describe("skills", () => {
       "learn_generate_html_widget",
       "learn_generate_mini_app",
     ])
+  })
+})
+
+
+describe("executeToolCall (tool execution choke point)", () => {
+  const stubTool = (name: string, run: Tool["run"] = async () => ({ ok: true })): Tool =>
+    defineTool({ name, description: name, parameters: z.object({ url: z.string().optional() }), run })
+
+  const ctxWith = (confirmTool?: ToolContext["confirmTool"]): ToolContext =>
+    ({ store: freshStore("c"), rootId: null, confirmTool })
+
+  it("returns an unknown_tool failure when the tool isn't in the set", async () => {
+    const out = await executeToolCall("nope", {}, [stubTool("fetch")], ctxWith(), new Set())
+    expect(out).toMatchObject({ ok: false, error: "unknown_tool", tool: "nope" })
+  })
+
+  it("runs a non-gated tool without consulting the confirmer", async () => {
+    let asked = false
+    const out = await executeToolCall(
+      "create_note", {}, [stubTool("create_note", async () => ({ id: "n1" }))],
+      ctxWith(async () => ((asked = true), true)), new Set(),
+    )
+    expect(asked).toBe(false)
+    expect(out).toEqual({ id: "n1" })
+  })
+
+  it("runs a gated tool when approved", async () => {
+    const out = await executeToolCall("fetch", { url: "x" }, [stubTool("fetch")], ctxWith(async () => true), new Set())
+    expect(out).toEqual({ ok: true })
+  })
+
+  it("returns user_declined and records the tool when refused", async () => {
+    const declined = new Set<string>()
+    const out = await executeToolCall("fetch", {}, [stubTool("fetch")], ctxWith(async () => false), declined)
+    expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
+    expect(declined.has("fetch")).toBe(true)
+  })
+
+  it("does NOT re-prompt a tool already declined this run (fail closed, no dialog spam)", async () => {
+    const declined = new Set<string>(["fetch"])
+    let asked = false
+    const out = await executeToolCall(
+      "fetch", {}, [stubTool("fetch")], ctxWith(async () => ((asked = true), true)), declined,
+    )
+    expect(asked).toBe(false) // the confirmer was never consulted the second time
+    expect(out).toMatchObject({ ok: false, error: "user_declined", tool: "fetch" })
+  })
+
+  it("normalizes a thrown tool into a tool_error (never propagates)", async () => {
+    const out = await executeToolCall(
+      "fetch", {}, [stubTool("fetch", async () => { throw new Error("kaboom") })], ctxWith(async () => true), new Set(),
+    )
+    expect(out).toMatchObject({ ok: false, error: "tool_error", tool: "fetch" })
+    expect((out as { message: string }).message).toContain("kaboom")
+  })
+
+  it("gates run without a confirmer wired (headless): the tool runs", async () => {
+    let ran = false
+    await executeToolCall("fetch", {}, [stubTool("fetch", async () => ((ran = true), { ok: true }))], ctxWith(), new Set())
+    expect(ran).toBe(true)
+  })
+})
+
+
+describe("runAgent — declined off-board tool is not re-prompted across turns", () => {
+  it("prompts once, then auto-declines a retry of the same tool in the same run", async () => {
+    let prompts = 0
+    const ran = { value: false }
+    const spy = defineTool({
+      name: "web_search",
+      description: "web_search",
+      parameters: z.object({ query: z.string().optional() }),
+      run: async () => ((ran.value = true), { ok: true }),
+    })
+    // The model tries web_search, is declined, then stubbornly tries it again.
+    const llm = new ScriptedLlm([
+      toolTurn("web_search", { query: "a" }),
+      toolTurn("web_search", { query: "b" }),
+      { kind: "text", text: "fine, answering without it" },
+    ])
+    const events = await drain(
+      runAgent({
+        userMessage: "go",
+        tools: [spy],
+        llm,
+        ctx: { store: freshStore("c"), rootId: null, confirmTool: async () => (prompts += 1, false) },
+      }),
+    )
+    expect(prompts).toBe(1) // dialog shown once, not on the retry
+    expect(ran.value).toBe(false)
+    const declines = events.filter(
+      (e) => e.type === "tool_result" && (e.result as { error?: string }).error === "user_declined",
+    )
+    expect(declines).toHaveLength(2) // both attempts get a clean declined result
   })
 })

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -8,6 +8,7 @@ import { addNode, freshStore, resetIdb } from "@/test/canvas"
 import { ScriptedLlm, toolTurn } from "@/test/llm"
 import { z } from "zod"
 import { executeToolCall, newConfirmGate, runAgent } from "./agent-loop"
+import { isToolFailure } from "./tool-result"
 import { defineTool } from "./types"
 import type { AgentEvent, LlmClient, LlmMessage, Tool, ToolContext } from "./types"
 import { createNote, editNote, getNote, linkNotes, listBoards, localTools, searchNotes, updateNote, writeNote } from "./tools"
@@ -487,6 +488,22 @@ describe("executeToolCall (tool execution choke point)", () => {
     )
     expect(out).toMatchObject({ ok: false, error: "tool_error", tool: "fetch" })
     expect((out as { message: string }).message).toContain("kaboom")
+  })
+
+  it("normalizes a tool's own {error} rejection into a tool_rejected failure", async () => {
+    const out = await executeToolCall(
+      "create_note", {}, [stubTool("create_note", async () => ({ error: "note not found" }))], ctxWith(), newConfirmGate(),
+    )
+    expect(out).toMatchObject({ ok: false, error: "tool_rejected", tool: "create_note", message: "note not found" })
+    expect(isToolFailure(out)).toBe(true) // uniform failure signal, not a bare {error}
+  })
+
+  it("passes a tool's success output through unchanged", async () => {
+    const out = await executeToolCall(
+      "create_note", {}, [stubTool("create_note", async () => ({ id: "n1", created: true }))], ctxWith(), newConfirmGate(),
+    )
+    expect(out).toEqual({ id: "n1", created: true })
+    expect(isToolFailure(out)).toBe(false)
   })
 
   it("gates run without a confirmer wired (headless): the tool runs", async () => {

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -52,13 +52,31 @@ const parseArgs = (raw: string): Record<string, unknown> => {
 }
 
 
+/** Order-independent JSON of a value, so equal args produce the same string. */
+const stableStringify = (v: unknown): string => {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null"
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`
+  const obj = v as Record<string, unknown>
+  return `{${Object.keys(obj)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`
+}
+
+
+/** Identity of a specific tool call (name + args) — the decline gate's key, so a
+ *  refusal is scoped to THAT call, not the whole tool. */
+const callKey = (name: string, args: Record<string, unknown>): string => `${name}:${stableStringify(args)}`
+
+
 /**
- * Per-run memory for the off-board confirm gate, so a tool is prompted at most
- * once per outcome across the whole run:
- *  - `declined` — the user said no; further calls fail closed WITHOUT reopening
- *    the dialog (a retrying model can't nag).
- *  - `approved` — the user chose "allow for this request"; further calls to the
- *    same tool run without prompting.
+ * Per-run memory for the off-board confirm gate:
+ *  - `declined` — SPECIFIC calls (tool + args, see `callKey`) the user refused.
+ *    An identical later call fails closed WITHOUT reopening the dialog (a
+ *    retrying model can't nag), but a DIFFERENT call of the same tool still
+ *    prompts — declining one web search doesn't ban the next.
+ *  - `approved` — TOOLS the user chose "allow for this request" for; every later
+ *    call to that tool runs without prompting (a deliberate broad grant).
  */
 export type ConfirmGate = { declined: Set<string>; approved: Set<string> }
 
@@ -91,11 +109,15 @@ export async function executeToolCall(
   // a throwing tool aborts the whole run — both surface as a `tool_error`.
   try {
     if (CONFIRM_TOOLS.has(tool.name) && ctx.confirmTool) {
-      if (gate.declined.has(tool.name)) return userDeclined(tool.name)
+      // Decline is per specific call; approval is per tool (broad). Check the
+      // exact-call decline first so an explicitly refused call stays refused
+      // even if the tool was later broadly approved.
+      const key = callKey(tool.name, args)
+      if (gate.declined.has(key)) return userDeclined(tool.name)
       if (!gate.approved.has(tool.name)) {
         const decision = await ctx.confirmTool({ name: tool.name, args })
         if (decision === "deny") {
-          gate.declined.add(tool.name)
+          gate.declined.add(key)
           return userDeclined(tool.name)
         }
         // "always" broadens consent to the rest of the run; "once" does not.

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -4,6 +4,7 @@
  * construction — the LLM is injected, so tests use a scripted mock.
  */
 import { z } from "zod"
+import { CONFIRM_TOOL_NAMES } from "./types"
 import type { AgentEvent, LlmClient, LlmMessage, LlmToolDef, LlmTurn, Tool, ToolContext } from "./types"
 import { isToolSoftError, toolRejected, toolThrew, unknownTool, userDeclined } from "./tool-result"
 import { agentLog } from "./debug"
@@ -25,7 +26,7 @@ export const DEFAULT_MAX_TURNS = 30
  * data or run attacker code. Note tools stay auto — they act on the user's own
  * board and gating them would wreck the normal build flow.
  */
-const CONFIRM_TOOLS = new Set(["fetch", "code_interpreter", "web_search"])
+const CONFIRM_TOOLS = new Set<string>(CONFIRM_TOOL_NAMES)
 
 
 /** Convert a tool's Zod schema to a plain JSON Schema (dropping the `$schema` tag). */

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -53,22 +53,36 @@ const parseArgs = (raw: string): Record<string, unknown> => {
 
 
 /**
+ * Per-run memory for the off-board confirm gate, so a tool is prompted at most
+ * once per outcome across the whole run:
+ *  - `declined` — the user said no; further calls fail closed WITHOUT reopening
+ *    the dialog (a retrying model can't nag).
+ *  - `approved` — the user chose "allow for this request"; further calls to the
+ *    same tool run without prompting.
+ */
+export type ConfirmGate = { declined: Set<string>; approved: Set<string> }
+
+
+/** A fresh gate for one run. */
+export const newConfirmGate = (): ConfirmGate => ({ declined: new Set(), approved: new Set() })
+
+
+/**
  * Execute one tool call under the loop's policy and return the model-facing
  * result: the tool's own output on success, or a structured `ToolFailure`
  * (unknown tool / user-declined / thrown error) the model can act on. The
  * single choke point for tool execution — the frontend analog of the backend's
  * tool decorator, so every failure origin yields one consistent shape.
  *
- * The off-board confirm gate de-dupes per run via `declinedTools`: once the user
- * declines a tool, a later call to the same tool fails closed WITHOUT reopening
- * the dialog, so a retrying model can't nag the user with repeat prompts.
+ * The off-board confirm gate is consulted only when the tool is neither already
+ * declined nor already approved this run (see {@link ConfirmGate}).
  */
 export async function executeToolCall(
   name: string,
   args: Record<string, unknown>,
   tools: Tool[],
   ctx: ToolContext,
-  declinedTools: Set<string>,
+  gate: ConfirmGate,
 ): Promise<unknown> {
   const tool = tools.find((t) => t.name === name)
   if (!tool) return unknownTool(name)
@@ -77,11 +91,15 @@ export async function executeToolCall(
   // a throwing tool aborts the whole run — both surface as a `tool_error`.
   try {
     if (CONFIRM_TOOLS.has(tool.name) && ctx.confirmTool) {
-      if (declinedTools.has(tool.name)) return userDeclined(tool.name)
-      const approved = await ctx.confirmTool({ name: tool.name, args })
-      if (!approved) {
-        declinedTools.add(tool.name)
-        return userDeclined(tool.name)
+      if (gate.declined.has(tool.name)) return userDeclined(tool.name)
+      if (!gate.approved.has(tool.name)) {
+        const decision = await ctx.confirmTool({ name: tool.name, args })
+        if (decision === "deny") {
+          gate.declined.add(tool.name)
+          return userDeclined(tool.name)
+        }
+        // "always" broadens consent to the rest of the run; "once" does not.
+        if (decision === "always") gate.approved.add(tool.name)
       }
     }
     return await tool.run(args, ctx)
@@ -112,9 +130,9 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
   if (opts.history) messages.push(...opts.history)
   messages.push({ role: "user", content: opts.userMessage })
 
-  // Off-board tools the user declined this run — never re-prompted (see
-  // executeToolCall). Spans all turns, so a retry in a later round is caught.
-  const declinedTools = new Set<string>()
+  // Per-run confirm memory (declined + approved). Spans all turns, so a retry
+  // or a follow-up call in a later round respects the earlier decision.
+  const gate = newConfirmGate()
 
   for (let turn = 0; turn < maxTurns; turn += 1) {
     // Prefer streaming: emit cumulative `assistant_text` per delta so the UI
@@ -155,7 +173,7 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
       // error normalization all live in executeToolCall, so every outcome —
       // declined, unknown, or thrown — feeds back one consistent structured
       // result and no failure origin aborts the run.
-      const output = await executeToolCall(call.name, args, opts.tools, opts.ctx, declinedTools)
+      const output = await executeToolCall(call.name, args, opts.tools, opts.ctx, gate)
       agentLog.tool(call.name, args, output)
       yield { type: "tool_result", toolName: call.name, result: output }
       messages.push({ role: "tool", toolCallId: call.id, content: JSON.stringify(output) })

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -5,7 +5,7 @@
  */
 import { z } from "zod"
 import type { AgentEvent, LlmClient, LlmMessage, LlmToolDef, LlmTurn, Tool, ToolContext } from "./types"
-import { toolThrew, unknownTool, userDeclined } from "./tool-result"
+import { isToolSoftError, toolRejected, toolThrew, unknownTool, userDeclined } from "./tool-result"
 import { agentLog } from "./debug"
 
 
@@ -124,7 +124,11 @@ export async function executeToolCall(
         if (decision === "always") gate.approved.add(tool.name)
       }
     }
-    return await tool.run(args, ctx)
+    const result = await tool.run(args, ctx)
+    // Normalize a tool's own `{ error }` rejection into the shared ToolFailure
+    // shape, so every failure origin — unknown / declined / thrown / rejected —
+    // answers `isToolFailure` uniformly.
+    return isToolSoftError(result) ? toolRejected(tool.name, result.error) : result
   } catch (err) {
     return toolThrew(tool.name, err)
   }

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -5,6 +5,7 @@
  */
 import { z } from "zod"
 import type { AgentEvent, LlmClient, LlmMessage, LlmToolDef, LlmTurn, Tool, ToolContext } from "./types"
+import { toolThrew, unknownTool, userDeclined } from "./tool-result"
 import { agentLog } from "./debug"
 
 
@@ -51,6 +52,45 @@ const parseArgs = (raw: string): Record<string, unknown> => {
 }
 
 
+/**
+ * Execute one tool call under the loop's policy and return the model-facing
+ * result: the tool's own output on success, or a structured `ToolFailure`
+ * (unknown tool / user-declined / thrown error) the model can act on. The
+ * single choke point for tool execution — the frontend analog of the backend's
+ * tool decorator, so every failure origin yields one consistent shape.
+ *
+ * The off-board confirm gate de-dupes per run via `declinedTools`: once the user
+ * declines a tool, a later call to the same tool fails closed WITHOUT reopening
+ * the dialog, so a retrying model can't nag the user with repeat prompts.
+ */
+export async function executeToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  tools: Tool[],
+  ctx: ToolContext,
+  declinedTools: Set<string>,
+): Promise<unknown> {
+  const tool = tools.find((t) => t.name === name)
+  if (!tool) return unknownTool(name)
+
+  // Confirm gate + run share one try/catch, so neither a throwing confirmer nor
+  // a throwing tool aborts the whole run — both surface as a `tool_error`.
+  try {
+    if (CONFIRM_TOOLS.has(tool.name) && ctx.confirmTool) {
+      if (declinedTools.has(tool.name)) return userDeclined(tool.name)
+      const approved = await ctx.confirmTool({ name: tool.name, args })
+      if (!approved) {
+        declinedTools.add(tool.name)
+        return userDeclined(tool.name)
+      }
+    }
+    return await tool.run(args, ctx)
+  } catch (err) {
+    return toolThrew(tool.name, err)
+  }
+}
+
+
 export type RunAgentOptions = {
   userMessage: string
   tools: Tool[]
@@ -71,6 +111,10 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
   if (opts.system) messages.push({ role: "system", content: opts.system })
   if (opts.history) messages.push(...opts.history)
   messages.push({ role: "user", content: opts.userMessage })
+
+  // Off-board tools the user declined this run — never re-prompted (see
+  // executeToolCall). Spans all turns, so a retry in a later round is caught.
+  const declinedTools = new Set<string>()
 
   for (let turn = 0; turn < maxTurns; turn += 1) {
     // Prefer streaming: emit cumulative `assistant_text` per delta so the UI
@@ -107,27 +151,11 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
     for (const call of result.calls) {
       const args = parseArgs(call.arguments)
       yield { type: "tool_start", toolName: call.name, args }
-      const tool = opts.tools.find((t) => t.name === call.name)
-      // A tool that throws (e.g. a managed service returning 500) must not abort
-      // the whole run: feed the error back as the tool result so the model can
-      // recover or answer without it, matching the unknown-tool path.
-      let output: unknown
-      if (!tool) {
-        output = { error: `unknown tool: ${call.name}` }
-      } else {
-        // Confirm + run share one try/catch so neither a declined confirm nor a
-        // throwing confirmer/tool aborts the whole run — the error is fed back.
-        try {
-          if (CONFIRM_TOOLS.has(tool.name) && opts.ctx.confirmTool && !(await opts.ctx.confirmTool({ name: tool.name, args }))) {
-            // Declined off-board action: feed a result back so the model adapts.
-            output = { error: "declined by user" }
-          } else {
-            output = await tool.run(args, opts.ctx)
-          }
-        } catch (err) {
-          output = { error: err instanceof Error ? err.message : String(err) }
-        }
-      }
+      // One choke point: unknown-tool guard, the off-board confirm gate, and
+      // error normalization all live in executeToolCall, so every outcome —
+      // declined, unknown, or thrown — feeds back one consistent structured
+      // result and no failure origin aborts the run.
+      const output = await executeToolCall(call.name, args, opts.tools, opts.ctx, declinedTools)
       agentLog.tool(call.name, args, output)
       yield { type: "tool_result", toolName: call.name, result: output }
       messages.push({ role: "tool", toolCallId: call.id, content: JSON.stringify(output) })

--- a/webui/src/features/agent/engine/tool-confirm-store.test.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.test.ts
@@ -6,30 +6,36 @@ beforeEach(() => useToolConfirm.setState({ pending: null }))
 
 
 describe("useToolConfirm", () => {
-  it("parks a request as pending and resolves true on allow", async () => {
+  it("parks a request as pending and resolves the decision on allow-once", async () => {
     const p = useToolConfirm.getState().request({ name: "fetch", args: { url: "x" } })
     expect(useToolConfirm.getState().pending?.name).toBe("fetch")
-    useToolConfirm.getState().resolve(true)
-    expect(await p).toBe(true)
+    useToolConfirm.getState().resolve("once")
+    expect(await p).toBe("once")
     expect(useToolConfirm.getState().pending).toBeNull()
   })
 
-  it("resolves false on decline", async () => {
-    const p = useToolConfirm.getState().request({ name: "fetch", args: {} })
-    useToolConfirm.getState().resolve(false)
-    expect(await p).toBe(false)
+  it("carries the 'always' decision through", async () => {
+    const p = useToolConfirm.getState().request({ name: "web_search", args: {} })
+    useToolConfirm.getState().resolve("always")
+    expect(await p).toBe("always")
   })
 
-  it("auto-declines a second request while one is pending (no clobber of the first)", async () => {
+  it("resolves 'deny' on decline", async () => {
+    const p = useToolConfirm.getState().request({ name: "fetch", args: {} })
+    useToolConfirm.getState().resolve("deny")
+    expect(await p).toBe("deny")
+  })
+
+  it("auto-denies a second request while one is pending (no clobber of the first)", async () => {
     const first = useToolConfirm.getState().request({ name: "fetch", args: { url: "a" } })
     const second = useToolConfirm.getState().request({ name: "code_interpreter", args: {} })
-    expect(await second).toBe(false) // new request fails closed
+    expect(await second).toBe("deny") // new request fails closed
     expect(useToolConfirm.getState().pending?.name).toBe("fetch") // first prompt untouched
-    useToolConfirm.getState().resolve(true)
-    expect(await first).toBe(true)
+    useToolConfirm.getState().resolve("once")
+    expect(await first).toBe("once")
   })
 
   it("resolve() is a no-op when nothing is pending", () => {
-    expect(() => useToolConfirm.getState().resolve(true)).not.toThrow()
+    expect(() => useToolConfirm.getState().resolve("once")).not.toThrow()
   })
 })

--- a/webui/src/features/agent/engine/tool-confirm-store.test.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest"
-import { useToolConfirm } from "./tool-confirm-store"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { resolveConfirmDecision, useToolConfirm } from "./tool-confirm-store"
 
 
 beforeEach(() => useToolConfirm.setState({ pending: null }))
@@ -37,5 +37,30 @@ describe("useToolConfirm", () => {
 
   it("resolve() is a no-op when nothing is pending", () => {
     expect(() => useToolConfirm.getState().resolve("once")).not.toThrow()
+  })
+})
+
+
+describe("resolveConfirmDecision", () => {
+  it("short-circuits a granted tool to 'once' WITHOUT opening the dialog", async () => {
+    const askDialog = vi.fn<() => Promise<"deny" | "once" | "always">>()
+    const decision = await resolveConfirmDecision("web_search", () => true, askDialog)
+    expect(decision).toBe("once") // not "always" — so it's re-checked every call (revocable mid-run)
+    expect(askDialog).not.toHaveBeenCalled()
+  })
+
+  it("defers to the dialog for a non-granted tool and returns its decision", async () => {
+    const askDialog = vi.fn(async () => "always" as const)
+    const decision = await resolveConfirmDecision("fetch", () => false, askDialog)
+    expect(askDialog).toHaveBeenCalledTimes(1)
+    expect(decision).toBe("always")
+  })
+
+  it("checks the grant per tool name (only the granted tool skips the prompt)", async () => {
+    const isAllowed = (t: string) => t === "web_search"
+    const ask = vi.fn(async () => "deny" as const)
+    expect(await resolveConfirmDecision("web_search", isAllowed, ask)).toBe("once")
+    expect(await resolveConfirmDecision("code_interpreter", isAllowed, ask)).toBe("deny")
+    expect(ask).toHaveBeenCalledTimes(1) // only the non-granted tool asked
   })
 })

--- a/webui/src/features/agent/engine/tool-confirm-store.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.ts
@@ -1,18 +1,13 @@
 import { create } from "zustand"
+import type { ToolConfirmDecision } from "./types"
+
+
+// Re-exported so existing importers keep their path; canonical home is types.ts.
+export type { ToolConfirmDecision } from "./types"
 
 
 /** A pending request to run an off-board tool, awaiting the user's decision. */
 export type ToolConfirmRequest = { name: string; args: Record<string, unknown> }
-
-
-/**
- * The user's answer to a confirm prompt:
- *  - `deny`   — don't run it (the loop also won't re-prompt this tool this run).
- *  - `once`   — run this call only; the next call to the tool prompts again.
- *  - `always` — run it, and auto-approve further calls to the SAME tool for the
- *    rest of this run (no more prompts). A deliberate broadening of consent.
- */
-export type ToolConfirmDecision = "deny" | "once" | "always"
 
 
 type Pending = (ToolConfirmRequest & { resolve: (decision: ToolConfirmDecision) => void }) | null

--- a/webui/src/features/agent/engine/tool-confirm-store.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.ts
@@ -49,3 +49,19 @@ export const useToolConfirm = create<ToolConfirmState>((set, get) => ({
     set({ pending: null })
   },
 }))
+
+
+/**
+ * Decide a confirm outcome without touching the UI. A standing per-tool grant
+ * (`isAutoAllowed`) short-circuits to `once` — run this call but do NOT record it
+ * in the run's approved set, so the grant is re-checked on every call and
+ * toggling it off mid-run takes effect on the very next call. Otherwise defer to
+ * the dialog. Kept as a pure function (ports injected) so it's unit-testable
+ * away from the submit hook.
+ */
+export const resolveConfirmDecision = (
+  toolName: string,
+  isAutoAllowed: (tool: string) => boolean,
+  askDialog: () => Promise<ToolConfirmDecision>,
+): Promise<ToolConfirmDecision> =>
+  isAutoAllowed(toolName) ? Promise.resolve("once") : askDialog()

--- a/webui/src/features/agent/engine/tool-confirm-store.ts
+++ b/webui/src/features/agent/engine/tool-confirm-store.ts
@@ -5,15 +5,25 @@ import { create } from "zustand"
 export type ToolConfirmRequest = { name: string; args: Record<string, unknown> }
 
 
-type Pending = (ToolConfirmRequest & { resolve: (ok: boolean) => void }) | null
+/**
+ * The user's answer to a confirm prompt:
+ *  - `deny`   — don't run it (the loop also won't re-prompt this tool this run).
+ *  - `once`   — run this call only; the next call to the tool prompts again.
+ *  - `always` — run it, and auto-approve further calls to the SAME tool for the
+ *    rest of this run (no more prompts). A deliberate broadening of consent.
+ */
+export type ToolConfirmDecision = "deny" | "once" | "always"
+
+
+type Pending = (ToolConfirmRequest & { resolve: (decision: ToolConfirmDecision) => void }) | null
 
 
 type ToolConfirmState = {
   pending: Pending
-  /** Ask the user to approve a tool run; resolves true (run) / false (decline). */
-  request: (req: ToolConfirmRequest) => Promise<boolean>
+  /** Ask the user to approve a tool run; resolves with their decision. */
+  request: (req: ToolConfirmRequest) => Promise<ToolConfirmDecision>
   /** Settle the pending request (from the confirm UI). No-op if nothing pending. */
-  resolve: (ok: boolean) => void
+  resolve: (decision: ToolConfirmDecision) => void
 }
 
 
@@ -29,13 +39,13 @@ export const useToolConfirm = create<ToolConfirmState>((set, get) => ({
     // One prompt at a time. If one is already open (a second/concurrent run),
     // decline the NEW request rather than clobbering the prompt the user is
     // deciding on — fail closed without disturbing the in-flight decision.
-    if (get().pending) return Promise.resolve(false)
-    return new Promise<boolean>((resolve) => set({ pending: { ...req, resolve } }))
+    if (get().pending) return Promise.resolve("deny")
+    return new Promise<ToolConfirmDecision>((resolve) => set({ pending: { ...req, resolve } }))
   },
-  resolve: (ok) => {
+  resolve: (decision) => {
     const p = get().pending
     if (!p) return
-    p.resolve(ok)
+    p.resolve(decision)
     set({ pending: null })
   },
 }))

--- a/webui/src/features/agent/engine/tool-result.test.ts
+++ b/webui/src/features/agent/engine/tool-result.test.ts
@@ -29,8 +29,14 @@ describe("tool-result contract", () => {
     expect(toolThrew("fetch", "raw string").message).toContain("raw string")
   })
 
-  it("isToolFailure discriminates failures from a tool's own output", () => {
+  it("isToolFailure is uniform across every failure origin", () => {
     expect(isToolFailure(userDeclined("x"))).toBe(true)
+    expect(isToolFailure(unknownTool("x"))).toBe(true)
+    expect(isToolFailure(toolThrew("x", new Error("e")))).toBe(true)
+    expect(isToolFailure(toolRejected("x", "e"))).toBe(true)
+  })
+
+  it("isToolFailure discriminates failures from a tool's own output", () => {
     expect(isToolFailure({ id: "n1", created: true })).toBe(false) // a tool's success output
     expect(isToolFailure({ error: "note not found" })).toBe(false) // a RAW soft error (not yet normalized)
     expect(isToolFailure(null)).toBe(false)

--- a/webui/src/features/agent/engine/tool-result.test.ts
+++ b/webui/src/features/agent/engine/tool-result.test.ts
@@ -3,12 +3,12 @@ import { isToolFailure, toolThrew, unknownTool, userDeclined } from "./tool-resu
 
 
 describe("tool-result contract", () => {
-  it("userDeclined names the tool, frames it as a permission choice, and says don't retry", () => {
+  it("userDeclined names the tool, frames it as a permission choice, scoped to this call", () => {
     const r = userDeclined("web_search")
     expect(r).toMatchObject({ ok: false, error: "user_declined", tool: "web_search" })
     expect(r.message).toContain("web_search")
     expect(r.message.toLowerCase()).toContain("declined")
-    expect(r.message.toLowerCase()).toContain("do not call")
+    expect(r.message.toLowerCase()).toContain("exact call") // per-call, not a tool-wide ban
   })
 
   it("unknownTool names the missing tool and steers back to valid ones", () => {

--- a/webui/src/features/agent/engine/tool-result.test.ts
+++ b/webui/src/features/agent/engine/tool-result.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { isToolFailure, toolThrew, unknownTool, userDeclined } from "./tool-result"
+
+
+describe("tool-result contract", () => {
+  it("userDeclined names the tool, frames it as a permission choice, and says don't retry", () => {
+    const r = userDeclined("web_search")
+    expect(r).toMatchObject({ ok: false, error: "user_declined", tool: "web_search" })
+    expect(r.message).toContain("web_search")
+    expect(r.message.toLowerCase()).toContain("declined")
+    expect(r.message.toLowerCase()).toContain("do not call")
+  })
+
+  it("unknownTool names the missing tool and steers back to valid ones", () => {
+    const r = unknownTool("frobnicate")
+    expect(r).toMatchObject({ ok: false, error: "unknown_tool", tool: "frobnicate" })
+    expect(r.message).toContain("frobnicate")
+    expect(r.message).toContain("no tool named")
+  })
+
+  it("toolThrew carries the tool name and the underlying error message", () => {
+    const r = toolThrew("code_interpreter", new Error("segfault"))
+    expect(r).toMatchObject({ ok: false, error: "tool_error", tool: "code_interpreter" })
+    expect(r.message).toContain("code_interpreter")
+    expect(r.message).toContain("segfault")
+  })
+
+  it("toolThrew stringifies a non-Error throw", () => {
+    expect(toolThrew("fetch", "raw string").message).toContain("raw string")
+  })
+
+  it("isToolFailure discriminates failures from a tool's own output", () => {
+    expect(isToolFailure(userDeclined("x"))).toBe(true)
+    expect(isToolFailure({ id: "n1", created: true })).toBe(false) // a tool's success output
+    expect(isToolFailure({ error: "note not found" })).toBe(false) // a tool's soft error (no `ok`)
+    expect(isToolFailure(null)).toBe(false)
+    expect(isToolFailure("declined")).toBe(false)
+  })
+})

--- a/webui/src/features/agent/engine/tool-result.test.ts
+++ b/webui/src/features/agent/engine/tool-result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { isToolFailure, toolThrew, unknownTool, userDeclined } from "./tool-result"
+import { isToolFailure, isToolSoftError, toolRejected, toolThrew, unknownTool, userDeclined } from "./tool-result"
 
 
 describe("tool-result contract", () => {
@@ -32,8 +32,22 @@ describe("tool-result contract", () => {
   it("isToolFailure discriminates failures from a tool's own output", () => {
     expect(isToolFailure(userDeclined("x"))).toBe(true)
     expect(isToolFailure({ id: "n1", created: true })).toBe(false) // a tool's success output
-    expect(isToolFailure({ error: "note not found" })).toBe(false) // a tool's soft error (no `ok`)
+    expect(isToolFailure({ error: "note not found" })).toBe(false) // a RAW soft error (not yet normalized)
     expect(isToolFailure(null)).toBe(false)
     expect(isToolFailure("declined")).toBe(false)
+  })
+
+  it("isToolSoftError recognizes the tool `{ error }` convention only", () => {
+    expect(isToolSoftError({ error: "note not found" })).toBe(true)
+    expect(isToolSoftError({ error: "" })).toBe(false) // empty isn't a failure signal
+    expect(isToolSoftError({ id: "n1", created: true })).toBe(false) // a success output
+    expect(isToolSoftError(toolRejected("create_note", "x"))).toBe(false) // already a ToolFailure (has `ok`)
+    expect(isToolSoftError(null)).toBe(false)
+  })
+
+  it("toolRejected normalizes a tool error into the shared failure shape", () => {
+    const r = toolRejected("create_note", "note not found")
+    expect(r).toEqual({ ok: false, error: "tool_rejected", tool: "create_note", message: "note not found" })
+    expect(isToolFailure(r)).toBe(true) // one uniform "did it fail?" check across all origins
   })
 })

--- a/webui/src/features/agent/engine/tool-result.ts
+++ b/webui/src/features/agent/engine/tool-result.ts
@@ -14,7 +14,7 @@
  */
 
 
-export type ToolErrorCode = "user_declined" | "unknown_tool" | "tool_error"
+export type ToolErrorCode = "user_declined" | "unknown_tool" | "tool_error" | "tool_rejected"
 
 
 /** A structured tool-call failure fed back to the model as the tool result. */
@@ -32,6 +32,30 @@ export const isToolFailure = (result: unknown): result is ToolFailure =>
   result !== null &&
   (result as { ok?: unknown }).ok === false &&
   typeof (result as { message?: unknown }).message === "string"
+
+
+/**
+ * The failure convention for tool authors: a tool signals a rejection (bad
+ * args, not found, validation) by returning `{ error: string }`. Detected here
+ * so `executeToolCall` can normalize it into a `ToolFailure` — keeping tools
+ * simple while the runtime/UI get one uniform failure shape. Not matched once a
+ * result is already a `ToolFailure` (has `ok`).
+ */
+export const isToolSoftError = (result: unknown): result is { error: string } =>
+  typeof result === "object" &&
+  result !== null &&
+  !("ok" in result) &&
+  typeof (result as { error?: unknown }).error === "string" &&
+  (result as { error: string }).error.length > 0
+
+
+/** Normalize a tool's own `{ error }` rejection into the shared failure shape. */
+export const toolRejected = (tool: string, message: string): ToolFailure => ({
+  ok: false,
+  error: "tool_rejected",
+  tool,
+  message,
+})
 
 
 /**

--- a/webui/src/features/agent/engine/tool-result.ts
+++ b/webui/src/features/agent/engine/tool-result.ts
@@ -14,6 +14,12 @@
  */
 
 
+/**
+ * Failure codes, by origin: `user_declined` (confirm gate), `unknown_tool` (no
+ * such tool), `tool_error` (the tool THREW — a crash, may be transient), and
+ * `tool_rejected` (the tool RAN and returned `{error}` — a deliberate rejection
+ * like bad args / not found).
+ */
 export type ToolErrorCode = "user_declined" | "unknown_tool" | "tool_error" | "tool_rejected"
 
 

--- a/webui/src/features/agent/engine/tool-result.ts
+++ b/webui/src/features/agent/engine/tool-result.ts
@@ -35,20 +35,21 @@ export const isToolFailure = (result: unknown): result is ToolFailure =>
 
 
 /**
- * The user declined an off-board tool at the confirm gate. Framed as a
- * permission choice (not a failure) with an explicit do-not-retry, so the model
- * neither loops nor causes the dialog to reopen.
+ * The user declined THIS specific off-board tool call at the confirm gate.
+ * Framed as a permission choice (not a failure), scoped to this call: a
+ * different call of the same tool may still be allowed, but repeating this exact
+ * call is pointless (it's remembered and auto-declined).
  */
 export const userDeclined = (tool: string): ToolFailure => ({
   ok: false,
   error: "user_declined",
   tool,
   message:
-    `The user declined to approve the "${tool}" tool for this request. This is a ` +
-    `permission choice, not a failure or a transient error. Do not call "${tool}" ` +
-    `again for this request. Continue using what you already know; if the task ` +
-    `genuinely requires it, briefly tell the user you could not use "${tool}" ` +
-    `because the request was not approved.`,
+    `The user declined this "${tool}" request — a permission choice, not a failure ` +
+    `or a transient error. Don't repeat this exact call. A genuinely different ` +
+    `"${tool}" request may still be allowed if the task needs it; otherwise ` +
+    `continue with what you already have and, if it matters, tell the user this ` +
+    `request wasn't approved.`,
 })
 
 

--- a/webui/src/features/agent/engine/tool-result.ts
+++ b/webui/src/features/agent/engine/tool-result.ts
@@ -1,0 +1,75 @@
+/**
+ * Uniform result contract for a single tool call in the browser agent loop.
+ *
+ * A successful call returns the tool's own output verbatim. A failure — the user
+ * declining an off-board tool, an unknown tool, or a thrown error — is shaped
+ * here into a structured, model-directed object instead of a terse, inconsistent
+ * string. `error` is a stable machine code (for the UI / telemetry); `message`
+ * is the natural-language guidance the model reads, so it understands what
+ * happened and what to do next (e.g. that web search was refused, and why).
+ *
+ * This is the frontend analog of the backend's tool decorator error contract —
+ * keeping both runtimes' tool-error semantics aligned as the server agent is
+ * retired.
+ */
+
+
+export type ToolErrorCode = "user_declined" | "unknown_tool" | "tool_error"
+
+
+/** A structured tool-call failure fed back to the model as the tool result. */
+export type ToolFailure = {
+  ok: false
+  error: ToolErrorCode
+  tool: string
+  message: string
+}
+
+
+/** True when a tool result is a structured failure (vs a tool's own output). */
+export const isToolFailure = (result: unknown): result is ToolFailure =>
+  typeof result === "object" &&
+  result !== null &&
+  (result as { ok?: unknown }).ok === false &&
+  typeof (result as { message?: unknown }).message === "string"
+
+
+/**
+ * The user declined an off-board tool at the confirm gate. Framed as a
+ * permission choice (not a failure) with an explicit do-not-retry, so the model
+ * neither loops nor causes the dialog to reopen.
+ */
+export const userDeclined = (tool: string): ToolFailure => ({
+  ok: false,
+  error: "user_declined",
+  tool,
+  message:
+    `The user declined to approve the "${tool}" tool for this request. This is a ` +
+    `permission choice, not a failure or a transient error. Do not call "${tool}" ` +
+    `again for this request. Continue using what you already know; if the task ` +
+    `genuinely requires it, briefly tell the user you could not use "${tool}" ` +
+    `because the request was not approved.`,
+})
+
+
+/** The model called a tool that isn't in this run's toolset. */
+export const unknownTool = (tool: string): ToolFailure => ({
+  ok: false,
+  error: "unknown_tool",
+  tool,
+  message:
+    `There is no tool named "${tool}". Only call tools that were provided to you. ` +
+    `Pick a valid tool for this step, or answer directly if none applies.`,
+})
+
+
+/** A tool threw while running (e.g. a managed service 500 or a network error). */
+export const toolThrew = (tool: string, err: unknown): ToolFailure => ({
+  ok: false,
+  error: "tool_error",
+  tool,
+  message:
+    `The "${tool}" tool failed with an error: ${err instanceof Error ? err.message : String(err)}. ` +
+    `You may retry once if this looks transient; otherwise continue without it and ` +
+    `tell the user what could not be completed.`,
+})

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -10,7 +10,26 @@ import { z } from "zod"
 import type { CanvasStore } from "@canvas-harness/core"
 import type { BoardRegistry } from "@/features/board/persist/local/board-registry"
 import type { LocalSearchIndex } from "@/features/board/search/local-index"
-import type { ToolConfirmDecision } from "./tool-confirm-store"
+
+
+/**
+ * Off-board tools gated by the confirm dialog — network egress + code execution.
+ * The single source of truth: the loop's gate (`CONFIRM_TOOLS`) and the settings
+ * trust store both derive from this, so a new gated tool is added in one place.
+ */
+export const CONFIRM_TOOL_NAMES = ["web_search", "fetch", "code_interpreter"] as const
+
+
+/** A gated off-board tool name. */
+export type ConfirmToolName = (typeof CONFIRM_TOOL_NAMES)[number]
+
+
+/**
+ * The user's answer to a confirm prompt: `deny` (don't run — the exact call is
+ * remembered and won't re-prompt), `once` (run this call only), `always` (run +
+ * auto-approve further calls to the same tool this run).
+ */
+export type ToolConfirmDecision = "deny" | "once" | "always"
 
 
 export type LlmToolCall = { id: string; name: string; arguments: string }

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -10,6 +10,7 @@ import { z } from "zod"
 import type { CanvasStore } from "@canvas-harness/core"
 import type { BoardRegistry } from "@/features/board/persist/local/board-registry"
 import type { LocalSearchIndex } from "@/features/board/search/local-index"
+import type { ToolConfirmDecision } from "./tool-confirm-store"
 
 
 export type LlmToolCall = { id: string; name: string; arguments: string }
@@ -70,12 +71,13 @@ export type ToolContext = {
   registry?: BoardRegistry
   /**
    * Optional gate for side-effecting / off-board tools (network egress, code
-   * execution). The loop calls it before running such a tool; resolve `true` to
-   * run, `false` to decline (the model gets a "declined" result and adapts).
+   * execution). The loop calls it before running such a tool; the decision is
+   * `deny` (model gets a "declined" result and adapts), `once` (run this call),
+   * or `always` (run + auto-approve further calls to the same tool this run).
    * When absent (tests / headless), gated tools run unprompted — the gate is a
    * UI concern wired only by the local submit path.
    */
-  confirmTool?: (req: { name: string; args: Record<string, unknown> }) => Promise<boolean>
+  confirmTool?: (req: { name: string; args: Record<string, unknown> }) => Promise<ToolConfirmDecision>
 }
 
 

--- a/webui/src/features/agent/local/agent-event-to-step.test.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.test.ts
@@ -26,6 +26,24 @@ describe("stepsFromEvents", () => {
   })
 
 
+  it("marks a step failed and shows the message when the result is a ToolFailure", () => {
+    const events: AgentEvent[] = [
+      { type: "tool_start", toolName: "web_search", args: { query: "x" } },
+      {
+        type: "tool_result",
+        toolName: "web_search",
+        result: { ok: false, error: "user_declined", tool: "web_search", message: "The user declined this request." },
+      },
+    ]
+    const [tool] = stepsFromEvents(events, "b")
+    expect(tool.type).toBe("tool_call")
+    if (tool.type === "tool_call") {
+      expect(tool.state).toBe("failed")
+      expect(tool.output).toBe("The user declined this request.")
+    }
+  })
+
+
   it("maps update_note → edit_note and link_notes correctly", () => {
     const events: AgentEvent[] = [
       { type: "tool_start", toolName: "update_note", args: { id: "n1", title: "B" } },

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -2,6 +2,7 @@ import type { ReasoningStep, ToolCallStep, ToolName } from "@/features/agent/typ
 import { normalizeReasoningSteps } from "@/features/agent/types/stream"
 import type { ToolOutput, UrlAnnotation } from "@/features/agent/types/tool-outputs"
 import type { AgentEvent } from "@/features/agent/engine/types"
+import { isToolFailure } from "@/features/agent/engine/tool-result"
 
 
 const field = (o: unknown, k: string): unknown =>
@@ -136,8 +137,15 @@ export const stepsFromEvents = (events: AgentEvent[], boardId: string): Reasonin
     } else if (ev.type === "tool_result") {
       const open = openByTool.get(ev.toolName)
       if (open) {
-        open.output = toOutput(ev.toolName, open.arguments?.input, ev.result, boardId)
-        open.state = "completed"
+        // A structured failure (declined / unknown / thrown / rejected) marks the
+        // step failed and shows its message; a success builds the UI output.
+        if (isToolFailure(ev.result)) {
+          open.output = ev.result.message
+          open.state = "failed"
+        } else {
+          open.output = toOutput(ev.toolName, open.arguments?.input, ev.result, boardId)
+          open.state = "completed"
+        }
         openByTool.delete(ev.toolName)
       }
     } else if (ev.type === "assistant_text") {

--- a/webui/src/features/agent/local/chat-history.test.ts
+++ b/webui/src/features/agent/local/chat-history.test.ts
@@ -13,6 +13,15 @@ const user = (text: string): ChatMessage => ({
 })
 
 
+const userWithContext = (text: string, context: string): ChatMessage => ({
+  id: `u-${text}`,
+  role: "user",
+  content: { markdown: text },
+  chatUid: "c1",
+  properties: { context: { type: "text", text: context } },
+})
+
+
 const assistant = (text: string, reasoning: ReasoningStep[] = []): ChatMessage => ({
   id: `a-${text}`,
   role: "assistant",
@@ -61,6 +70,23 @@ describe("toLlmHistory", () => {
     const history = toLlmHistory([user("build"), assistant("", [createNoteStep("n9", "X")])])
     expect(history).toHaveLength(2)
     expect(history[1].content).toContain("create_note")
+  })
+
+
+  it("re-wraps a past user turn's selected-note context (mirrors the backend)", () => {
+    const ctx = "<SelectedNote>\nNoteId: n1\nTitle: Cats\n</SelectedNote>"
+    const [first] = toLlmHistory([
+      userWithContext("expand it", ctx),
+      assistant("sure"),
+    ])
+    // The agent must still see WHAT "it" referred to on a reloaded conversation.
+    expect(first.content).toBe(`<MessageContext>\n\n${ctx}\n\n</MessageContext>\n\nexpand it`)
+  })
+
+
+  it("leaves a user turn without context as bare text", () => {
+    const [first] = toLlmHistory([user("hi"), assistant("hello")])
+    expect(first.content).toBe("hi") // no empty <MessageContext> envelope
   })
 
 

--- a/webui/src/features/agent/local/chat-history.ts
+++ b/webui/src/features/agent/local/chat-history.ts
@@ -10,6 +10,7 @@ import type { LlmMessage } from "@/features/agent/engine/types"
 import type { ReasoningStep } from "@/features/agent/types/stream"
 import { isToolCallStep } from "@/features/agent/types/stream"
 import type { ToolOutput } from "@/features/agent/types/tool-outputs"
+import { wrapWithMessageContext } from "./message-context"
 
 
 // Recent turns fed back as context. Mirrors the backend AssistantSession
@@ -84,7 +85,13 @@ const compactReasoning = (steps: ReasoningStep[]): string => {
 /** A message's LLM content: assistant turns prepend their reasoning/tool traces. */
 const compactMessageContent = (message: ChatMessage): string => {
   const markdown = message.content.markdown?.trim() ?? ""
-  if (message.role !== "assistant") return markdown
+  if (message.role !== "assistant") {
+    // Mirror the backend's `to_chat_message`: a past user turn re-includes the
+    // selected-note context it was sent with, so cross-turn references ("expand
+    // it") stay resolvable. wrapWithMessageContext emits the same envelope the
+    // live turn uses, and returns the bare prompt when there's no context.
+    return wrapWithMessageContext(markdown, message.properties?.context?.text)
+  }
   const reasoning = compactReasoning(message.properties?.reasoning?.reasoning ?? [])
   return reasoning ? `${reasoning}\n\n${markdown}`.trim() : markdown
 }

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -19,7 +19,7 @@ import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
 import { rebuildDocIndex } from "@/features/board/search/use-doc-index"
 import { getLocalStores } from "@/features/local-stores"
 import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
-import { useToolConfirm, type ToolConfirmDecision } from "@/features/agent/engine/tool-confirm-store"
+import { resolveConfirmDecision, useToolConfirm, type ToolConfirmDecision } from "@/features/agent/engine/tool-confirm-store"
 import { useToolTrustStore } from "@/features/agent/settings/tool-trust-store"
 import type { AgentEvent } from "@/features/agent/engine/types"
 import { planSystemPrompt } from "@/features/agent/prompts"
@@ -204,13 +204,14 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         // Gate off-board tools (network/code) behind a user confirmation, so a
         // prompt-injected tool call can't silently exfiltrate or run code. A
         // standing per-tool "always allow" grant (Settings) skips the prompt for
-        // that tool — read at call time so a mid-run toggle applies.
-        const confirmTool = (req: { name: string; args: Record<string, unknown> }): Promise<ToolConfirmDecision> => {
-          if (useToolTrustStore.getState().isAutoAllowed(req.name)) {
-            return Promise.resolve("always")
-          }
-          return useToolConfirm.getState().request(req)
-        }
+        // that tool. Both ports are read via getState() per call, so a mid-run
+        // toggle (on OR off) applies to the next call.
+        const confirmTool = (req: { name: string; args: Record<string, unknown> }): Promise<ToolConfirmDecision> =>
+          resolveConfirmDecision(
+            req.name,
+            useToolTrustStore.getState().isAutoAllowed,
+            () => useToolConfirm.getState().request(req),
+          )
         for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search, confirmTool } })) {
           // Streaming yields a cumulative assistant_text per token — replace the
           // previous snapshot in place instead of appending one event per token.

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -19,7 +19,8 @@ import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
 import { rebuildDocIndex } from "@/features/board/search/use-doc-index"
 import { getLocalStores } from "@/features/local-stores"
 import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
-import { useToolConfirm } from "@/features/agent/engine/tool-confirm-store"
+import { useToolConfirm, type ToolConfirmDecision } from "@/features/agent/engine/tool-confirm-store"
+import { useToolTrustStore } from "@/features/agent/settings/tool-trust-store"
 import type { AgentEvent } from "@/features/agent/engine/types"
 import { planSystemPrompt } from "@/features/agent/prompts"
 import { useByokStore } from "@/features/agent/byok/byok-store"
@@ -201,9 +202,15 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
           : system
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
         // Gate off-board tools (network/code) behind a user confirmation, so a
-        // prompt-injected tool call can't silently exfiltrate or run code.
-        const confirmTool = (req: { name: string; args: Record<string, unknown> }) =>
-          useToolConfirm.getState().request(req)
+        // prompt-injected tool call can't silently exfiltrate or run code. A
+        // standing per-tool "always allow" grant (Settings) skips the prompt for
+        // that tool — read at call time so a mid-run toggle applies.
+        const confirmTool = (req: { name: string; args: Record<string, unknown> }): Promise<ToolConfirmDecision> => {
+          if (useToolTrustStore.getState().isAutoAllowed(req.name)) {
+            return Promise.resolve("always")
+          }
+          return useToolConfirm.getState().request(req)
+        }
         for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search, confirmTool } })) {
           // Streaming yields a cumulative assistant_text per token — replace the
           // previous snapshot in place instead of appending one event per token.

--- a/webui/src/features/agent/settings/settings-dialog.tsx
+++ b/webui/src/features/agent/settings/settings-dialog.tsx
@@ -11,6 +11,8 @@ import {
 import { cn } from "@/lib/utils"
 import { useIsSignedIn } from "@/lib/auth"
 import { useByokStore, type SearchEngine } from "@/features/agent/byok/byok-store"
+import { useToolTrustStore, type ConfirmToolName } from "@/features/agent/settings/tool-trust-store"
+import { Switch } from "@/components/ui/switch"
 import { ByokKeyForm } from "@/features/agent/byok/byok-key-form"
 import { ModelChoiceMenu } from "@/features/agent/components/chat/input-settings/model-card"
 import { useChatStore } from "@/features/agent/store/chat-store"
@@ -286,6 +288,27 @@ function ProvidersPane() {
 
 
 /**
+ * A standing "always allow" grant for one off-board tool. When on, the agent
+ * skips the per-call confirm prompt for that tool (this device only). Per-tool
+ * on purpose — trusting web search shouldn't silently trust code execution.
+ */
+function TrustToolRow({ tool, title, description }: { tool: ConfirmToolName; title: string; description: string }) {
+  const on = useToolTrustStore((s) => s.autoAllow[tool])
+  const setAutoAllow = useToolTrustStore((s) => s.setAutoAllow)
+
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2.5">
+      <div className="min-w-0">
+        <div className="text-sm">{title}</div>
+        <div className="text-[11px] text-muted-foreground">{description}</div>
+      </div>
+      <Switch checked={on} onCheckedChange={(v) => setAutoAllow(tool, v)} label={title} />
+    </div>
+  )
+}
+
+
+/**
  * Web search: a list of engine options with a usable marker. Available engines
  * (our keys when signed in, or a saved BYOK key) are selectable; the rest are
  * greyed until you add a key below. The picked engine is the one the agent uses;
@@ -314,6 +337,17 @@ function SearchPane() {
   return (
     <div>
       <PaneTitle title="Web search" hint="Pick a provider. Available ones use our keys; add your own key to enable another (relayed, never stored)." />
+
+      <TrustToolRow
+        tool="web_search"
+        title="Always allow web search"
+        description="Skip the confirmation prompt for web searches on this device."
+      />
+      <TrustToolRow
+        tool="fetch"
+        title="Always allow fetching web pages"
+        description="Skip the prompt when the assistant opens a URL. Only enable if you trust the pages your boards link to."
+      />
 
       <div className="mb-4 overflow-hidden rounded-lg border border-border">
         {SEARCH_ENGINES.map((e) => {
@@ -369,6 +403,11 @@ function CodePane() {
   return (
     <div>
       <PaneTitle title="Code interpreter" hint="Runs in a Daytona sandbox. Add your Daytona key to run on your own account (relayed, never stored)." />
+      <TrustToolRow
+        tool="code_interpreter"
+        title="Always allow running code"
+        description="Skip the confirmation prompt before the assistant runs code. It runs in a sandbox, but only enable if you understand the risk."
+      />
       <div className="mb-2 flex items-center gap-2 text-xs font-medium">
         <StatusDot usable={usable} />
         Daytona

--- a/webui/src/features/agent/settings/tool-trust-store.test.ts
+++ b/webui/src/features/agent/settings/tool-trust-store.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useToolTrustStore } from "./tool-trust-store"
+
+
+const KEY = "dim0.tool_trust"
+
+
+beforeEach(() => {
+  localStorage.clear()
+  useToolTrustStore.setState({ autoAllow: { web_search: false, fetch: false, code_interpreter: false } })
+})
+
+
+describe("useToolTrustStore", () => {
+  it("defaults every off-board tool to off (gate on)", () => {
+    const { isAutoAllowed } = useToolTrustStore.getState()
+    expect(isAutoAllowed("web_search")).toBe(false)
+    expect(isAutoAllowed("fetch")).toBe(false)
+    expect(isAutoAllowed("code_interpreter")).toBe(false)
+  })
+
+  it("grants per tool, independently — trusting one doesn't trust the others", () => {
+    useToolTrustStore.getState().setAutoAllow("web_search", true)
+    const { isAutoAllowed } = useToolTrustStore.getState()
+    expect(isAutoAllowed("web_search")).toBe(true)
+    expect(isAutoAllowed("fetch")).toBe(false)
+    expect(isAutoAllowed("code_interpreter")).toBe(false)
+  })
+
+  it("persists the whole grant map and reads back the change", () => {
+    useToolTrustStore.getState().setAutoAllow("code_interpreter", true)
+    expect(useToolTrustStore.getState().isAutoAllowed("code_interpreter")).toBe(true)
+    expect(JSON.parse(localStorage.getItem(KEY) ?? "{}")).toMatchObject({ code_interpreter: true })
+  })
+
+  it("toggling back off persists too (revocable)", () => {
+    useToolTrustStore.getState().setAutoAllow("fetch", true)
+    useToolTrustStore.getState().setAutoAllow("fetch", false)
+    expect(useToolTrustStore.getState().isAutoAllowed("fetch")).toBe(false)
+    expect(JSON.parse(localStorage.getItem(KEY) ?? "{}")).toMatchObject({ fetch: false })
+  })
+
+  it("isAutoAllowed is safe for an unknown tool name", () => {
+    expect(useToolTrustStore.getState().isAutoAllowed("create_note")).toBe(false)
+  })
+
+  it("persists independently of any BYOK key (managed-mode users keep the grant)", () => {
+    // Regression guard for why this isn't in byok-store, whose persist() drops
+    // everything when no key is set.
+    useToolTrustStore.getState().setAutoAllow("web_search", true)
+    expect(localStorage.getItem(KEY)).toBeTruthy()
+    expect(localStorage.getItem("dim0.byok")).toBeNull()
+  })
+})

--- a/webui/src/features/agent/settings/tool-trust-store.test.ts
+++ b/webui/src/features/agent/settings/tool-trust-store.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import { useToolTrustStore } from "./tool-trust-store"
+import { loadToolTrust, useToolTrustStore } from "./tool-trust-store"
 
 
 const KEY = "dim0.tool_trust"
@@ -50,5 +50,29 @@ describe("useToolTrustStore", () => {
     useToolTrustStore.getState().setAutoAllow("web_search", true)
     expect(localStorage.getItem(KEY)).toBeTruthy()
     expect(localStorage.getItem("dim0.byok")).toBeNull()
+  })
+})
+
+
+describe("loadToolTrust (rehydration)", () => {
+  it("returns all-off when nothing is stored", () => {
+    localStorage.clear()
+    expect(loadToolTrust()).toEqual({ web_search: false, fetch: false, code_interpreter: false })
+  })
+
+  it("rehydrates a stored grant map", () => {
+    localStorage.setItem(KEY, JSON.stringify({ web_search: true, code_interpreter: true }))
+    expect(loadToolTrust()).toEqual({ web_search: true, fetch: false, code_interpreter: true })
+  })
+
+  it("coerces a partial payload — missing keys default to off", () => {
+    localStorage.setItem(KEY, JSON.stringify({ fetch: true }))
+    expect(loadToolTrust()).toEqual({ web_search: false, fetch: true, code_interpreter: false })
+  })
+
+  it("falls back to all-off on corrupt (non-JSON) storage — never throws", () => {
+    localStorage.setItem(KEY, "{not json")
+    expect(() => loadToolTrust()).not.toThrow()
+    expect(loadToolTrust()).toEqual({ web_search: false, fetch: false, code_interpreter: false })
   })
 })

--- a/webui/src/features/agent/settings/tool-trust-store.ts
+++ b/webui/src/features/agent/settings/tool-trust-store.ts
@@ -1,4 +1,9 @@
 import { create } from "zustand"
+import { CONFIRM_TOOL_NAMES, type ConfirmToolName } from "@/features/agent/engine/types"
+
+
+// Re-exported so settings-dialog keeps importing it from here; canonical in types.ts.
+export type { ConfirmToolName } from "@/features/agent/engine/types"
 
 
 /**
@@ -16,33 +21,24 @@ import { create } from "zustand"
 const STORAGE_KEY = "dim0.tool_trust"
 
 
-/** The off-board tools gated by the confirm dialog — keep in sync with
- *  `CONFIRM_TOOLS` in agent-loop.ts. */
-export type ConfirmToolName = "web_search" | "fetch" | "code_interpreter"
-
-
-const ALL_OFF = (): Record<ConfirmToolName, boolean> => ({
-  web_search: false,
-  fetch: false,
-  code_interpreter: false,
-})
+const ALL_OFF = (): Record<ConfirmToolName, boolean> =>
+  Object.fromEntries(CONFIRM_TOOL_NAMES.map((n) => [n, false])) as Record<ConfirmToolName, boolean>
 
 
 /**
  * Read the persisted grant map from localStorage, tolerant of a missing,
  * corrupt, or partial payload (each missing/garbage field defaults to off).
- * Exported for testing the rehydration path. Never throws.
+ * Derives the tool set from `CONFIRM_TOOL_NAMES`, so a new gated tool is covered
+ * automatically. Exported for testing the rehydration path. Never throws.
  */
 export const loadToolTrust = (): Record<ConfirmToolName, boolean> => {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return ALL_OFF()
     const parsed = JSON.parse(raw) as Partial<Record<ConfirmToolName, boolean>>
-    return {
-      web_search: Boolean(parsed.web_search),
-      fetch: Boolean(parsed.fetch),
-      code_interpreter: Boolean(parsed.code_interpreter),
-    }
+    return Object.fromEntries(
+      CONFIRM_TOOL_NAMES.map((n) => [n, Boolean(parsed[n])]),
+    ) as Record<ConfirmToolName, boolean>
   } catch {
     return ALL_OFF()
   }

--- a/webui/src/features/agent/settings/tool-trust-store.ts
+++ b/webui/src/features/agent/settings/tool-trust-store.ts
@@ -28,7 +28,12 @@ const ALL_OFF = (): Record<ConfirmToolName, boolean> => ({
 })
 
 
-const load = (): Record<ConfirmToolName, boolean> => {
+/**
+ * Read the persisted grant map from localStorage, tolerant of a missing,
+ * corrupt, or partial payload (each missing/garbage field defaults to off).
+ * Exported for testing the rehydration path. Never throws.
+ */
+export const loadToolTrust = (): Record<ConfirmToolName, boolean> => {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return ALL_OFF()
@@ -54,7 +59,7 @@ type ToolTrustState = {
 
 
 export const useToolTrustStore = create<ToolTrustState>((set, get) => ({
-  autoAllow: load(),
+  autoAllow: loadToolTrust(),
   isAutoAllowed: (tool) => Boolean((get().autoAllow as Record<string, boolean>)[tool]),
   setAutoAllow: (tool, on) => {
     const autoAllow = { ...get().autoAllow, [tool]: on }

--- a/webui/src/features/agent/settings/tool-trust-store.ts
+++ b/webui/src/features/agent/settings/tool-trust-store.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand"
+
+
+/**
+ * Persistent, device-local trust preferences for the off-board tool confirm
+ * gate. Kept separate from `byok-store` on purpose: this must persist even with
+ * no BYOK key set (managed web search / fetch are the common case), whereas
+ * byok-store only writes localStorage when a key exists.
+ *
+ * Each `autoAllow[tool]` is a standing "always allow" grant surfaced in Settings
+ * — a deliberate, revocable opt-in that skips the per-call prompt across runs
+ * for that ONE tool. Per-tool on purpose: trusting web search shouldn't silently
+ * trust code execution.
+ */
+
+const STORAGE_KEY = "dim0.tool_trust"
+
+
+/** The off-board tools gated by the confirm dialog — keep in sync with
+ *  `CONFIRM_TOOLS` in agent-loop.ts. */
+export type ConfirmToolName = "web_search" | "fetch" | "code_interpreter"
+
+
+const ALL_OFF = (): Record<ConfirmToolName, boolean> => ({
+  web_search: false,
+  fetch: false,
+  code_interpreter: false,
+})
+
+
+const load = (): Record<ConfirmToolName, boolean> => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return ALL_OFF()
+    const parsed = JSON.parse(raw) as Partial<Record<ConfirmToolName, boolean>>
+    return {
+      web_search: Boolean(parsed.web_search),
+      fetch: Boolean(parsed.fetch),
+      code_interpreter: Boolean(parsed.code_interpreter),
+    }
+  } catch {
+    return ALL_OFF()
+  }
+}
+
+
+type ToolTrustState = {
+  autoAllow: Record<ConfirmToolName, boolean>
+  /** True when `tool` has a standing grant (safe to pass any tool name). */
+  isAutoAllowed: (tool: string) => boolean
+  /** Toggle a tool's standing grant and persist it on this device. */
+  setAutoAllow: (tool: ConfirmToolName, on: boolean) => void
+}
+
+
+export const useToolTrustStore = create<ToolTrustState>((set, get) => ({
+  autoAllow: load(),
+  isAutoAllowed: (tool) => Boolean((get().autoAllow as Record<string, boolean>)[tool]),
+  setAutoAllow: (tool, on) => {
+    const autoAllow = { ...get().autoAllow, [tool]: on }
+    set({ autoAllow })
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(autoAllow))
+    } catch {
+      // storage unavailable — the preference stays in-memory for this session
+    }
+  },
+}))


### PR DESCRIPTION
Stacked on #172 (base = `phase23/local-agent-on-synced`) so the diff is just this change.

## Why
When the user declines an off-board tool (web search / fetch / code), the browser agent loop fed back a bare `{ error: "declined by user" }` — terse, tool-anonymous, no guidance, and inconsistent with the loop's other error strings (`unknown tool: x`, raw `err.message`). The decline policy was also inline in the loop, and a model that retried a declined tool would reopen the confirm dialog (nag loop). This formalizes the contract and centralizes it — the frontend analog of the backend's tool decorator.

## What
- **`tool-result.ts`** — the `ToolFailure` contract `{ ok, error, tool, message }` with builders `userDeclined` / `unknownTool` / `toolThrew`. `error` is a stable machine code (UI/telemetry); `message` is model-directed natural language: what happened + what to do next. A decline reads as a *permission choice, not a failure*, with an explicit do-not-retry and "answer with what you have / tell the user it wasn't approved".
- **`executeToolCall`** — one tool-execution choke point: unknown-tool guard, the confirm gate, and error normalization in a single place. Confirm + run share one try/catch, so a throwing confirmer or tool never aborts the run.
- **No re-prompt** — a per-run `declinedTools` set fails a re-called declined tool closed *without* reopening the dialog.

## Example fed to the model on "No"
```json
{
  "ok": false,
  "error": "user_declined",
  "tool": "web_search",
  "message": "The user declined to approve the \"web_search\" tool for this request. This is a permission choice, not a failure or a transient error. Do not call \"web_search\" again this turn. Continue using what you already know; if the task genuinely requires it, briefly tell the user you could not use \"web_search\" because the request was not approved."
}
```

## Tests
Contract builders + `isToolFailure`; `executeToolCall` across unknown / non-gated / approved / declined / repeat-declined / throwing / no-confirmer; and a `runAgent` integration proving one prompt then auto-decline on retry. Existing loop tests updated to the new shape. `type-check` + `eslint` clean; 39 tests pass.

Depends on #172 (the dialog-mount fix that stops the hang); merge that first.
