### PR TITLE
ci(desktop): Tauri installer build workflow + window sizing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,75 @@
+name: Desktop Build
+
+# Builds the standalone Tauri desktop app (installers) for macOS, Linux, and
+# Windows and uploads them as artifacts. Manual trigger — desktop builds are
+# heavy, so they don't run on every push. Unsigned; code-signing / notarization
+# is a later step (needs platform secrets).
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-latest = Apple Silicon (arm64). ubuntu-22.04 for a more portable
+        # AppImage glibc. windows-latest for the MSI/NSIS installers.
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: webui/src-tauri
+
+      # The Tauri crate links webkit2gtk/gtk on Linux; rusqlite's bundled SQLite
+      # needs a C toolchain (present by default).
+      - name: Install Tauri system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxdo-dev \
+            patchelf
+
+      - name: Install webui dependencies
+        run: npm ci
+        working-directory: webui
+
+      # The frontend build script loads ../.env via dotenv; the desktop app
+      # resolves its server URL at runtime, so the sample values suffice to build.
+      - name: Provide build env
+        run: cp .env.sample .env
+
+      - name: Build desktop app (installers)
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: webui
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: dim0-desktop-${{ matrix.platform }}
+          path: webui/src-tauri/target/release/bundle/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ up-build: ## Force rebuild images, then start all services for $(PROFILE)
 build: ## Just (re)build images (no start)
 	$(COMPOSE) --profile $(PROFILE) build
 
+.PHONY: desktop-dev
+desktop-dev: ## Run the Tauri desktop app in dev (native window + hot reload); needs Rust
+	cd webui && npm run tauri-dev
+
+.PHONY: desktop-build
+desktop-build: ## Build the desktop installer for this OS → webui/src-tauri/target/release/bundle
+	cd webui && npm run tauri-build
+
 .PHONY: pull
 pull: ## Pull published backend and webui images for DIM0_VERSION
 	DIM0_VERSION=$(DIM0_VERSION) $(COMPOSE_IMAGES_BASE) pull backend webui

--- a/webui/src-tauri/tauri.conf.json
+++ b/webui/src-tauri/tauri.conf.json
@@ -13,8 +13,11 @@
     "windows": [
       {
         "title": "Dim0",
-        "width": 1920,
-        "height": 1080,
+        "width": 1440,
+        "height": 900,
+        "minWidth": 900,
+        "minHeight": 600,
+        "center": true,
         "resizable": true,
         "fullscreen": false
       }


### PR DESCRIPTION
Stacked on #178. Answers two gaps you flagged: there was **no build action** (only a `cargo test` job), and the window size needed tightening.

## Desktop Build workflow (`.github/workflows/desktop-build.yml`)
- **Trigger:** `workflow_dispatch` (manual) — desktop builds are heavy, so they don't run on every push.
- **Matrix:** `macos-latest` (Apple Silicon / arm64), `ubuntu-22.04` (older glibc → more portable AppImage), `windows-latest` (MSI/NSIS).
- Uses **`tauri-apps/tauri-action@v0`** (`projectPath: webui`), with Node + Rust + cargo cache, Linux WebKit/GTK deps, and `cp .env.sample .env` (the frontend build's dotenv needs a file; the desktop app resolves its server URL at runtime).
- Uploads the built installers as artifacts (`dim0-desktop-<platform>`, 14-day retention).
- **Unsigned** for now — code-signing (Apple notarization / Windows Authenticode) needs platform secrets; that's a deliberate later step, called out so it's not a surprise.

## Window sizing (`tauri.conf.json`)
We *did* specify resolution, but `1920x1080` opened larger than many laptop screens and there were no floors. Now:
- default **1440×900** (moderate), **minWidth 900 / minHeight 600** (can't shrink to unusable), **center: true**, still resizable.

## Notes
- No secrets required to run it; produces test/review builds.
- To ship signed releases later: add signing secrets + (optionally) switch the trigger to release/tag and let `tauri-action` attach to a GitHub release.
- Retarget to `main` once #178 lands.