### PR TITLE
fix(board): navigate the open board to the synced route after promoting it

### DIFF
--- a/webui/src/features/board/local/use-enable-sync.test.ts
+++ b/webui/src/features/board/local/use-enable-sync.test.ts
@@ -1,27 +1,30 @@
 import { describe, expect, it } from "vitest"
-import { isPromotedBoardCurrentlyOpen } from "./use-enable-sync"
+import { promoteNavTarget } from "./use-enable-sync"
 
 
-describe("isPromotedBoardCurrentlyOpen", () => {
-  it("is true when the promoted board is the one open at /local/$id", () => {
-    expect(isPromotedBoardCurrentlyOpen("/local/board-1", "board-1")).toBe(true)
+describe("promoteNavTarget", () => {
+  it("targets the synced route when the promoted board is open at /local/$id", () => {
+    expect(promoteNavTarget("/local/board-1", "board-1")).toEqual({
+      to: "/boards/$id",
+      params: { id: "board-1" },
+    })
   })
 
-  it("is false when viewing a different local board (promoted from the sidebar)", () => {
-    expect(isPromotedBoardCurrentlyOpen("/local/board-2", "board-1")).toBe(false)
+  it("returns null when viewing a different local board (promoted from the sidebar)", () => {
+    expect(promoteNavTarget("/local/board-2", "board-1")).toBeNull()
   })
 
-  it("is false when not on a board route (e.g. the dashboard)", () => {
-    expect(isPromotedBoardCurrentlyOpen("/", "board-1")).toBe(false)
-    expect(isPromotedBoardCurrentlyOpen("/local", "board-1")).toBe(false)
+  it("returns null when not on a board route (e.g. the dashboard)", () => {
+    expect(promoteNavTarget("/", "board-1")).toBeNull()
+    expect(promoteNavTarget("/local", "board-1")).toBeNull()
   })
 
-  it("is false when the board is already open on the synced route", () => {
+  it("returns null when the board is already open on the synced route", () => {
     // Already synced → the local route no longer matches, so no re-navigate.
-    expect(isPromotedBoardCurrentlyOpen("/boards/board-1", "board-1")).toBe(false)
+    expect(promoteNavTarget("/boards/board-1", "board-1")).toBeNull()
   })
 
   it("does not match a board id that is only a path prefix", () => {
-    expect(isPromotedBoardCurrentlyOpen("/local/board-1/extra", "board-1")).toBe(false)
+    expect(promoteNavTarget("/local/board-1/extra", "board-1")).toBeNull()
   })
 })

--- a/webui/src/features/board/local/use-enable-sync.test.ts
+++ b/webui/src/features/board/local/use-enable-sync.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { isPromotedBoardCurrentlyOpen } from "./use-enable-sync"
+
+
+describe("isPromotedBoardCurrentlyOpen", () => {
+  it("is true when the promoted board is the one open at /local/$id", () => {
+    expect(isPromotedBoardCurrentlyOpen("/local/board-1", "board-1")).toBe(true)
+  })
+
+  it("is false when viewing a different local board (promoted from the sidebar)", () => {
+    expect(isPromotedBoardCurrentlyOpen("/local/board-2", "board-1")).toBe(false)
+  })
+
+  it("is false when not on a board route (e.g. the dashboard)", () => {
+    expect(isPromotedBoardCurrentlyOpen("/", "board-1")).toBe(false)
+    expect(isPromotedBoardCurrentlyOpen("/local", "board-1")).toBe(false)
+  })
+
+  it("is false when the board is already open on the synced route", () => {
+    // Already synced → the local route no longer matches, so no re-navigate.
+    expect(isPromotedBoardCurrentlyOpen("/boards/board-1", "board-1")).toBe(false)
+  })
+
+  it("does not match a board id that is only a path prefix", () => {
+    expect(isPromotedBoardCurrentlyOpen("/local/board-1/extra", "board-1")).toBe(false)
+  })
+})

--- a/webui/src/features/board/local/use-enable-sync.ts
+++ b/webui/src/features/board/local/use-enable-sync.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
+import { useNavigate, useRouterState } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { useAppStore } from "@/store"
@@ -17,18 +17,33 @@ import type { EnableSyncResult } from "@/features/board/harness/sync/enable-sync
 
 
 /**
- * Promote a local board to synced (local → synced) from the dashboard.
+ * True when a just-promoted board is the one currently open at `/local/$id`, so
+ * the view must move to the synced route. Promoting a board you're NOT viewing
+ * (from the dashboard/sidebar) returns false — your current view stays put.
+ */
+export function isPromotedBoardCurrentlyOpen(pathname: string, boardId: string): boolean {
+  return pathname === `/local/${boardId}`
+}
+
+
+/**
+ * Promote a local board to synced (local → synced), from the dashboard or the
+ * sidebar.
  *
  * Wires the real deps to the `enableSync` orchestrator: a fresh BoardPersistence
  * for the snapshot + compaction, the adopt API, and the registry flip. Signed-out
  * users are routed to sign-in (a synced board needs an owner). On success it
- * invalidates the synced-board list so the card moves into the "Synced" group.
- * `pendingId` is the board mid-promotion (for a spinner / disabled state).
+ * invalidates the synced-board list so the card moves into the "Synced" group,
+ * and — if the promoted board is the one currently open — navigates it to the
+ * synced route so the live view re-mounts in collab mode instead of continuing
+ * to edit the now-superseded local copy. `pendingId` is the board mid-promotion
+ * (for a spinner / disabled state).
  */
 export function useEnableSync() {
   const userId = useAppStore((s) => s.userId)
   const userPlan = useAppStore((s) => s.userPlan)
   const navigate = useNavigate()
+  const location = useRouterState({ select: (s) => s.location })
   const queryClient = useQueryClient()
   const { data: syncedBoards = [] } = useListBoards(userId)
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -74,6 +89,22 @@ export function useEnableSync() {
         if (result.ok) {
           await queryClient.invalidateQueries({ queryKey: ["listBoards", userId] })
           toast.success("Sync enabled — this board is now backed up and shareable.")
+          // If the promoted board is the one currently open at `/local/$id`, move
+          // the view to the synced route so it re-mounts in collab mode. Promotion
+          // is in-place (same id) but LocalBoardScreen renders `<HarnessCanvas
+          // local />` and never re-binds, so without this the live view keeps
+          // editing the local-only copy and edits never reach the backend. Only
+          // the currently-viewed board navigates; promoting another from the
+          // dashboard/sidebar leaves your view put. Preserve the folder layer.
+          if (isPromotedBoardCurrentlyOpen(location.pathname, boardId)) {
+            void navigate({
+              to: "/boards/$id",
+              params: { id: boardId },
+              // Carry the current search (incl. the folder-layer `root_id`) across
+              // the route change so promotion doesn't jump back to the root layer.
+              search: (prev: Record<string, unknown>) => ({ ...prev }),
+            })
+          }
         } else {
           toast.error("Couldn't enable sync. Please try again.")
         }
@@ -84,7 +115,7 @@ export function useEnableSync() {
         setPendingId(null)
       }
     },
-    [userId, userPlan, syncedBoards, navigate, queryClient],
+    [userId, userPlan, syncedBoards, navigate, location, queryClient],
   )
 
   return { enableSync: run, pendingId }

--- a/webui/src/features/board/local/use-enable-sync.ts
+++ b/webui/src/features/board/local/use-enable-sync.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react"
-import { useNavigate, useRouterState } from "@tanstack/react-router"
+import { useNavigate, useRouter } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { useAppStore } from "@/store"
@@ -16,13 +16,19 @@ import { enableSync } from "@/features/board/harness/sync/enable-sync"
 import type { EnableSyncResult } from "@/features/board/harness/sync/enable-sync"
 
 
+/** Where to send the view after a promote, or `null` to leave it put. */
+export type PromoteNavTarget = { to: "/boards/$id"; params: { id: string } } | null
+
+
 /**
- * True when a just-promoted board is the one currently open at `/local/$id`, so
- * the view must move to the synced route. Promoting a board you're NOT viewing
- * (from the dashboard/sidebar) returns false — your current view stays put.
+ * Decide where the view goes after a successful promote. When the promoted board
+ * is the one currently open at `/local/$id`, return the synced-route target so it
+ * re-mounts in collab mode; otherwise `null` (promoting a board you're NOT
+ * viewing, from the dashboard/sidebar, leaves your current view put). Pure so the
+ * navigate decision + target shape are unit-testable without a router.
  */
-export function isPromotedBoardCurrentlyOpen(pathname: string, boardId: string): boolean {
-  return pathname === `/local/${boardId}`
+export function promoteNavTarget(pathname: string, boardId: string): PromoteNavTarget {
+  return pathname === `/local/${boardId}` ? { to: "/boards/$id", params: { id: boardId } } : null
 }
 
 
@@ -43,7 +49,7 @@ export function useEnableSync() {
   const userId = useAppStore((s) => s.userId)
   const userPlan = useAppStore((s) => s.userPlan)
   const navigate = useNavigate()
-  const location = useRouterState({ select: (s) => s.location })
+  const router = useRouter()
   const queryClient = useQueryClient()
   const { data: syncedBoards = [] } = useListBoards(userId)
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -96,10 +102,13 @@ export function useEnableSync() {
           // editing the local-only copy and edits never reach the backend. Only
           // the currently-viewed board navigates; promoting another from the
           // dashboard/sidebar leaves your view put. Preserve the folder layer.
-          if (isPromotedBoardCurrentlyOpen(location.pathname, boardId)) {
+          // Read the LIVE pathname (not one captured at promote-start): the
+          // promote spans several awaits, and if the user navigated away
+          // meanwhile we must not yank them to the synced route.
+          const navTarget = promoteNavTarget(router.state.location.pathname, boardId)
+          if (navTarget) {
             void navigate({
-              to: "/boards/$id",
-              params: { id: boardId },
+              ...navTarget,
               // Carry the current search (incl. the folder-layer `root_id`) across
               // the route change so promotion doesn't jump back to the root layer.
               search: (prev: Record<string, unknown>) => ({ ...prev }),
@@ -115,7 +124,7 @@ export function useEnableSync() {
         setPendingId(null)
       }
     },
-    [userId, userPlan, syncedBoards, navigate, location, queryClient],
+    [userId, userPlan, syncedBoards, navigate, router, queryClient],
   )
 
   return { enableSync: run, pendingId }


### PR DESCRIPTION
## Bug
Promote the local board you're currently viewing, then edit its title / add nodes → the changes don't show in the sidebar, and the board feels "stale/deleted."

## Root cause
Promotion (`enableSync`) is **in-place** — same board id: it adopts under the id and flips the local registry entry to `syncEngine:"v2"`. But nothing re-mounts the open view, and the two render paths are split by route:
- `/local/$id` → `LocalBoardScreen` mounts `<HarnessCanvas local />` — local-only, **no collab client**. Never re-binds on the registry flip.
- `/boards/$id` → `BoardScreen` → the harness **without** `local` — the v2 collab client that pushes edits to the backend.

Neither `enableSync` caller navigated. So after promoting the board you're in, you kept editing the **local-only** copy: edits never reached the backend, the SYNCED sidebar entry (from `useListBoards`) stayed at the adopt-time label, and `selectOnDeviceBoards` dropped the board from the LOCAL group once it appeared in the backend list — hence "editing a stale/deleted board."

## Fix
On a successful promote, if the promoted board is the one open at `/local/$id`, navigate to `/boards/$id` so the view re-mounts in collab mode; the `search` updater carries the folder layer (`root_id`) across. Promoting a board you're **not** viewing (from the dashboard/sidebar) leaves your view put. Centralized in `useEnableSync`, so both call sites (sidebar + dashboard) get it.

The open-board check is extracted to a pure `isPromotedBoardCurrentlyOpen(pathname, boardId)` and unit-tested: matches only `/local/$id`, prefix-safe, false on the dashboard, a different local board, and the already-synced route.

## Tests
5 new unit tests for the predicate; existing enable-sync + boards-home suites still green. type-check + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
