### PR TITLE
feat(desktop): release workflow + install scripts + README download

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -8,9 +8,9 @@ name: Desktop Release
 # (`desktop-build.yml` is the workflow_dispatch "does it compile on every OS" check;
 # this one is the tag-driven publish.)
 #
-# The public server URL is baked in from the `DESKTOP_API_URL` repo variable — the
-# same VITE_API_URL the web frontend uses. Unset ⇒ a local-only build that asks the
-# user to connect a server.
+# The public server URL is baked in from the `API_ORIGIN` repo variable — the same
+# server-origin var `.env` uses — into VITE_API_URL. Unset ⇒ a local-only build that
+# asks the user to connect a server.
 on:
   push:
     tags: ["v*"]
@@ -63,19 +63,19 @@ jobs:
         run: npm ci
         working-directory: webui
 
-      # Bake VITE_API_URL (the server users sign in to) from the DESKTOP_API_URL repo
-      # variable; unset ⇒ drop it entirely → a local-only build. bash so it runs the
-      # same on the Windows runner (git-bash).
+      # Bake VITE_API_URL (the server users sign in to) from the API_ORIGIN repo
+      # variable — the same server-origin var `.env` uses. Unset ⇒ drop it entirely
+      # → a local-only build. bash so it runs the same on the Windows runner (git-bash).
       - name: Prepare build env
         shell: bash
         run: |
           cp .env.sample .env
           grep -v '^VITE_API_URL=' .env > .env.tmp && mv .env.tmp .env
-          if [ -n "${DESKTOP_API_URL}" ]; then
-            echo "VITE_API_URL=${DESKTOP_API_URL}" >> .env
+          if [ -n "${API_ORIGIN}" ]; then
+            echo "VITE_API_URL=${API_ORIGIN}" >> .env
           fi
         env:
-          DESKTOP_API_URL: ${{ vars.DESKTOP_API_URL }}
+          API_ORIGIN: ${{ vars.API_ORIGIN }}
 
       - name: Build desktop installers
         run: npm run tauri-build

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,126 @@
+name: Desktop Release
+
+# Cut a desktop release: push a version tag (e.g. `v0.3.60`) → build installers for
+# macOS, Linux, and Windows → publish ONE GitHub Release with them attached, plus a
+# curl-installable macOS `.app` zip (see install.sh). A tag with a prerelease part
+# (e.g. `v0.3.60-rc.1`) publishes as a pre-release.
+#
+# (`desktop-build.yml` is the workflow_dispatch "does it compile on every OS" check;
+# this one is the tag-driven publish.)
+#
+# The public server URL is baked in from the `DESKTOP_API_URL` repo variable — the
+# same VITE_API_URL the web frontend uses. Unset ⇒ a local-only build that asks the
+# user to connect a server.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the release + upload assets
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: webui/src-tauri
+
+      - name: Install Tauri system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxdo-dev \
+            patchelf
+
+      - name: Install webui dependencies
+        run: npm ci
+        working-directory: webui
+
+      # Bake VITE_API_URL (the server users sign in to) from the DESKTOP_API_URL repo
+      # variable; unset ⇒ drop it entirely → a local-only build. bash so it runs the
+      # same on the Windows runner (git-bash).
+      - name: Prepare build env
+        shell: bash
+        run: |
+          cp .env.sample .env
+          grep -v '^VITE_API_URL=' .env > .env.tmp && mv .env.tmp .env
+          if [ -n "${DESKTOP_API_URL}" ]; then
+            echo "VITE_API_URL=${DESKTOP_API_URL}" >> .env
+          fi
+        env:
+          DESKTOP_API_URL: ${{ vars.DESKTOP_API_URL }}
+
+      - name: Build desktop installers
+        run: npm run tauri-build
+        working-directory: webui
+
+      # install.sh curls a zip of the .app (not the .dmg): a terminal download isn't
+      # Gatekeeper-quarantined, so the ad-hoc-signed app launches with no prompt.
+      - name: Package macOS .app zip
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          ditto -c -k --keepParent \
+            "webui/src-tauri/target/release/bundle/macos/Dim0.app" \
+            "Dim0-aarch64-mac.zip"
+
+      - name: Collect installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: dim0-${{ matrix.platform }}
+          path: |
+            webui/src-tauri/target/release/bundle/dmg/*.dmg
+            webui/src-tauri/target/release/bundle/appimage/*.AppImage
+            webui/src-tauri/target/release/bundle/deb/*.deb
+            webui/src-tauri/target/release/bundle/msi/*.msi
+            webui/src-tauri/target/release/bundle/nsis/*-setup.exe
+            Dim0-aarch64-mac.zip
+          if-no-files-found: ignore
+          retention-days: 14
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all installers
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          files: dist/**
+          fail_on_unmatched_files: false

--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ Stop it with `make down-run` (add `make kill-run` to wipe volumes).
 
 > Want to hack on the source instead of the images? See **[Run from source](#run-from-source)** below.
 
+## Desktop app
+
+Prefer a native app? Dim0 ships a standalone desktop build (macOS · Linux · Windows) that runs **fully local and offline on your own keys** — boards live on-device and the agent calls providers directly. Sign in to use managed AI and sync boards across devices.
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/vcmf/dim0/main/install.sh | sh
+```
+
+**Windows** (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/vcmf/dim0/main/install.ps1 | iex
+```
+
+The install scripts fetch the latest release from your terminal, so the app launches **without a Gatekeeper / SmartScreen prompt** (it's ad-hoc signed; not yet notarized). You can also grab installers straight from the [Releases page](https://github.com/vcmf/dim0/releases) — a browser download shows the usual first-run security prompt until we notarize.
+
 ## What it is
 
 Most AI tools start with a chat box and bolt the rest of the product on around it. Dim0 goes the other way - the board is the workspace, and the agent is one of the things living on it.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,25 @@
+# Dim0 desktop installer for Windows (PowerShell).
+#   irm https://raw.githubusercontent.com/vcmf/dim0/main/install.ps1 | iex
+#
+# Downloads the newest release's installer and runs it. Fetched from the terminal,
+# so it carries no mark-of-the-web and skips the SmartScreen prompt a browser
+# download would trigger. (A UAC elevation prompt for the installer is still expected.)
+$ErrorActionPreference = "Stop"
+$repo = "vcmf/dim0"
+
+Write-Host "`nInstalling Dim0..."
+$release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+Write-Host "  latest release: $($release.tag_name)"
+
+# Prefer the NSIS setup .exe; fall back to the MSI.
+$asset = $release.assets | Where-Object { $_.name -like "*setup.exe" } | Select-Object -First 1
+if (-not $asset) { $asset = $release.assets | Where-Object { $_.name -like "*.msi" } | Select-Object -First 1 }
+if (-not $asset) { throw "no Windows build found in $($release.tag_name)" }
+
+$out = Join-Path $env:TEMP $asset.name
+Write-Host "  downloading $($asset.name)"
+Invoke-WebRequest $asset.browser_download_url -OutFile $out
+
+Write-Host "  launching the installer..."
+Start-Process -FilePath $out -Wait
+Write-Host "`nDone. Dim0 should be in your Start menu.`n"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Dim0 desktop installer for macOS and Linux.
+#   curl -fsSL https://raw.githubusercontent.com/vcmf/dim0/main/install.sh | sh
+#
+# Downloads the newest release for your OS from GitHub. Terminal downloads are not
+# Gatekeeper-quarantined, so on macOS this launches with no security prompt (the app
+# is ad-hoc signed; a browser .dmg download is not notarized yet and would prompt).
+set -eu
+
+REPO="vcmf/dim0"
+API="https://api.github.com/repos/$REPO/releases/latest"
+
+say() { printf '  %s\n' "$1"; }
+die() { printf '\nDim0 install failed: %s\n' "$1" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is required"
+
+printf '\nInstalling Dim0...\n'
+json="$(curl -fsSL "$API")" || die "could not reach GitHub"
+tag="$(printf '%s' "$json" | grep -oE '"tag_name": *"[^"]+"' | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+[ -n "${tag:-}" ] && say "latest release: $tag"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os" in
+  Darwin)
+    [ "$arch" = "arm64" ] || die "only Apple Silicon (arm64) is built right now; yours is $arch"
+    url="$(printf '%s' "$json" | grep -oE 'https://[^"]+-mac\.zip' | head -1)"
+    [ -n "$url" ] || die "no macOS build found in $tag"
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    say "downloading $(basename "$url")"
+    curl -fsSL "$url" -o "$tmp/dim0.zip" || die "download failed"
+    /usr/bin/ditto -x -k "$tmp/dim0.zip" "$tmp" || die "could not unzip"
+    [ -d "$tmp/Dim0.app" ] || die "archive did not contain Dim0.app"
+    dest="/Applications"
+    [ -w "$dest" ] || dest="$HOME/Applications"
+    mkdir -p "$dest"
+    rm -rf "$dest/Dim0.app"
+    mv "$tmp/Dim0.app" "$dest/Dim0.app"
+    # Belt-and-suspenders: strip quarantine in case the file ever carried it.
+    xattr -dr com.apple.quarantine "$dest/Dim0.app" 2>/dev/null || true
+    say "installed to $dest/Dim0.app"
+    printf '\nDone. Launch it from Spotlight, or: open "%s/Dim0.app"\n\n' "$dest"
+    ;;
+  Linux)
+    url="$(printf '%s' "$json" | grep -oE 'https://[^"]+\.AppImage' | head -1)"
+    [ -n "$url" ] || die "no Linux build found in $tag"
+    dest="${DIM0_BIN:-$HOME/.local/bin}"
+    mkdir -p "$dest"
+    say "downloading $(basename "$url")"
+    curl -fsSL "$url" -o "$dest/dim0" || die "download failed"
+    chmod +x "$dest/dim0"
+    say "installed to $dest/dim0"
+    case ":$PATH:" in
+      *":$dest:"*) : ;;
+      *) printf '\nNote: %s is not on your PATH. Add it, or run %s/dim0 directly.\n' "$dest" "$dest" ;;
+    esac
+    printf '\nDone. Run: dim0\n\n'
+    ;;
+  *)
+    die "unsupported OS: $os (this installer covers macOS and Linux; Windows uses install.ps1)"
+    ;;
+esac

--- a/webui/src-tauri/tauri.conf.json
+++ b/webui/src-tauri/tauri.conf.json
@@ -35,6 +35,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   }
 }


### PR DESCRIPTION
Stacked on #180. Turns the desktop build into **public, prompt-free downloads** — the smterm model, adapted for Tauri.

## What's in it

**Release workflow** (`.github/workflows/desktop-release.yml`) — on a version **tag** (`v*`): build installers for macOS/Linux/Windows → publish **one GitHub Release** with all of them attached, plus a curl-installable macOS `.app` zip. (`#180`'s `desktop-build.yml` stays as the `workflow_dispatch` "does it compile" check.) Prereleases auto-detected from a `-` in the tag.

**No first-run prompt — even unsigned.** This is the key bit. The install scripts fetch from the **terminal**, and terminal downloads aren't Gatekeeper-quarantined (macOS) / carry no mark-of-the-web (Windows) — the exact triggers for those prompts. So:
- `install.sh` (macOS/Linux): `curl`s the `.app` zip → `/Applications` → `xattr -dr com.apple.quarantine` (belt-and-suspenders). Linux → AppImage to `~/.local/bin`.
- `install.ps1` (Windows): `Invoke-WebRequest` the NSIS setup `.exe` → run. No SmartScreen (UAC elevation still expected).
- `tauri.conf`: **ad-hoc sign** the macOS app (`signingIdentity: "-"`) so it actually *runs* on Apple Silicon without a Developer cert (quarantine-strip handles the *prompt*; ad-hoc handles *can it launch*).

**README** — a `## Desktop app` section with the `curl … | sh` / `irm … | iex` one-liners.

**Baked server** — the workflow writes `VITE_API_URL` from the **`API_ORIGIN` repo variable** (set it to your public server → users just sign in; unset → a local-only build).

## Caveats (documented)
- **Unsigned/unnotarized** for now — the script path is prompt-free, but a **browser** download from the Releases page still prompts until we notarize. Notarization (Apple cert + Windows Authenticode via CI secrets) + auto-update (Tauri updater) are follow-ups.
- macOS is **arm64-only** for now (matches the build); add universal/x64 later.
- Windows installer still shows a **UAC** prompt (that's elevation, not SmartScreen).

## Verify
- YAML + `tauri.conf.json` validated locally. The actual per-OS build + the no-prompt behavior can only be verified once the workflow runs on a tag (needs the GitHub runners) and you install on each OS — same "first CI run is the real test" caveat as #180.

## Merge order
Base is `ci/desktop-build` (#180); retarget to `main` after #180 (and #178) land. To cut the first release: set the `API_ORIGIN` repo variable, then push a tag.