### PR TITLE
fix(billing): gate frontend tiers/limits on backend billing_enabled (OSS fix, FE half)

### DIFF
--- a/webui/src/components/sidebar/app-sidebar.tsx
+++ b/webui/src/components/sidebar/app-sidebar.tsx
@@ -34,7 +34,6 @@ import {
 import { ModeToggle } from '@/components/mode-toggle'
 import { HomeMenuItem } from './home'
 import { useNavigate } from '@tanstack/react-router'
-import { BILLING_ENABLED } from '@/config/billing'
 import { TierBadge } from '@/features/user-settings/components/tier-badge'
 
 
@@ -58,6 +57,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
   const userId = useAppStore(s => s.userId)
   const userEmail = useAppStore(s => s.userEmail)
   const userPlan = useAppStore(s => s.userPlan)
+  const billingActive = useAppStore(s => s.billingActive)
   // Signed-out ("root") gets the same shell but a local-only nav: no Dashboard/
   // Chats (both need the backend), and a sign-in CTA instead of the account menu.
   const signedIn = isSignedIn(userId)
@@ -289,7 +289,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
                             >
                               {userEmail}
                             </span>
-                            {BILLING_ENABLED ? (
+                            {billingActive ? (
                               <div className="mt-1">
                                 <TierBadge plan={userPlan} />
                               </div>
@@ -305,7 +305,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
                           <UserProfileIcon className="mr-2 h-4 w-4" strokeWidth={2} />
                           <span>Profile</span>
                         </DropdownMenuItem>
-                        {BILLING_ENABLED ? (
+                        {billingActive ? (
                           <DropdownMenuItem
                             className='text-xs bg-gradient-to-br from-secondary-foreground/10 via-secondary-foreground/5 to-transparent text-secondary-foreground'
                             onClick={() => navigate({ to: "/settings/billing" })}

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -53,8 +53,10 @@ export function NewBoardItem() {
   const userId = useAppStore(s => s.userId)
   const { data: boards = [] } = useListBoards(userId)
   const userPlan = useAppStore(s => s.userPlan)
+  // Subscribe so the gate re-renders when billingActive is hydrated at boot.
+  const billingActive = useAppStore(s => s.billingActive)
   const navigate = useNavigate()
-  const boardCreationLimited = isBoardCreationLimited(userPlan, boards.length)
+  const boardCreationLimited = billingActive && isBoardCreationLimited(userPlan, boards.length)
 
   const handleClick = async () => {
     if (boardCreationLimited) return

--- a/webui/src/features/board/lib/board-limit.test.ts
+++ b/webui/src/features/board/lib/board-limit.test.ts
@@ -1,22 +1,29 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
+import { useAppStore } from "@/store"
+import {
+  canCreateSubBoard,
+  isBoardCreationLimited,
+  isNodeTypeAtLimit,
+  MAX_BOARD_DEPTH,
+  nodeLimitFor,
+} from "./board-limit"
 
 
-afterEach(() => {
-  vi.resetModules()
-  vi.doUnmock("@/config/billing")
-})
-
-
-async function loadWith(billingEnabled: boolean) {
-  vi.resetModules()
-  vi.doMock("@/config/billing", () => ({ BILLING_ENABLED: billingEnabled }))
-  return import("./board-limit")
+// The billing gate now reads the backend-authoritative `billingActive` from the
+// app store (not the raw VITE flag), so drive it directly.
+function setBillingActive(active: boolean) {
+  useAppStore.setState({ billingActive: active })
 }
 
 
+afterEach(() => {
+  setBillingActive(false)
+})
+
+
 describe("node limits — billing active", () => {
-  it("resolves per-plan limits for documents, mini-apps and code sandboxes", async () => {
-    const { nodeLimitFor } = await loadWith(true)
+  it("resolves per-plan limits for documents, mini-apps and code sandboxes", () => {
+    setBillingActive(true)
     expect(nodeLimitFor("document", "free")).toBe(3)
     expect(nodeLimitFor("document", "plus")).toBe(25)
     expect(nodeLimitFor("mini-app", "free")).toBe(10)
@@ -24,30 +31,37 @@ describe("node limits — billing active", () => {
     expect(nodeLimitFor("code-sandbox", "basic")).toBe(60)
   })
 
-  it("treats folders as a universal limit regardless of plan", async () => {
-    const { nodeLimitFor } = await loadWith(true)
+  it("treats folders as a universal limit regardless of plan", () => {
+    setBillingActive(true)
     expect(nodeLimitFor("folder", "free")).toBe(10)
     expect(nodeLimitFor("folder", "plus")).toBe(10)
   })
 
-  it("flags a type as at-limit only once the count reaches the cap", async () => {
-    const { isNodeTypeAtLimit } = await loadWith(true)
+  it("flags a type as at-limit only once the count reaches the cap", () => {
+    setBillingActive(true)
     expect(isNodeTypeAtLimit("document", "free", 2)).toBe(false)
     expect(isNodeTypeAtLimit("document", "free", 3)).toBe(true)
     expect(isNodeTypeAtLimit("mini-app", "plus", 99)).toBe(false)
     expect(isNodeTypeAtLimit("mini-app", "plus", 100)).toBe(true)
   })
 
-  it("returns null (unlimited) for unknown types", async () => {
-    const { nodeLimitFor } = await loadWith(true)
+  it("returns null (unlimited) for unknown types", () => {
+    setBillingActive(true)
     expect(nodeLimitFor("rect", "free")).toBeNull()
+  })
+
+  it("enforces the free board cap when billing is active", () => {
+    setBillingActive(true)
+    expect(isBoardCreationLimited("free", 4)).toBe(false)
+    expect(isBoardCreationLimited("free", 5)).toBe(true)
+    expect(isBoardCreationLimited("plus", 999)).toBe(false) // unlimited plan
   })
 })
 
 
 describe("node limits — billing inactive (OSS)", () => {
-  it("drops per-plan limits to unlimited but keeps universal folder limit", async () => {
-    const { nodeLimitFor, isNodeTypeAtLimit } = await loadWith(false)
+  it("drops per-plan limits to unlimited but keeps universal folder limit", () => {
+    setBillingActive(false)
     expect(nodeLimitFor("document", "free")).toBeNull()
     expect(nodeLimitFor("mini-app", "free")).toBeNull()
     expect(isNodeTypeAtLimit("document", "free", 999)).toBe(false)
@@ -55,12 +69,17 @@ describe("node limits — billing inactive (OSS)", () => {
     expect(nodeLimitFor("folder", "free")).toBe(10)
     expect(isNodeTypeAtLimit("folder", "free", 10)).toBe(true)
   })
+
+  it("never limits board creation in OSS mode, even for a `free` plan at any count", () => {
+    // The reported bug: self-host with a `free`-labelled user was capped at 5.
+    setBillingActive(false)
+    expect(isBoardCreationLimited("free", 999)).toBe(false)
+  })
 })
 
 
 describe("folder nesting depth", () => {
-  it("allows root and child levels but blocks a 4th", async () => {
-    const { canCreateSubBoard, MAX_BOARD_DEPTH } = await loadWith(true)
+  it("allows root and child levels but blocks a 4th", () => {
     expect(MAX_BOARD_DEPTH).toBe(2)
     expect(canCreateSubBoard(0)).toBe(true) // root
     expect(canCreateSubBoard(1)).toBe(true) // child

--- a/webui/src/features/board/lib/board-limit.ts
+++ b/webui/src/features/board/lib/board-limit.ts
@@ -1,7 +1,12 @@
-import { BILLING_ENABLED } from "@/config/billing"
 import type { BillingPlan } from "@/lib/decode-jwt"
 import { useAppStore } from "@/store"
 import { useListBoards } from "../api/list-boards"
+
+
+// Backend-authoritative billing gate (flag AND Stripe keys). Non-reactive read
+// for the pure limit helpers; the reactive hooks below use a selector. Never the
+// raw VITE flag — see docs/adr/ADR-BILLING-001.
+const billingActive = (): boolean => useAppStore.getState().billingActive
 
 
 // ----------------------------------------------------------------------------
@@ -26,7 +31,7 @@ export function boardLimitForPlan(plan: BillingPlan): number {
 
 
 export function isBoardCreationLimited(plan: BillingPlan, boardCount: number): boolean {
-  return BILLING_ENABLED && boardCount >= BOARD_LIMITS[plan]
+  return billingActive() && boardCount >= BOARD_LIMITS[plan]
 }
 
 
@@ -67,7 +72,7 @@ export function nodeLimitFor(type: string, plan: BillingPlan): number | null {
   const entry = NODE_LIMITS[type]
   if (entry === undefined) return null
   if (typeof entry === "number") return entry
-  if (!BILLING_ENABLED) return null
+  if (!billingActive()) return null
   return entry[plan]
 }
 

--- a/webui/src/features/board/lib/board-limit.ts
+++ b/webui/src/features/board/lib/board-limit.ts
@@ -3,9 +3,12 @@ import { useAppStore } from "@/store"
 import { useListBoards } from "../api/list-boards"
 
 
-// Backend-authoritative billing gate (flag AND Stripe keys). Non-reactive read
-// for the pure limit helpers; the reactive hooks below use a selector. Never the
-// raw VITE flag — see docs/adr/ADR-BILLING-001.
+// Backend-authoritative billing gate (flag AND Stripe keys, never the raw VITE
+// flag — see docs/adr/ADR-BILLING-001). This is a NON-reactive read: the pure
+// helpers use it for correctness at call time (create paths read fresh here),
+// but a component that must RE-RENDER when billingActive flips (e.g. after boot
+// hydration) MUST also select `s.billingActive` itself — see
+// useIsBoardCreationLimited / NewBoardItem.
 const billingActive = (): boolean => useAppStore.getState().billingActive
 
 
@@ -42,8 +45,11 @@ export function isBoardCreationLimited(plan: BillingPlan, boardCount: number): b
 export function useIsBoardCreationLimited(): boolean {
   const userId = useAppStore((s) => s.userId)
   const userPlan = useAppStore((s) => s.userPlan)
+  // Subscribe to billingActive so the gate re-renders when the boot fetch flips
+  // it (e.g. flag-on-but-keyless self-host: seeded true → hydrated false).
+  const billingActive = useAppStore((s) => s.billingActive)
   const { data: boards = [] } = useListBoards(userId)
-  return isBoardCreationLimited(userPlan, boards.length)
+  return billingActive && isBoardCreationLimited(userPlan, boards.length)
 }
 
 

--- a/webui/src/features/user-settings/components/tier-badge.tsx
+++ b/webui/src/features/user-settings/components/tier-badge.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/ui/badge"
-import { BILLING_ENABLED } from "@/config/billing"
+import { useAppStore } from "@/store"
 import type { BillingPlan } from "@/lib/decode-jwt"
 import { AwardIcon } from "@/components/icons"
 
@@ -10,7 +10,8 @@ type TierBadgeProps = {
 
 
 export function TierBadge({ plan }: TierBadgeProps) {
-  if (!BILLING_ENABLED) return null
+  const billingActive = useAppStore((s) => s.billingActive)
+  if (!billingActive) return null
 
   const isPaid = plan === "plus" || plan === "basic"
 

--- a/webui/src/features/user-settings/screens/billing-screen.tsx
+++ b/webui/src/features/user-settings/screens/billing-screen.tsx
@@ -16,7 +16,6 @@ import { refresh } from "@/api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { BILLING_ENABLED } from "@/config/billing"
 import { TierBadge } from "@/features/user-settings/components/tier-badge"
 import {
   createCheckoutSession,
@@ -57,6 +56,7 @@ function FeatureRow({ icon, label }: FeatureRowProps) {
 export function BillingScreen() {
   const userPlan = useAppStore(s => s.userPlan)
   const setUserPlan = useAppStore(s => s.setUserPlan)
+  const billingActive = useAppStore(s => s.billingActive)
   const [busyAction, setBusyAction] = useState<"upgrade-basic" | "upgrade-plus" | "manage" | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null)
@@ -66,7 +66,7 @@ export function BillingScreen() {
   const searchParams = useMemo(() => new URLSearchParams(window.location.search), [])
 
   useEffect(() => {
-    if (!BILLING_ENABLED) return
+    if (!billingActive) return
 
     void (async () => {
       try {
@@ -78,10 +78,10 @@ export function BillingScreen() {
         setErrorMessage(error instanceof Error ? error.message : "Could not load billing status.")
       }
     })()
-  }, [])
+  }, [billingActive])
 
   useEffect(() => {
-    if (!BILLING_ENABLED) return
+    if (!billingActive) return
     if (refreshedAfterReturn.current) return
     if (searchParams.get("checkout") !== "success") return
 
@@ -99,7 +99,7 @@ export function BillingScreen() {
         setErrorMessage("Could not refresh billing plan after checkout.")
       }
     })()
-  }, [searchParams, setUserPlan])
+  }, [billingActive, searchParams, setUserPlan])
 
   const onUpgrade = async (plan: PaidPlan) => {
     setErrorMessage(null)
@@ -174,7 +174,7 @@ export function BillingScreen() {
   const basicIntervalLabel = billingPublicConfig?.basic_price?.interval || "month"
   const plusIntervalLabel = billingPublicConfig?.plus_price?.interval || "month"
 
-  if (!BILLING_ENABLED) return null
+  if (!billingActive) return null
 
   return (
     <div className="absolute inset-0 overflow-y-auto scrollbar-thin bg-background">

--- a/webui/src/features/user-settings/screens/settings-screen.tsx
+++ b/webui/src/features/user-settings/screens/settings-screen.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from "@tanstack/react-router"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { BILLING_ENABLED } from "@/config/billing"
 import { getBillingSummary, type BillingSummary } from "@/features/user-settings/api/billing"
 import { TierBadge } from "@/features/user-settings/components/tier-badge"
 import { useAppStore } from "@/store"
@@ -14,10 +13,11 @@ export function SettingsScreen() {
   const navigate = useNavigate()
   const userEmail = useAppStore(s => s.userEmail)
   const userPlan = useAppStore(s => s.userPlan)
+  const billingActive = useAppStore(s => s.billingActive)
   const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null)
 
   useEffect(() => {
-    if (!BILLING_ENABLED) return
+    if (!billingActive) return
 
     void (async () => {
       try {
@@ -27,7 +27,7 @@ export function SettingsScreen() {
         setBillingSummary(null)
       }
     })()
-  }, [])
+  }, [billingActive])
 
   const expiresAtLabel = useMemo(() => {
     if (!billingSummary?.cancel_at_period_end) return null
@@ -48,7 +48,7 @@ export function SettingsScreen() {
               <span className="text-sm text-muted-foreground">Email</span>
               <span className="text-sm font-medium">{userEmail}</span>
             </div>
-            {BILLING_ENABLED ? (
+            {billingActive ? (
               <div className="flex items-center justify-between gap-4">
                 <span className="text-sm text-muted-foreground">Current plan</span>
                 <div className="flex items-center gap-2">
@@ -64,7 +64,7 @@ export function SettingsScreen() {
           </CardContent>
         </Card>
 
-        {BILLING_ENABLED ? (
+        {billingActive ? (
           <Card className="border-secondary-foreground/60 bg-gradient-to-br from-secondary-foreground/20 via-secondary-foreground/10 to-card">
             <CardHeader>
               <CardTitle>Billing</CardTitle>

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -13,6 +13,7 @@ import { clearTokens } from '@/features/signin/auth-storage'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useBoardAppStore } from '@/features/board/harness/store/board-app-store'
 import { useAuth } from '@/features/signin/hooks/auth'
+import { getBillingPublicConfig } from '@/features/user-settings/api/billing'
 import { initConnectionState } from '@/features/connection/connection-state'
 import { OfflineOverlay } from '@/features/connection/offline-overlay'
 import { AuthGraphTexture } from '@/features/signin/components/auth-graph-texture'
@@ -32,6 +33,19 @@ export function RootLayout() {
   const setUserPlan = useAppStore(s => s.setUserPlan)
   const setEmailVerificationEnabled = useAppStore(s => s.setEmailVerificationEnabled)
   const setEmailVerified = useAppStore(s => s.setEmailVerified)
+  const setBillingActive = useAppStore(s => s.setBillingActive)
+
+  // Billing is "active" only if the backend has the flag AND the Stripe keys —
+  // a fact the web container can't compute. Consume the backend's answer so a
+  // flag-set-but-keyless deploy correctly reads as OSS (no tiers/limits).
+  // Unauthenticated + cached; the build-flag seed avoids a flash meanwhile.
+  useEffect(() => {
+    let cancelled = false
+    getBillingPublicConfig()
+      .then((cfg) => { if (!cancelled) setBillingActive(cfg.billing_enabled) })
+      .catch(() => { /* keep the seeded default on error */ })
+    return () => { cancelled = true }
+  }, [setBillingActive])
 
   const onLogout = useCallback(() => {
     clearTokens()

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -37,15 +37,18 @@ export function RootLayout() {
 
   // Billing is "active" only if the backend has the flag AND the Stripe keys —
   // a fact the web container can't compute. Consume the backend's answer so a
-  // flag-set-but-keyless deploy correctly reads as OSS (no tiers/limits).
-  // Unauthenticated + cached; the build-flag seed avoids a flash meanwhile.
+  // flag-set-but-keyless deploy correctly reads as OSS (no tiers/limits). Only
+  // signed-in users: billing UI/limits never apply signed-out, and the
+  // local-first front door makes zero backend calls when signed out. The
+  // build-flag seed covers the pre-fetch window.
   useEffect(() => {
+    if (!isSignedIn(userId)) return
     let cancelled = false
     getBillingPublicConfig()
       .then((cfg) => { if (!cancelled) setBillingActive(cfg.billing_enabled) })
       .catch(() => { /* keep the seeded default on error */ })
     return () => { cancelled = true }
-  }, [setBillingActive])
+  }, [userId, setBillingActive])
 
   const onLogout = useCallback(() => {
     clearTokens()

--- a/webui/src/store.ts
+++ b/webui/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand/react"
 import type { BillingPlan } from "@/lib/decode-jwt"
+import { BILLING_ENABLED } from "@/config/billing"
 
 
 /**
@@ -9,11 +10,20 @@ export interface AppStore {
   userId: string
   userEmail: string
   userPlan: BillingPlan
+  /**
+   * Backend-authoritative "billing is active" (`is_billing_active`: the flag AND
+   * all Stripe keys present). Hydrated at boot from `/billing/public-config`;
+   * seeded from the build flag so a correctly-configured deploy doesn't flash.
+   * Gate tiers/limits on THIS, never the raw `VITE_BILLING_ENABLED` flag — the
+   * web container can't see the Stripe keys. See docs/adr/ADR-BILLING-001.
+   */
+  billingActive: boolean
   emailVerificationEnabled: boolean
   emailVerified: boolean
   setUserId: (userId: string) => void
   setUserEmail: (email: string) => void
   setUserPlan: (plan: BillingPlan) => void
+  setBillingActive: (active: boolean) => void
   setEmailVerificationEnabled: (enabled: boolean) => void
   setEmailVerified: (verified: boolean) => void
 }
@@ -29,6 +39,8 @@ export const useAppStore = create<AppStore>((set) => ({
 
   userPlan: "free",
 
+  billingActive: BILLING_ENABLED,
+
   emailVerificationEnabled: false,
 
   emailVerified: true,
@@ -38,6 +50,8 @@ export const useAppStore = create<AppStore>((set) => ({
   setUserEmail: (userEmail) => set({ userEmail }),
 
   setUserPlan: (userPlan) => set({ userPlan }),
+
+  setBillingActive: (billingActive) => set({ billingActive }),
 
   setEmailVerificationEnabled: (emailVerificationEnabled) => set({ emailVerificationEnabled }),
 


### PR DESCRIPTION
Frontend half of the OSS-billing fix (backend is #174). Closes the last divergence: the UI decided "is billing on?" from the bare `VITE_BILLING_ENABLED` flag, but the **web container has no Stripe keys**, so it can't compute the real gate (`is_billing_active` = flag AND keys). A flag-set-but-keyless deploy therefore showed a free tier with **board/node limits** while the backend ran fully unlocked.

## What
- **store**: new `billingActive`, seeded from the build flag (so a correctly-configured deploy doesn't flash) and hydrated at boot from `/billing/public-config` — whose `billing_enabled` is the backend's authoritative `is_billing_active`.
- Repointed **every** gate off the raw flag onto `billingActive`:
  - `board-limit.ts` — `isBoardCreationLimited` / `nodeLimitFor` (the actual 5-board + per-type caps the user hit)
  - `TierBadge`, `settings-screen`, `billing-screen`, `app-sidebar` (tier UI)
- `BILLING_ENABLED` now survives only as the store's seed default.

## Why this is the right channel
The app already communicates backend/deploy decisions to the SPA this way — `/billing/public-config` (backend-computed) and the JWT plan claim (already `plus` for OSS). The frontend just consumes the backend's answer instead of re-deriving a value it structurally can't. See **ADR-BILLING-001**.

## Tests
`board-limit.test` now drives the store (real gate) instead of module-mocking the flag, and adds the regression case: **billing inactive ⇒ a `free`-plan user is never board-capped at any count**. 430 board/user-settings/store tests pass; type-check + eslint clean.

## Note
Independent of #174 at the code level, but the two are the same fix — merge #174 (backend `/me` + entitlement) alongside this so token, `/me`, and the UI all agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
