### PR TITLE
fix(billing): OSS deploys resolve to plus everywhere (plan reporting matched to enforcement)

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -15,4 +15,5 @@ Applies to `backend/**` (package `topix`). Repo-wide rules (commits) are in the 
 - **Collab is the only edit path:** human WS ops and the in-process agent (`collab/agent_bridge.py`) both allocate a seq from the oplog, apply to `GraphStore`, and broadcast a `peer-op`. Seq authority is the oplog, not `room.seq`.
 - Two agent execution models coexist: the server-side OpenAI-Agents agent (`agents/`) and the thin `/ai/*` proxies for the browser engine (`api/router/ai.py`).
 - `chat_transcript` stores browser-agent transcripts as opaque JSON (never the `Message` model) — see `docs/adr/ADR-AGENT-001` before changing that path.
-- Models resolve via `config/catalog.py` over `backend/topix/models.yml` (one YAML entry per model; first route whose provider key is present wins). Billing off → plan resolves to `plus`.
+- Models resolve via `config/catalog.py` over `backend/topix/models.yml` (one YAML entry per model; first route whose provider key is present wins).
+- Billing off (`is_billing_active()` false — flag off OR Stripe keys missing) → full-OSS: plan resolves to `plus`, no limits, resolved through the one `resolve_effective_plan` helper. See `docs/adr/ADR-BILLING-001`.

--- a/backend/test/unit/api/router/test_billing_me_router.py
+++ b/backend/test/unit/api/router/test_billing_me_router.py
@@ -1,0 +1,67 @@
+"""Router tests for GET /billing/me — the plan the settings UI reads.
+
+Pins the OSS regression: with billing inactive the endpoint MUST report `plus` +
+`billing_enabled: False` (not `free`), so a self-host deploy doesn't show a free
+tier with limits. The `is_billing_active` gate is patched; when active a small
+fake store stands in.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from topix.api.router import billing
+from topix.api.router.billing import router
+from topix.api.utils.security import get_current_user_uid
+
+
+def _build_client(monkeypatch, *, active: bool, row=None) -> TestClient:
+    monkeypatch.setattr(billing, "is_billing_active", lambda: active)
+    app = FastAPI()
+    app.include_router(router)
+
+    class _Store:
+        async def get_user_billing(self, user_uid: str):
+            return row
+
+    app.user_billing_store = _Store()
+
+    async def _fake_uid():
+        return "u1"
+
+    app.dependency_overrides[get_current_user_uid] = _fake_uid
+    return TestClient(app)
+
+
+def test_me_reports_oss_plus_when_billing_inactive(monkeypatch):
+    """Billing inactive → /me reports plus + billing_enabled False (the regression)."""
+    client = _build_client(monkeypatch, active=False)
+    data = client.get("/billing/me").json()["data"]
+    assert data["plan"] == "plus"
+    assert data["billing_enabled"] is False
+
+
+def test_me_reports_free_for_a_user_with_no_subscription_when_active(monkeypatch):
+    """Billing active, no subscription → free + billing_enabled True."""
+    client = _build_client(monkeypatch, active=True, row=None)
+    data = client.get("/billing/me").json()["data"]
+    assert data["plan"] == "free"
+    assert data["billing_enabled"] is True
+
+
+def test_me_status_gates_a_never_paid_subscription_when_active(monkeypatch):
+    """Billing active, incomplete sub → displays free, not the paid plan."""
+    row = SimpleNamespace(
+        plan="plus",
+        status="incomplete",
+        cancel_at_period_end=False,
+        current_period_start=None,
+        current_period_end=None,
+    )
+    client = _build_client(monkeypatch, active=True, row=row)
+    data = client.get("/billing/me").json()["data"]
+    assert data["plan"] == "free"  # incomplete sub doesn't display as paid
+    assert data["billing_enabled"] is True

--- a/backend/test/unit/api/utils/test_entitlements.py
+++ b/backend/test/unit/api/utils/test_entitlements.py
@@ -1,0 +1,106 @@
+"""Unit tests for plan / entitlement resolution.
+
+The load-bearing invariant: when billing is inactive (flag off OR Stripe keys
+missing → `is_billing_active()` false), the deploy is full-OSS and every plan
+resolver returns `plus` WITHOUT touching the billing store. When active, the
+stored plan is returned, status-gated.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from topix.api.utils.rate_limit import entitlements
+from topix.api.utils.rate_limit.entitlements import (
+    resolve_effective_plan,
+    resolve_entitlement_context,
+)
+
+
+def _set_billing_active(monkeypatch, active: bool):
+    monkeypatch.setattr(entitlements, "is_billing_active", lambda: active)
+
+
+class _FailIfCalledStore:
+    """Store that must never be hit (proves the OSS short-circuit skips it)."""
+
+    async def get_user_billing(self, user_uid: str):
+        raise AssertionError(f"store should not be called for {user_uid}")
+
+
+class _StubStore:
+    def __init__(self, row):
+        self.row = row
+        self.calls: list[str] = []
+
+    async def get_user_billing(self, user_uid: str):
+        self.calls.append(user_uid)
+        return self.row
+
+
+def _req(store=None):
+    app = SimpleNamespace(user_billing_store=store) if store is not None else SimpleNamespace()
+    return SimpleNamespace(app=app)
+
+
+# --- billing inactive → OSS plus, no store access ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_effective_plan_is_plus_and_skips_store_when_inactive(monkeypatch):
+    """Inactive billing → plus, and the store is never queried."""
+    _set_billing_active(monkeypatch, False)
+    assert await resolve_effective_plan(_req(_FailIfCalledStore()), "u1") == "plus"
+
+
+@pytest.mark.asyncio
+async def test_entitlement_is_plus_no_cycle_when_inactive(monkeypatch):
+    """Inactive billing → plus entitlement with no billing cycle (nothing metered)."""
+    _set_billing_active(monkeypatch, False)
+    ctx = await resolve_entitlement_context(_req(_FailIfCalledStore()), "u1")
+    assert ctx.plan == "plus"
+    assert ctx.cycle is None
+
+
+# --- billing active → stored plan, status-gated ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_no_row_is_free(monkeypatch):
+    """Active billing with no subscription row → free."""
+    _set_billing_active(monkeypatch, True)
+    store = _StubStore(None)
+    assert await resolve_effective_plan(_req(store), "u1") == "free"
+    assert store.calls == ["u1"]
+
+
+@pytest.mark.asyncio
+async def test_active_paid_active_row_is_that_plan(monkeypatch):
+    """Active billing with a paid+active row → that plan."""
+    _set_billing_active(monkeypatch, True)
+    store = _StubStore(SimpleNamespace(plan="plus", status="active"))
+    assert await resolve_effective_plan(_req(store), "u1") == "plus"
+
+
+@pytest.mark.asyncio
+async def test_active_never_paid_incomplete_falls_back_to_free(monkeypatch):
+    """A never-paid (`incomplete`) subscription must not grant a paid tier."""
+    _set_billing_active(monkeypatch, True)
+    store = _StubStore(SimpleNamespace(plan="plus", status="incomplete"))
+    assert await resolve_effective_plan(_req(store), "u1") == "free"
+
+
+@pytest.mark.asyncio
+async def test_entitlement_carries_billing_cycle_when_present(monkeypatch):
+    """Active billing with period bounds → entitlement carries the billing cycle."""
+    _set_billing_active(monkeypatch, True)
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=30)
+    store = _StubStore(
+        SimpleNamespace(plan="plus", status="active", current_period_start=start, current_period_end=end)
+    )
+    ctx = await resolve_entitlement_context(_req(store), "u1")
+    assert ctx.plan == "plus"
+    assert ctx.cycle is not None
+    assert ctx.cycle.start == start and ctx.cycle.end == end

--- a/backend/test/unit/api/utils/test_rate_limiter.py
+++ b/backend/test/unit/api/utils/test_rate_limiter.py
@@ -7,7 +7,7 @@ import pytest
 
 from fastapi import HTTPException, status
 
-from topix.api.utils.rate_limit import policy
+from topix.api.utils.rate_limit import entitlements, policy
 from topix.api.utils.rate_limit.dependency import rate_limiter
 from topix.api.utils.rate_limit.policy import (
     DAILY_UTC_LIMITS,
@@ -17,8 +17,10 @@ from topix.api.utils.rate_limit.policy import (
 
 
 def _set_billing_active(monkeypatch, active: bool):
-    """Patch the billing-active gate the policy layer consults."""
+    """Patch the billing-active gate in BOTH namespaces that consult it —
+    `policy` (limit resolution) and `entitlements` (plan resolution)."""
     monkeypatch.setattr(policy, "is_billing_active", lambda: active)
+    monkeypatch.setattr(entitlements, "is_billing_active", lambda: active)
 
 
 class _FakeRedisStore:

--- a/backend/test/unit/api/utils/test_rate_limiter.py
+++ b/backend/test/unit/api/utils/test_rate_limiter.py
@@ -17,8 +17,10 @@ from topix.api.utils.rate_limit.policy import (
 
 
 def _set_billing_active(monkeypatch, active: bool):
-    """Patch the billing-active gate in BOTH namespaces that consult it —
-    `policy` (limit resolution) and `entitlements` (plan resolution)."""
+    """Patch the billing-active gate in both namespaces that consult it.
+
+    `policy` resolves the limits; `entitlements` resolves the plan.
+    """
     monkeypatch.setattr(policy, "is_billing_active", lambda: active)
     monkeypatch.setattr(entitlements, "is_billing_active", lambda: active)
 

--- a/backend/test/unit/api/utils/test_token_plan.py
+++ b/backend/test/unit/api/utils/test_token_plan.py
@@ -4,12 +4,14 @@ from types import SimpleNamespace
 
 import pytest
 
-from topix.api.utils.rate_limit import token_plan
+from topix.api.utils.rate_limit import entitlements
 from topix.api.utils.rate_limit.token_plan import resolve_plan_for_token
 
 
 def _set_billing_active(monkeypatch, active: bool):
-    monkeypatch.setattr(token_plan, "is_billing_active", lambda: active)
+    # resolve_plan_for_token delegates to resolve_effective_plan, which reads the
+    # gate from the entitlements module namespace.
+    monkeypatch.setattr(entitlements, "is_billing_active", lambda: active)
 
 
 class _FailIfCalledStore:

--- a/backend/topix/api/router/billing.py
+++ b/backend/topix/api/router/billing.py
@@ -187,21 +187,40 @@ async def get_billing_state(
     request: Request,
     user_id: Annotated[str, Depends(get_current_user_uid)],
 ):
-    """Return billing state used by the settings UI."""
+    """Return billing state used by the settings UI.
+
+    `billing_enabled` is the authoritative deploy flag (`is_billing_active` =
+    flag on AND Stripe keys present); the UI must gate tiers/limits on it rather
+    than re-deriving from its own env flag. When billing is inactive the deploy
+    runs full-OSS: plan `plus`, everything unlocked.
+    """
+    if not is_billing_active():
+        return {
+            "plan": "plus",
+            "status": "active",
+            "billing_enabled": False,
+            "cancel_at_period_end": False,
+            "current_period_start": None,
+            "current_period_end": None,
+        }
+
     user_billing_store: UserBillingStore = request.app.user_billing_store
     billing = await user_billing_store.get_user_billing(user_id)
     if billing is None:
         return {
             "plan": "free",
             "status": "active",
+            "billing_enabled": True,
             "cancel_at_period_end": False,
             "current_period_start": None,
             "current_period_end": None,
         }
 
     return {
-        "plan": billing.plan,
+        # Status-gated so a never-paid (`incomplete`) sub doesn't display as paid.
+        "plan": effective_plan(billing.plan, billing.status),
         "status": billing.status,
+        "billing_enabled": True,
         "cancel_at_period_end": billing.cancel_at_period_end,
         "current_period_start": billing.current_period_start,
         "current_period_end": billing.current_period_end,

--- a/backend/topix/api/utils/rate_limit/entitlements.py
+++ b/backend/topix/api/utils/rate_limit/entitlements.py
@@ -2,38 +2,63 @@
 
 from fastapi import Request
 
+from topix.api.utils.billing.stripe_config import is_billing_active
 from topix.api.utils.rate_limit.types import BillingCycle, EntitlementContext, PlanType
 from topix.api.utils.rate_limit.windows import as_utc
 from topix.datatypes.user_billing import effective_plan
 from topix.store.user_billing import UserBillingStore
 
+# Plan when billing is on but the user has no (or a never-paid) subscription.
 DEFAULT_PLAN: PlanType = "free"
+# Plan when billing is inactive (OSS / self-host): everything unlocked.
+OSS_PLAN: PlanType = "plus"
+
+
+async def resolve_effective_plan(request: Request, user_uid: str) -> PlanType:
+    """Resolve a user's effective plan — the single source of truth.
+
+    - Billing inactive (flag off OR Stripe keys missing → `is_billing_active()`
+      false): `plus` — OSS/self-host runs fully unlocked, no tiering.
+    - Billing active: the stored plan, gated on subscription status so a
+      never-paid (`incomplete`) subscription never grants a paid tier.
+
+    Used by the token claim and the `/billing/me` report; `resolve_entitlement_context`
+    applies the same gate before it also needs the billing cycle.
+    """
+    if not is_billing_active():
+        return OSS_PLAN
+
+    store: UserBillingStore | None = getattr(request.app, "user_billing_store", None)
+    if store is None:
+        return DEFAULT_PLAN
+    billing = await store.get_user_billing(user_uid)
+    if billing is None:
+        return DEFAULT_PLAN
+    return effective_plan(billing.plan, billing.status)
 
 
 async def resolve_entitlement_context(request: Request, user_uid: str) -> EntitlementContext:
-    """Resolve plan and optional billing context for the request user.
+    """Resolve plan + optional billing-cycle window for the request user.
 
-    The plan is gated on subscription status so a never-paid (`incomplete`)
-    subscription does not grant paid entitlements.
+    Billing inactive → `plus` with no cycle (OSS: nothing is metered). Otherwise
+    the status-gated stored plan plus its billing cycle when present.
     """
+    if not is_billing_active():
+        return EntitlementContext(plan=OSS_PLAN)
+
     store: UserBillingStore | None = getattr(request.app, "user_billing_store", None)
     if store is None:
         return EntitlementContext(plan=DEFAULT_PLAN)
-
     billing = await store.get_user_billing(user_uid)
     if billing is None:
         return EntitlementContext(plan=DEFAULT_PLAN)
 
     plan = effective_plan(billing.plan, billing.status)
-
-    cycle_start = billing.current_period_start
-    cycle_end = billing.current_period_end
-
-    if cycle_start and cycle_end:
-        start_utc = as_utc(cycle_start)
-        end_utc = as_utc(cycle_end)
+    if billing.current_period_start and billing.current_period_end:
+        start_utc = as_utc(billing.current_period_start)
+        end_utc = as_utc(billing.current_period_end)
         if start_utc < end_utc:
             return EntitlementContext(plan=plan, cycle=BillingCycle(start=start_utc, end=end_utc))
 
-    # Fallback: no cycle information yet (e.g. free user or pre-billing setup).
+    # No cycle information yet (e.g. free user or pre-billing setup).
     return EntitlementContext(plan=plan)

--- a/backend/topix/api/utils/rate_limit/token_plan.py
+++ b/backend/topix/api/utils/rate_limit/token_plan.py
@@ -2,28 +2,15 @@
 
 from fastapi import Request
 
-from topix.api.utils.billing.stripe_config import is_billing_active
-from topix.datatypes.user_billing import BillingPlan, effective_plan
-from topix.store.user_billing import UserBillingStore
+from topix.api.utils.rate_limit.entitlements import resolve_effective_plan
+from topix.datatypes.user_billing import BillingPlan
 
 
 async def resolve_plan_for_token(request: Request, user_uid: str) -> BillingPlan:
-    """Resolve plan claim for access token payload.
+    """Resolve the plan claim stamped into the access token.
 
-    When billing is inactive (disabled or unconfigured), return plus so the UI
-    unlocks all features for OSS / self-hosted deploys.
+    Delegates to the shared `resolve_effective_plan` so the token, `/billing/me`,
+    and rate-limit entitlement can never disagree about a user's plan: billing
+    inactive → `plus` (OSS unlocked); active → the status-gated stored plan.
     """
-    if not is_billing_active():
-        return "plus"
-
-    store: UserBillingStore | None = getattr(request.app, "user_billing_store", None)
-    if store is None:
-        return "free"
-
-    billing = await store.get_user_billing(user_uid)
-    if billing is None:
-        return "free"
-
-    # Gate on status so a never-paid (`incomplete`) subscription never yields a
-    # paid plan claim in the access token.
-    return effective_plan(billing.plan, billing.status)
+    return await resolve_effective_plan(request, user_uid)

--- a/docs/adr/ADR-BILLING-001-oss-mode-when-billing-inactive.md
+++ b/docs/adr/ADR-BILLING-001-oss-mode-when-billing-inactive.md
@@ -1,0 +1,46 @@
+# ADR-BILLING-001: Billing-inactive deploys run full-OSS (plan `plus`, no limits)
+
+**Status:** Accepted · 2026-07-30
+**Applies to:** `backend/topix/api/utils/rate_limit/**`, `backend/topix/api/router/billing.py`, `backend/topix/api/utils/billing/stripe_config.py`, `webui/src/config/billing.ts`, `webui/src/features/board/lib/board-limit.ts`
+
+## Decision
+Billing is **active** iff `is_billing_active()` — `VITE_BILLING_ENABLED` truthy
+**AND** all required Stripe env vars present (`stripe_config.REQUIRED_ENV_VARS`).
+When inactive (self-host / OSS), the deploy runs fully unlocked: effective plan
+`plus`, no tier gating, no rate/board/model limits.
+
+- The effective plan MUST be resolved through the single helper
+  `resolve_effective_plan` (`rate_limit/entitlements.py`); `resolve_plan_for_token`
+  (JWT claim), `resolve_entitlement_context` (rate-limit), and `GET /billing/me`
+  all go through it or apply the same `is_billing_active()` gate. No fourth copy.
+- The frontend MUST consume the backend's decision — the JWT plan claim and
+  `billing_enabled` from `/billing/me` (or `/billing/public-config`) — and MUST
+  NOT gate tiers/limits on `VITE_BILLING_ENABLED` alone.
+
+## Why
+`VITE_BILLING_ENABLED` is read by BOTH the backend gate and the frontend flag,
+but only the backend also checks the Stripe keys. When the plan decision was
+copied into several resolvers, some (`/billing/me`, `resolve_entitlement_context`)
+dropped the `is_billing_active()` check and defaulted to `free` — so a self-host
+deploy with the flag set but no keys showed a **free tier with limits** even
+though enforcement was (correctly) bypassed. The frontend made it worse by
+re-deriving "billing on?" from the bare flag it can't fully evaluate (the web
+container has no Stripe keys). One authority, consumed everywhere, is the fix.
+Regressed once (PR #153 removed the original OSS bypass from the limits path).
+
+## Consequences
+- Adding a plan consumer: call `resolve_effective_plan`, never re-check the flag.
+- Self-host stays unlimited with zero billing config; a keyless-but-flag-on deploy
+  is treated as OSS, not a broken free tier.
+- Enforcement already honored `is_billing_active()` (policy / capacity / boards /
+  ai-metering); this aligns *reporting* and the *frontend* with it.
+
+## Rejected alternatives
+- **Per-resolver `is_billing_active` checks, copied** — how it drifted; one helper instead.
+- **Frontend trusts `VITE_BILLING_ENABLED`** — the web container lacks the Stripe
+  keys, so it can't compute the real gate; it must consume the backend's answer.
+
+## Verify
+`grep -rn "is_billing_active" backend/topix/api/utils/rate_limit backend/topix/api/router/billing.py`
+shows the gate reached only via `resolve_effective_plan` / `resolve_entitlement_context` / `/billing/me`;
+`grep -rn "VITE_BILLING_ENABLED\|BILLING_ENABLED" webui/src/features` shows no tier/limit gate keying on the raw flag.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,3 +8,4 @@ by ID from other docs instead of restating the decision (each fact lives once).
 |----|----------|
 | [ADR-AGENT-001](./ADR-AGENT-001-opaque-transcript-storage.md) | Browser-agent chat transcripts are stored as opaque JSON, not the server `Message` model. |
 | [ADR-AGENT-002](./ADR-AGENT-002-tool-confirm-gate-and-result-contract.md) | Off-board tool confirm gate + unified `ToolFailure` result contract. |
+| [ADR-BILLING-001](./ADR-BILLING-001-oss-mode-when-billing-inactive.md) | Billing-inactive deploys run full-OSS (plan `plus`, no limits); one plan resolver, consumed by the frontend. |


### PR DESCRIPTION
## Why
On a self-host / OSS deploy (billing not activated), the settings UI showed a **free tier with limits** even though nothing was actually enforced. Enforcement was already correctly OSS-bypassed everywhere via `is_billing_active()` (policy / capacity / boards / `/ai` metering) — but **plan *reporting* wasn't**: `GET /billing/me` and `resolve_entitlement_context` defaulted to `free`, while the JWT claim (`resolve_plan_for_token`) correctly returned `plus`. The gate had been copied into several resolvers and two of them dropped it (regressed in #153, which removed the original OSS limits bypass).

`is_billing_active()` = `VITE_BILLING_ENABLED` truthy **AND** all required Stripe keys present. Anything missing ⇒ OSS ⇒ plan `plus`, no tier, no limits.

## What
- **`entitlements.py`** — one `resolve_effective_plan` (the single source: inactive → `plus`; active → status-gated stored plan). `resolve_entitlement_context` applies the same gate before it also needs the billing cycle.
- **`token_plan.resolve_plan_for_token`** — now delegates to it (was a third copy).
- **`GET /billing/me`** — OSS short-circuit → `plan:"plus"` + `billing_enabled:false`; also status-gates the plan (it was returning the raw stored plan, unlike the token).

Enforcement behavior is unchanged; this aligns *reporting* with it, so the token claim, `/me`, and rate-limit entitlement can no longer disagree.

## Tests
Resolver matrix (inactive→plus with **no store access**; active no-row→free; paid+active→plan; never-paid `incomplete`→free; cycle carried) + a `/billing/me` router test pinning the regression. The existing rate-limiter test now patches the gate in both namespaces (`policy` + `entitlements`). 194 api unit tests pass; ruff clean.

## Follow-up (separate PR, not here)
Frontend must consume `billing_enabled` from the backend rather than the bare `VITE_BILLING_ENABLED` flag (the web container has no Stripe keys, so it can't evaluate the real gate). See **ADR-BILLING-001** — the board-limit / tier-badge gates should key on the backend signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
