### PR TITLE
feat(desktop): Google sign-in via system browser (loopback + PKCE) + back-to-boards

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -76,3 +76,12 @@ PASSWORD_RESET_ENABLED=false
 OPENAI_AGENTS_DISABLE_TRACING=
 OPENAI_AGENTS_DONT_LOG_MODEL_DATA=
 OPENAI_AGENTS_DONT_LOG_TOOL_DATA=
+
+# Google sign-in (optional). Enable + set a "Web application" OAuth client for the
+# web app (GIS). For the desktop (Tauri) app, add a separate "Desktop app" OAuth
+# client — the web client can't do the 127.0.0.1 loopback redirect the desktop uses.
+# The backend exchanges the desktop auth code, so its secret stays server-side.
+GOOGLE_CONNECT_ENABLED=false
+GOOGLE_CLIENT_ID=
+GOOGLE_DESKTOP_CLIENT_ID=
+GOOGLE_DESKTOP_CLIENT_SECRET=

--- a/backend/topix/api/datatypes/requests.py
+++ b/backend/topix/api/datatypes/requests.py
@@ -25,6 +25,14 @@ class GoogleSigninRequest(BaseModel):
     id_token: str
 
 
+class GoogleDesktopSigninRequest(BaseModel):
+    """Desktop loopback Google sign-in: auth code + PKCE verifier + the redirect URI."""
+
+    code: str
+    code_verifier: str
+    redirect_uri: str
+
+
 class RefreshRequest(BaseModel):
     """Refresh token request model."""
 

--- a/backend/topix/api/router/users.py
+++ b/backend/topix/api/router/users.py
@@ -10,12 +10,18 @@ from fastapi.security import OAuth2PasswordRequestForm
 from topix.api.datatypes.requests import (
     EmailVerificationRequest,
     ForgotPasswordRequest,
+    GoogleDesktopSigninRequest,
     GoogleSigninRequest,
     RefreshRequest,
     ResetPasswordRequest,
     UserSignupRequest,
 )
-from topix.api.utils.auth_methods import get_google_client_id, is_google_connect_available
+from topix.api.utils.auth_methods import (
+    get_google_client_id,
+    get_google_desktop_client_id,
+    is_google_connect_available,
+    is_google_desktop_available,
+)
 from topix.api.utils.decorators import with_standard_response
 from topix.api.utils.email_verification import (
     DEFAULT_RESEND_COOLDOWN_SECONDS,
@@ -28,7 +34,7 @@ from topix.api.utils.email_verification import (
     send_email_verification_link,
     utc_now,
 )
-from topix.api.utils.google_connect import verify_google_id_token
+from topix.api.utils.google_connect import exchange_desktop_code, verify_google_id_token
 from topix.api.utils.password_reset import (
     DEFAULT_RESET_RESEND_COOLDOWN_SECONDS,
     build_password_reset_url,
@@ -100,10 +106,13 @@ async def _issue_tokens(request: Request, user: User) -> dict:
 async def get_auth_methods():
     """Return which authentication methods are currently available."""
     google_available = is_google_connect_available()
+    desktop_available = is_google_desktop_available()
     return {
         "local": True,
         "google": google_available,
         "google_client_id": get_google_client_id() if google_available else None,
+        # The desktop app authorizes against its own "Desktop app" OAuth client.
+        "google_desktop_client_id": get_google_desktop_client_id() if desktop_available else None,
     }
 
 
@@ -125,21 +134,8 @@ async def login_for_access_token(
     return await _issue_tokens(request, user)
 
 
-@router.post("/google-signin")
-@with_standard_response
-async def google_signin(
-    response: Response,
-    request: Request,
-    body: Annotated[GoogleSigninRequest, Body(description="Google sign-in token payload")],
-):
-    """Sign in with Google when the provider is enabled and configured."""
-    if not is_google_connect_available():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Google connect is not available",
-        )
-
-    payload = verify_google_id_token(body.id_token)
+async def _google_signin_with_payload(request: Request, payload: dict):
+    """Find/create the user for a verified Google payload, then issue tokens (web + desktop)."""
     user_store: UserStore = request.app.user_store
     user = await user_store.get_user_by_google_sub(payload["sub"])
     if user is not None:
@@ -173,6 +169,40 @@ async def google_signin(
         ) from exc
 
     return await _issue_tokens(request, new_user)
+
+
+@router.post("/google-signin")
+@with_standard_response
+async def google_signin(
+    response: Response,
+    request: Request,
+    body: Annotated[GoogleSigninRequest, Body(description="Google sign-in token payload")],
+):
+    """Sign in with Google (web) — verify the GIS id_token and issue tokens."""
+    if not is_google_connect_available():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Google connect is not available",
+        )
+    payload = verify_google_id_token(body.id_token)
+    return await _google_signin_with_payload(request, payload)
+
+
+@router.post("/google-signin-desktop")
+@with_standard_response
+async def google_signin_desktop(
+    request: Request,
+    body: Annotated[GoogleDesktopSigninRequest, Body(description="Desktop loopback auth code + PKCE")],
+):
+    """Desktop Google sign-in: exchange the loopback code (PKCE) server-side, then issue tokens."""
+    if not is_google_desktop_available():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Google desktop sign-in is not available",
+        )
+    id_token = await exchange_desktop_code(body.code, body.code_verifier, body.redirect_uri)
+    payload = verify_google_id_token(id_token, audience=get_google_desktop_client_id())
+    return await _google_signin_with_payload(request, payload)
 
 
 @router.post("/signup")

--- a/backend/topix/api/utils/auth_methods.py
+++ b/backend/topix/api/utils/auth_methods.py
@@ -4,6 +4,10 @@ import os
 
 GOOGLE_CONNECT_ENABLED_ENV = "GOOGLE_CONNECT_ENABLED"
 GOOGLE_CLIENT_ID_ENV = "GOOGLE_CLIENT_ID"
+# Desktop (Tauri) uses a separate Google OAuth client of type "Desktop app" so the
+# loopback (127.0.0.1:<any port>) redirect is allowed — the web client can't do that.
+GOOGLE_DESKTOP_CLIENT_ID_ENV = "GOOGLE_DESKTOP_CLIENT_ID"
+GOOGLE_DESKTOP_CLIENT_SECRET_ENV = "GOOGLE_DESKTOP_CLIENT_SECRET"
 
 
 def _is_truthy(value: str | None) -> bool:
@@ -35,3 +39,22 @@ def get_google_client_id() -> str | None:
 def is_google_connect_available() -> bool:
     """Return whether Google connect is both enabled and configured."""
     return is_google_connect_enabled() and get_google_client_id() is not None
+
+
+def get_google_desktop_client_id() -> str | None:
+    """Return the Google "Desktop app" OAuth client id, when configured."""
+    return _read_env(GOOGLE_DESKTOP_CLIENT_ID_ENV)
+
+
+def get_google_desktop_client_secret() -> str | None:
+    """Return the Google "Desktop app" OAuth client secret, when configured."""
+    return _read_env(GOOGLE_DESKTOP_CLIENT_SECRET_ENV)
+
+
+def is_google_desktop_available() -> bool:
+    """Whether desktop (loopback+PKCE) Google sign-in is configured (own id + secret)."""
+    return (
+        is_google_connect_enabled()
+        and get_google_desktop_client_id() is not None
+        and get_google_desktop_client_secret() is not None
+    )

--- a/backend/topix/api/utils/google_connect.py
+++ b/backend/topix/api/utils/google_connect.py
@@ -1,15 +1,62 @@
 """Google connect token verification helpers."""
 
+import httpx
+
 from fastapi import HTTPException, status
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 
-from topix.api.utils.auth_methods import get_google_client_id
+from topix.api.utils.auth_methods import (
+    get_google_client_id,
+    get_google_desktop_client_id,
+    get_google_desktop_client_secret,
+)
+
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 
 
-def verify_google_id_token(id_token: str) -> dict:
-    """Verify a Google ID token and return its decoded claims."""
-    client_id = get_google_client_id()
+async def exchange_desktop_code(code: str, code_verifier: str, redirect_uri: str) -> str:
+    """Exchange a desktop loopback auth code (PKCE) for a Google ID token.
+
+    The backend holds the "Desktop app" client secret and performs the token
+    exchange, so the secret never ships in the app. Returns the raw `id_token`.
+    """
+    client_id = get_google_desktop_client_id()
+    client_secret = get_google_desktop_client_secret()
+    if not client_id or not client_secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google desktop sign-in is not configured",
+        )
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            GOOGLE_TOKEN_ENDPOINT,
+            data={
+                "code": code,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code_verifier": code_verifier,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+        )
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Google code exchange failed",
+        )
+    id_token = resp.json().get("id_token")
+    if not id_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Google token response missing id_token",
+        )
+    return id_token
+
+
+def verify_google_id_token(id_token: str, audience: str | None = None) -> dict:
+    """Verify a Google ID token against `audience` (default: web client id); return claims."""
+    client_id = audience or get_google_client_id()
     if client_id is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/webui/src-tauri/Cargo.lock
+++ b/webui/src-tauri/Cargo.lock
@@ -107,6 +107,7 @@ name = "app"
 version = "0.3.59"
 dependencies = [
  "log",
+ "open",
  "rusqlite",
  "serde",
  "serde_json",
@@ -114,6 +115,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tiny_http",
+ "urlencoding",
 ]
 
 [[package]]
@@ -121,6 +124,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "atk"
@@ -502,6 +511,12 @@ dependencies = [
  "serde",
  "windows-link 0.1.3",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1609,6 +1624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1887,25 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "itoa"
@@ -2469,6 +2509,16 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
@@ -4157,6 +4207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +4553,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/webui/src-tauri/Cargo.toml
+++ b/webui/src-tauri/Cargo.toml
@@ -29,3 +29,8 @@ tauri-plugin-http = "2"
 # transactions. Chosen over the pooled sql plugin so multi-statement writes are
 # genuinely atomic (see storage.rs).
 rusqlite = { version = "0.32", features = ["bundled"] }
+# System-browser Google OAuth (loopback + PKCE): a one-shot local server catches
+# the redirect, `open` launches the default browser. See oauth.rs.
+tiny_http = "0.12"
+open = "5"
+urlencoding = "2"

--- a/webui/src-tauri/src/lib.rs
+++ b/webui/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use tauri::Manager;
 
+mod oauth;
 mod storage;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -28,7 +29,8 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       storage::sql_execute,
       storage::sql_select,
-      storage::sql_tx
+      storage::sql_tx,
+      oauth::google_oauth
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/webui/src-tauri/src/oauth.rs
+++ b/webui/src-tauri/src/oauth.rs
@@ -25,20 +25,22 @@ fn enc(s: &str) -> String {
 }
 
 
-/// Parse `code` and `state` from a redirect request path (`/?code=..&state=..`).
-fn parse_code_state(path: &str) -> (Option<String>, Option<String>) {
+/// Read one query parameter from a request path, URL-decoded.
+fn query_param(path: &str, key: &str) -> Option<String> {
     let query = path.splitn(2, '?').nth(1).unwrap_or("");
-    let mut code = None;
-    let mut state = None;
     for pair in query.split('&') {
         let mut it = pair.splitn(2, '=');
-        match (it.next(), it.next()) {
-            (Some("code"), Some(v)) => code = urlencoding::decode(v).ok().map(|c| c.into_owned()),
-            (Some("state"), Some(v)) => state = urlencoding::decode(v).ok().map(|c| c.into_owned()),
-            _ => {}
+        if it.next() == Some(key) {
+            return it.next().and_then(|v| urlencoding::decode(v).ok()).map(|c| c.into_owned());
         }
     }
-    (code, state)
+    None
+}
+
+
+/// Parse `code` and `state` from a redirect request path (`/?code=..&state=..`).
+fn parse_code_state(path: &str) -> (Option<String>, Option<String>) {
+    (query_param(path, "code"), query_param(path, "state"))
 }
 
 
@@ -56,6 +58,7 @@ fn wait_for_code(server: Server, expected_state: &str) -> Result<String, String>
             Err(e) => return Err(e.to_string()),
         };
         let (code, state) = parse_code_state(request.url());
+        let error = query_param(request.url(), "error");
         let matched = code.is_some() && state.as_deref() == Some(expected_state);
         let body = if matched {
             "<h2>Signed in — you can close this tab and return to Dim0.</h2>"
@@ -71,6 +74,11 @@ fn wait_for_code(server: Server, expected_state: &str) -> Result<String, String>
             } else {
                 Err("OAuth state mismatch".into())
             };
+        }
+        // Google redirects with `?error=access_denied` when the user cancels/denies —
+        // fail fast instead of looping until the timeout.
+        if let Some(e) = error {
+            return Err(format!("Google sign-in was cancelled or failed: {e}"));
         }
     }
 }
@@ -118,13 +126,22 @@ pub async fn google_oauth(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_code_state;
+    use super::{parse_code_state, query_param};
 
     #[test]
     fn parses_code_and_state() {
         let (code, state) = parse_code_state("/?code=abc123&state=xyz&scope=openid");
         assert_eq!(code.as_deref(), Some("abc123"));
         assert_eq!(state.as_deref(), Some("xyz"));
+    }
+
+    #[test]
+    fn reads_error_param() {
+        assert_eq!(
+            query_param("/?error=access_denied&state=xyz", "error").as_deref(),
+            Some("access_denied"),
+        );
+        assert!(query_param("/?code=abc&state=xyz", "error").is_none());
     }
 
     #[test]

--- a/webui/src-tauri/src/oauth.rs
+++ b/webui/src-tauri/src/oauth.rs
@@ -1,0 +1,141 @@
+//! System-browser Google OAuth for the desktop app (loopback + PKCE).
+//!
+//! Google blocks OAuth inside embedded webviews, so the desktop flow opens the OS
+//! browser to Google's consent screen with a `127.0.0.1:<port>` redirect, runs a
+//! one-shot loopback server to catch the auth `code`, and returns it to the webview.
+//! The code + PKCE verifier are then exchanged for tokens **server-side** (the
+//! client secret never ships in the app).
+
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tiny_http::{Header, Response, Server};
+
+
+#[derive(Serialize)]
+pub struct OauthResult {
+    pub code: String,
+    pub redirect_uri: String,
+}
+
+
+/// Percent-encode a query-parameter value.
+fn enc(s: &str) -> String {
+    urlencoding::encode(s).into_owned()
+}
+
+
+/// Parse `code` and `state` from a redirect request path (`/?code=..&state=..`).
+fn parse_code_state(path: &str) -> (Option<String>, Option<String>) {
+    let query = path.splitn(2, '?').nth(1).unwrap_or("");
+    let mut code = None;
+    let mut state = None;
+    for pair in query.split('&') {
+        let mut it = pair.splitn(2, '=');
+        match (it.next(), it.next()) {
+            (Some("code"), Some(v)) => code = urlencoding::decode(v).ok().map(|c| c.into_owned()),
+            (Some("state"), Some(v)) => state = urlencoding::decode(v).ok().map(|c| c.into_owned()),
+            _ => {}
+        }
+    }
+    (code, state)
+}
+
+
+/// Serve the loopback until the redirect arrives (or a 5-minute timeout), matching
+/// `state` (CSRF). Stray requests (favicon, etc.) are answered and ignored.
+fn wait_for_code(server: Server, expected_state: &str) -> Result<String, String> {
+    let deadline = Instant::now() + Duration::from_secs(300);
+    loop {
+        if Instant::now() >= deadline {
+            return Err("timed out waiting for Google sign-in".into());
+        }
+        let request = match server.recv_timeout(Duration::from_secs(1)) {
+            Ok(Some(r)) => r,
+            Ok(None) => continue,
+            Err(e) => return Err(e.to_string()),
+        };
+        let (code, state) = parse_code_state(request.url());
+        let matched = code.is_some() && state.as_deref() == Some(expected_state);
+        let body = if matched {
+            "<h2>Signed in — you can close this tab and return to Dim0.</h2>"
+        } else {
+            "<h2>Sign-in failed. You can close this tab.</h2>"
+        };
+        let header =
+            Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..]).unwrap();
+        let _ = request.respond(Response::from_string(body).with_header(header));
+        if let Some(c) = code {
+            return if state.as_deref() == Some(expected_state) {
+                Ok(c)
+            } else {
+                Err("OAuth state mismatch".into())
+            };
+        }
+    }
+}
+
+
+/// Open the browser to Google's consent screen and return the auth code + the
+/// loopback redirect URI it was issued for (needed by the server-side exchange).
+/// PKCE `code_challenge` and CSRF `state` are generated in the webview.
+#[tauri::command]
+pub async fn google_oauth(
+    client_id: String,
+    scope: String,
+    code_challenge: String,
+    state: String,
+) -> Result<OauthResult, String> {
+    let server = Server::http("127.0.0.1:0").map_err(|e| e.to_string())?;
+    let port = server
+        .server_addr()
+        .to_ip()
+        .map(|addr| addr.port())
+        .ok_or_else(|| "could not resolve loopback port".to_string())?;
+    let redirect_uri = format!("http://127.0.0.1:{port}");
+
+    let auth_url = format!(
+        "https://accounts.google.com/o/oauth2/v2/auth?response_type=code\
+&client_id={}&redirect_uri={}&scope={}&code_challenge={}\
+&code_challenge_method=S256&state={}&access_type=offline&prompt=select_account",
+        enc(&client_id),
+        enc(&redirect_uri),
+        enc(&scope),
+        enc(&code_challenge),
+        enc(&state),
+    );
+
+    open::that(&auth_url).map_err(|e| format!("could not open browser: {e}"))?;
+
+    let expected = state.clone();
+    let code = tauri::async_runtime::spawn_blocking(move || wait_for_code(server, &expected))
+        .await
+        .map_err(|e| e.to_string())??;
+
+    Ok(OauthResult { code, redirect_uri })
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::parse_code_state;
+
+    #[test]
+    fn parses_code_and_state() {
+        let (code, state) = parse_code_state("/?code=abc123&state=xyz&scope=openid");
+        assert_eq!(code.as_deref(), Some("abc123"));
+        assert_eq!(state.as_deref(), Some("xyz"));
+    }
+
+    #[test]
+    fn url_decodes_values() {
+        let (code, _) = parse_code_state("/?code=a%2Fb%3Dc");
+        assert_eq!(code.as_deref(), Some("a/b=c"));
+    }
+
+    #[test]
+    fn none_when_absent() {
+        let (code, state) = parse_code_state("/favicon.ico");
+        assert!(code.is_none() && state.is_none());
+    }
+}

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -85,6 +85,8 @@ export type AuthMethods = {
   local: boolean
   google: boolean
   google_client_id?: string | null
+  /** Desktop (Tauri) authorizes against its own "Desktop app" OAuth client. */
+  google_desktop_client_id?: string | null
 }
 
 
@@ -326,6 +328,39 @@ export async function googleSignin(idToken: string): Promise<TokenPayload> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id_token: idToken }),
+  })
+
+  if (!res.ok) {
+    const message = await readErrorMessage(res, "Google sign in failed")
+    throw new Error(message)
+  }
+
+  const json: unknown = await res.json()
+  const token = (json as { data?: { token?: TokenPayload }; token?: TokenPayload }).data?.token
+    ?? (json as { token?: TokenPayload }).token
+
+  if (!token?.access_token) throw new Error("Google sign in failed")
+
+  setAccessToken(token.access_token)
+  if (token.refresh_token) setRefreshToken(token.refresh_token)
+
+  return token
+}
+
+
+/**
+ * Desktop Google sign-in: hand the loopback auth code + PKCE verifier to the
+ * backend, which exchanges them (secret stays server-side) and returns app tokens.
+ */
+export async function googleSigninDesktop(
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+): Promise<TokenPayload> {
+  const res = await trackedFetch(new URL("/users/google-signin-desktop", API_URL).toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, code_verifier: codeVerifier, redirect_uri: redirectUri }),
   })
 
   if (!res.ok) {

--- a/webui/src/features/signin/lib/desktop-google.ts
+++ b/webui/src/features/signin/lib/desktop-google.ts
@@ -1,0 +1,32 @@
+import { invoke } from "@tauri-apps/api/core"
+import { googleSigninDesktop, type TokenPayload } from "@/api"
+
+
+const b64url = (bytes: Uint8Array): string =>
+  btoa(String.fromCharCode(...bytes)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+
+
+/** A PKCE verifier + its S256 challenge (RFC 7636). */
+async function makePkce(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = b64url(crypto.getRandomValues(new Uint8Array(32)))
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))
+  return { verifier, challenge: b64url(new Uint8Array(digest)) }
+}
+
+
+/**
+ * Desktop Google sign-in via the system browser (loopback + PKCE). The Rust
+ * `google_oauth` command opens the default browser to Google's consent screen and
+ * returns the auth `code` from the loopback redirect; the backend then exchanges
+ * the code (its client secret) for tokens. Google can't run OAuth inside the
+ * webview, which is why this goes through the OS browser instead of GIS.
+ */
+export async function desktopGoogleSignin(clientId: string): Promise<TokenPayload> {
+  const { verifier, challenge } = await makePkce()
+  const state = b64url(crypto.getRandomValues(new Uint8Array(16)))
+  const { code, redirect_uri } = await invoke<{ code: string; redirect_uri: string }>(
+    "google_oauth",
+    { clientId, scope: "openid email profile", codeChallenge: challenge, state },
+  )
+  return googleSigninDesktop(code, verifier, redirect_uri)
+}

--- a/webui/src/features/signin/screens/sign-in.tsx
+++ b/webui/src/features/signin/screens/sign-in.tsx
@@ -13,6 +13,8 @@ import { Separator } from "@/components/ui/separator"
 import { Loader2Icon, LockIcon, MailIcon } from "@/components/icons"
 import { PasswordInput } from "../components/password-input"
 import { renderGoogleSigninButton } from "../lib/google-connect"
+import { desktopGoogleSignin } from "../lib/desktop-google"
+import { isTauri } from "@/platform"
 
 /** Renders the sign-in screen and routes successful authentication into the app. */
 export function SigninPage() {
@@ -67,7 +69,19 @@ export function SigninPage() {
     },
   })
 
+  // Desktop: GIS can't run in the webview, so sign in via the system browser
+  // (loopback + PKCE). Uses the "Desktop app" OAuth client, exchanged server-side.
+  const desktopGoogleMutation = useMutation({
+    mutationFn: (clientId: string) => desktopGoogleSignin(clientId),
+    onMutate: () => setGoogleError(null),
+    onSuccess: completeSignin,
+    onError: error => {
+      setGoogleError((error as Error).message || "Unable to continue with Google")
+    },
+  })
+
   React.useEffect(() => {
+    if (isTauri()) return // web-only: the GIS button doesn't work in the desktop webview
     const authMethods = authMethodsQuery.data
     const target = googleButtonRef.current
     const clientId = authMethods?.google_client_id
@@ -106,9 +120,13 @@ export function SigninPage() {
   }, [authMethodsQuery.data, googleSigninMutation])
 
   const authMethods = authMethodsQuery.data
+  const desktop = isTauri()
   const showLocalSignin = authMethods?.local ?? true
-  const showGoogleSignin = Boolean(authMethods?.google && authMethods.google_client_id)
-  const showSeparator = showLocalSignin && showGoogleSignin
+  // Web uses GIS (needs the web client id); desktop uses the system-browser flow
+  // (needs the "Desktop app" client id). Never both.
+  const showGoogleWeb = !desktop && Boolean(authMethods?.google && authMethods.google_client_id)
+  const showGoogleDesktop = desktop && Boolean(authMethods?.google && authMethods.google_desktop_client_id)
+  const showSeparator = showLocalSignin && (showGoogleWeb || showGoogleDesktop)
   const localError = localSigninMutation.isError
     ? (localSigninMutation.error as Error).message || "Unable to sign in"
     : null
@@ -196,7 +214,7 @@ export function SigninPage() {
               </div>
             ) : null}
 
-            {showGoogleSignin ? (
+            {showGoogleWeb ? (
               <div className="space-y-3">
                 {googleError ? (
                   <p className="text-sm text-destructive">{googleError}</p>
@@ -213,7 +231,34 @@ export function SigninPage() {
               </div>
             ) : null}
 
-            {!authMethodsQuery.isLoading && !showLocalSignin && !showGoogleSignin ? (
+            {showGoogleDesktop ? (
+              <div className="space-y-2">
+                {googleError ? (
+                  <p className="text-sm text-destructive">{googleError}</p>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => desktopGoogleMutation.mutate(authMethods!.google_desktop_client_id!)}
+                  disabled={desktopGoogleMutation.isPending}
+                >
+                  {desktopGoogleMutation.isPending ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Loader2Icon className="h-4 w-4 animate-spin" />
+                      Continue in your browser…
+                    </span>
+                  ) : (
+                    "Continue with Google"
+                  )}
+                </Button>
+                <p className="text-center text-xs text-muted-foreground">
+                  Opens your browser to sign in, then returns here.
+                </p>
+              </div>
+            ) : null}
+
+            {!authMethodsQuery.isLoading && !showLocalSignin && !showGoogleWeb && !showGoogleDesktop ? (
               <p className="text-sm text-destructive">
                 No sign-in methods are currently available.
               </p>
@@ -256,6 +301,12 @@ export function SigninPage() {
               </span>
               <Link to="/forgot-password" className="text-muted-foreground underline">
                 Forgot password?
+              </Link>
+            </div>
+
+            <div className="text-center">
+              <Link to="/" className="text-sm text-muted-foreground underline underline-offset-2">
+                ← Back to boards
               </Link>
             </div>
           </form>

--- a/webui/src/features/signin/screens/sign-in.tsx
+++ b/webui/src/features/signin/screens/sign-in.tsx
@@ -125,7 +125,10 @@ export function SigninPage() {
   // Web uses GIS (needs the web client id); desktop uses the system-browser flow
   // (needs the "Desktop app" client id). Never both.
   const showGoogleWeb = !desktop && Boolean(authMethods?.google && authMethods.google_client_id)
-  const showGoogleDesktop = desktop && Boolean(authMethods?.google && authMethods.google_desktop_client_id)
+  // Desktop availability is independent of the web client — the backend only
+  // returns google_desktop_client_id when the Desktop OAuth client is configured,
+  // so its presence alone gates the button (a deploy may have desktop but no web).
+  const showGoogleDesktop = desktop && Boolean(authMethods?.google_desktop_client_id)
   const showSeparator = showLocalSignin && (showGoogleWeb || showGoogleDesktop)
   const localError = localSigninMutation.isError
     ? (localSigninMutation.error as Error).message || "Unable to sign in"


### PR DESCRIPTION
Stacked on #178. Fixes the two desktop sign-in issues: Google's button did nothing, and there was no way back from `/signin`.

## Why Google broke on desktop
Google **disallows OAuth inside embedded webviews** (`disallowed_useragent`), and the GIS button also validates the page origin — which is `tauri://localhost`, not a registered https origin. So the button rendered but clicking it did nothing. The fix is the standard native-app pattern: **system-browser OAuth with a loopback redirect + PKCE.**

## The flow
1. **Rust `google_oauth` command** (`src-tauri/src/oauth.rs`): opens the default browser to Google's consent screen with a `127.0.0.1:<random port>` redirect; a one-shot loopback server catches the auth `code` (CSRF `state`-checked, 5-min timeout), returns `{ code, redirect_uri }`. Query parsing is unit-tested.
2. **Frontend** (`desktop-google.ts`): generates PKCE (S256), invokes the command, hands the code + verifier to the backend.
3. **Backend** (`/users/google-signin-desktop`): exchanges the code **server-side** (the Desktop client secret never ships in the app), verifies the id_token against the desktop client's audience, and reuses the shared user-create + token path. `auth-methods` now also returns `google_desktop_client_id`.
4. `sign-in.tsx` branches on `isTauri()`: desktop shows **"Continue with Google"** (system browser); web keeps GIS unchanged.

## Also: "← Back to boards"
The native window has no browser back and the auth screen hides the sidebar, so `/signin` was a trap. Added a **"← Back to boards"** link (helps the web app too).

## Setup you must do (one-time)
Create a **Google "Desktop app" OAuth client** in Google Cloud Console (it auto-allows any `127.0.0.1` port — a Web client can't). Then set on the backend:
```
GOOGLE_CONNECT_ENABLED=true
GOOGLE_CLIENT_ID=<your web client id>            # existing, for the web GIS button
GOOGLE_DESKTOP_CLIENT_ID=<the Desktop client id>
GOOGLE_DESKTOP_CLIENT_SECRET=<the Desktop client secret>
```
Unset ⇒ the desktop Google button simply doesn't show (email/password still works).

## Verification
- ✅ Rust `cargo test` **7/7** (incl. 3 oauth parse tests), backend **ruff** clean + imports OK, frontend **check-all** + full vitest **1110/1110**.
- ▶︎ **End-to-end is untestable in the sandbox** (needs a real browser, your Desktop OAuth client, and the native window) — this is built to the standard loopback+PKCE pattern, but the **first real run on your machine is the test**. Likely first-run wrinkles: the exact Google client config / redirect handling.

## Notes
- `code`/`state` transit the loopback; the token exchange (with the secret) is backend-only.
- No new Tauri capability needed (custom command; `open` is a Rust op). No Google hosts in the http allow-list (exchange is server-side).
- Retarget to `main` after #178 lands.