### PR TITLE
feat(agent): desktop-direct BYOK parse (Mistral OCR) + more search engines

### DIFF
--- a/webui/src-tauri/capabilities/default.json
+++ b/webui/src-tauri/capabilities/default.json
@@ -12,7 +12,11 @@
       "allow": [
         { "url": "https://api.openai.com/*" },
         { "url": "https://openrouter.ai/*" },
-        { "url": "https://api.linkup.so/*" }
+        { "url": "https://api.linkup.so/*" },
+        { "url": "https://api.tavily.com/*" },
+        { "url": "https://api.perplexity.ai/*" },
+        { "url": "https://api.exa.ai/*" },
+        { "url": "https://api.mistral.ai/*" }
       ]
     }
   ]

--- a/webui/src/features/agent/engine/doc-parse.ts
+++ b/webui/src/features/agent/engine/doc-parse.ts
@@ -12,6 +12,8 @@ import type { ServiceResolution } from "./services/kinds"
 import { resolveService } from "./services/resolve"
 import { isOverQuotaError, runIdHeaders } from "./services/run"
 import { servicesUpload } from "./services/transport"
+import { desktopMistralParse } from "./services/desktop-parse"
+import { isTauri } from "@/platform"
 
 
 /** The `/ai/parse` reply: the document's OCR'd markdown + its page count. */
@@ -77,9 +79,17 @@ export const resolveParseClient = (opts: {
     byok: cred ? { parse: cred } : {},
   })
   if (resolution.mode === "off") return null
+  // Desktop BYOK: OCR the PDF directly against Mistral (CORS-free) instead of our
+  // proxy, so parsing works offline-of-our-servers. In the browser this is always
+  // null → unchanged behaviour.
+  const desktopPost =
+    isTauri() && resolution.mode === "byok" && opts.byokKey
+      ? desktopMistralParse(opts.byokKey)
+      : null
   return managedParseClient({
     runId: opts.runId,
     byokKey: opts.byokKey ?? undefined,
     alwaysByok: resolution.mode === "byok",
+    ...(desktopPost ? { post: desktopPost } : {}),
   })
 }

--- a/webui/src/features/agent/engine/services/desktop-parse.test.ts
+++ b/webui/src/features/agent/engine/services/desktop-parse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { desktopMistralParse } from "./desktop-parse"
+
+
+describe("desktopMistralParse", () => {
+  it("posts the PDF as a base64 data-URI with the BYOK key and joins page markdown", async () => {
+    const calls: { url: string; init?: RequestInit }[] = []
+    const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: url as string, init })
+      return new Response(
+        JSON.stringify({ pages: [{ index: 0, markdown: "# One" }, { index: 1, markdown: "Two" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    }) as typeof fetch
+
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "doc.pdf", { type: "application/pdf" })
+    const res = await desktopMistralParse("sk-mistral", fakeFetch)(file)
+
+    expect(res).toEqual({ markdown: "# One\n\nTwo", pages: 2 })
+    expect(calls[0].url).toBe("https://api.mistral.ai/v1/ocr")
+    expect(new Headers(calls[0].init?.headers).get("Authorization")).toBe("Bearer sk-mistral")
+    const body = JSON.parse(calls[0].init?.body as string)
+    expect(body.model).toBe("mistral-ocr-latest")
+    expect(body.document.type).toBe("document_url")
+    expect(body.document.document_url).toMatch(/^data:application\/pdf;base64,/)
+  })
+
+  it("throws with the provider status on a non-2xx reply", async () => {
+    const fakeFetch = (async () => new Response("bad key", { status: 401 })) as typeof fetch
+    const file = new File([new Uint8Array([0])], "doc.pdf", { type: "application/pdf" })
+    await expect(desktopMistralParse("bad", fakeFetch)(file)).rejects.toThrow(/401/)
+  })
+})

--- a/webui/src/features/agent/engine/services/desktop-parse.ts
+++ b/webui/src/features/agent/engine/services/desktop-parse.ts
@@ -1,0 +1,52 @@
+/**
+ * Desktop-direct BYOK document parsing — OCR a PDF straight from the Tauri
+ * webview (CORS-free via plugin-http) with the user's own Mistral key, returning
+ * the same shape `/ai/parse` does, so the parse client is unchanged. This is what
+ * lets document Q&A ingest work fully offline-of-our-servers on desktop.
+ *
+ * Mistral OCR takes the PDF as a base64 data-URI in one request (same call the
+ * backend `MistralParser` makes) — no multi-step upload.
+ */
+import { providerPostJson, type FetchFn } from "./desktop-http"
+
+
+type ParseResponse = { markdown: string; pages: number }
+type ParsePost = (file: File) => Promise<ParseResponse>
+
+type OcrPage = { index?: number; markdown?: string }
+type OcrResponse = { pages?: OcrPage[] }
+
+
+/** Base64-encode a File's bytes, chunked so the char-code spread stays in-bounds. */
+const fileToBase64 = async (file: File): Promise<string> => {
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const chunk = 0x8000
+  let binary = ""
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
+
+/** Direct Mistral OCR (BYOK), mapped to the `/ai/parse` `{ markdown, pages }` shape. */
+export const desktopMistralParse =
+  (apiKey: string, fetchImpl?: FetchFn): ParsePost =>
+  async (file) => {
+    const b64 = await fileToBase64(file)
+    const res = await providerPostJson<OcrResponse>(
+      "https://api.mistral.ai/v1/ocr",
+      {
+        model: "mistral-ocr-latest",
+        document: { type: "document_url", document_url: `data:application/pdf;base64,${b64}` },
+        include_image_base64: false,
+      },
+      { Authorization: `Bearer ${apiKey}` },
+      fetchImpl,
+    )
+    const pages = res.pages ?? []
+    return {
+      markdown: pages.map((p) => p.markdown ?? "").join("\n\n"),
+      pages: pages.length,
+    }
+  }

--- a/webui/src/features/agent/engine/services/desktop-search.test.ts
+++ b/webui/src/features/agent/engine/services/desktop-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { desktopLinkupSearch, desktopSearchPost } from "./desktop-search"
+import { desktopExaSearch, desktopLinkupSearch, desktopSearchPost } from "./desktop-search"
 
 
 describe("desktopLinkupSearch", () => {
@@ -40,10 +40,32 @@ describe("desktopLinkupSearch", () => {
 })
 
 
+describe("desktopExaSearch", () => {
+  it("uses the x-api-key header and maps text/summary to content", async () => {
+    const calls: { url: string; init?: RequestInit }[] = []
+    const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: url as string, init })
+      return new Response(
+        JSON.stringify({ results: [{ url: "https://a.com", title: "A", text: "alpha" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    }) as typeof fetch
+
+    const res = await desktopExaSearch("exa-key", fakeFetch)({ query: "q" })
+
+    expect(res.results).toEqual([{ url: "https://a.com", title: "A", content: "alpha" }])
+    expect(calls[0].url).toBe("https://api.exa.ai/search")
+    expect(new Headers(calls[0].init?.headers).get("x-api-key")).toBe("exa-key")
+  })
+})
+
+
 describe("desktopSearchPost", () => {
-  it("returns a client for a ported engine (linkup) and null otherwise", () => {
-    expect(desktopSearchPost("linkup", "k")).toBeTypeOf("function")
-    expect(desktopSearchPost("tavily", "k")).toBeNull()
+  it("returns a client for every ported engine, null for unported/undefined", () => {
+    for (const engine of ["linkup", "tavily", "perplexity", "exa"]) {
+      expect(desktopSearchPost(engine, "k")).toBeTypeOf("function")
+    }
+    expect(desktopSearchPost("bing", "k")).toBeNull()
     expect(desktopSearchPost(undefined, "k")).toBeNull()
   })
 })

--- a/webui/src/features/agent/engine/services/desktop-search.ts
+++ b/webui/src/features/agent/engine/services/desktop-search.ts
@@ -4,8 +4,8 @@
  * does, so the search client is unchanged. This is what lets web search work
  * fully offline-of-our-servers on desktop with the user's own key.
  *
- * Only providers ported here work desktop-direct; an unported engine falls back
- * to the (online) `/ai/search` path. Extend `DESKTOP_SEARCH` as more are ported.
+ * Request/response shapes mirror the backend `websearch/tools.py`. An engine not
+ * in `DESKTOP_SEARCH` falls back to the (online) `/ai/search` path.
  */
 import { providerPostJson, type FetchFn } from "./desktop-http"
 import type { SearchResult } from "./clients"
@@ -14,39 +14,81 @@ import type { SearchResult } from "./clients"
 type SearchResponse = { answer: string; results: SearchResult[] }
 type SearchPost = (body: { query: string; engine?: string }) => Promise<SearchResponse>
 
-type LinkupResult = { url: string; name?: string; content?: string; favicon?: string }
+const asResults = (results: SearchResult[]): SearchResponse => ({ answer: "", results })
 
 
-/** Direct Linkup search (BYOK), mapped to the `/ai/search` reply shape. */
+/** Direct Linkup search (BYOK). */
 export const desktopLinkupSearch =
   (apiKey: string, fetchImpl?: FetchFn): SearchPost =>
   async (body) => {
-    const res = await providerPostJson<{ results?: LinkupResult[] }>(
+    const res = await providerPostJson<{ results?: Array<{ url: string; name?: string; content?: string }> }>(
       "https://api.linkup.so/v1/search",
       { q: body.query, outputType: "searchResults", depth: "standard" },
       { Authorization: `Bearer ${apiKey}` },
       fetchImpl,
     )
-    return {
-      answer: "",
-      results: (res.results ?? []).map((r) => ({
-        url: r.url,
-        title: r.name ?? "",
-        content: r.content ?? "",
-      })),
-    }
+    return asResults((res.results ?? []).map((r) => ({ url: r.url, title: r.name ?? "", content: r.content ?? "" })))
   }
 
 
-/** Ported desktop-direct BYOK search providers, keyed by engine id. */
+/** Direct Tavily search (BYOK). */
+export const desktopTavilySearch =
+  (apiKey: string, fetchImpl?: FetchFn): SearchPost =>
+  async (body) => {
+    const res = await providerPostJson<{ results?: Array<{ url: string; title?: string; content?: string }> }>(
+      "https://api.tavily.com/search",
+      { query: body.query, max_results: 10, search_depth: "advanced", auto_parameters: true },
+      { Authorization: `Bearer ${apiKey}` },
+      fetchImpl,
+    )
+    return asResults((res.results ?? []).map((r) => ({ url: r.url, title: r.title ?? "", content: r.content ?? "" })))
+  }
+
+
+/** Direct Perplexity search (BYOK). */
+export const desktopPerplexitySearch =
+  (apiKey: string, fetchImpl?: FetchFn): SearchPost =>
+  async (body) => {
+    const res = await providerPostJson<{ results?: Array<{ url: string; title?: string; snippet?: string }> }>(
+      "https://api.perplexity.ai/search",
+      { query: body.query, max_results: 10, max_tokens_per_page: 1200 },
+      { Authorization: `Bearer ${apiKey}` },
+      fetchImpl,
+    )
+    return asResults((res.results ?? []).map((r) => ({ url: r.url, title: r.title ?? "", content: r.snippet ?? "" })))
+  }
+
+
+/** Direct Exa search (BYOK). Uses the `x-api-key` header, not a bearer token. */
+export const desktopExaSearch =
+  (apiKey: string, fetchImpl?: FetchFn): SearchPost =>
+  async (body) => {
+    const res = await providerPostJson<{
+      results?: Array<{ url: string; title?: string; text?: string; summary?: string }>
+    }>(
+      "https://api.exa.ai/search",
+      { query: body.query, type: "fast", numResults: 10, contents: { context: true } },
+      { "x-api-key": apiKey },
+      fetchImpl,
+    )
+    return asResults(
+      (res.results ?? []).map((r) => ({ url: r.url, title: r.title ?? "", content: r.text ?? r.summary ?? "" })),
+    )
+  }
+
+
+/** Ported desktop-direct BYOK search providers, keyed by engine id (byok-store `SearchEngine`). */
 const DESKTOP_SEARCH: Record<string, (apiKey: string) => SearchPost> = {
   linkup: (apiKey) => desktopLinkupSearch(apiKey),
+  tavily: (apiKey) => desktopTavilySearch(apiKey),
+  perplexity: (apiKey) => desktopPerplexitySearch(apiKey),
+  exa: (apiKey) => desktopExaSearch(apiKey),
 }
 
 
 /**
  * A desktop-direct `SearchPost` for the engine, or `null` if that engine isn't
- * ported yet (caller then keeps the online `/ai/search` path).
+ * ported (caller then keeps the online `/ai/search` path).
  */
 export const desktopSearchPost = (engine: string | undefined, apiKey: string): SearchPost | null => {
   const make = engine ? DESKTOP_SEARCH[engine] : undefined


### PR DESCRIPTION
Follow-up to #178, **stacked on it** (uses that PR's `desktop-http` relay). Closes the last offline gap in the desktop BYOK agent: `parse` and non-Linkup search now work fully offline with the user's own keys, matching LLM + Linkup search.

## What's in it

**Parse (Mistral OCR), desktop-direct** — `desktop-parse.ts`: OCR a PDF straight from the webview via `plugin-http` with the user's Mistral key, returning the same `{ markdown, pages }` shape as `/ai/parse`, so `doc-parse.ts` / ingest are unchanged. `resolveParseClient` uses it on `isTauri() && byok`. Document Q&A ingest now works offline; previously `parse` resolved to `off` offline and the upload greyed out.

The single-POST base64 data-URI approach was **confirmed against the backend** — `MistralParser` makes the exact same call (`document: { type: "document_url", document_url: "data:application/pdf;base64,…" }`), so no fragile multi-step upload.

**More BYOK search engines** — ported `tavily` / `perplexity` / `exa` alongside `linkup` into `DESKTOP_SEARCH` (request/response shapes mirror `backend/.../websearch/tools.py`; Exa uses `x-api-key`). Any BYOK search engine now works offline, not just Linkup. Registry keys match the byok-store `SearchEngine` union.

**Capabilities** — granted the four provider hosts (`tavily.com`, `perplexity.ai`, `exa.ai`, `mistral.ai`) in the http allow-list.

## Unchanged
Managed (online) path is untouched; the browser build is unaffected (everything `isTauri()`-gated). `fetch`/`code_interpreter` remain managed-only by existing design.

## Verification
- ✅ `check-all` clean; full vitest **1104/1104**
- New unit tests: `desktop-parse` (base64 data-URI request shape + page→markdown mapping + non-2xx error) and `desktop-search` Exa mapping + all four engines registered.
- ▶︎ On-device (needs the native window): OCR a real PDF offline with a Mistral key; run each BYOK search engine offline.

## Merge order
Rebase/retarget to `main` once #178 lands.