### PR TITLE
fix(ci): build desktop installers from Release (token tags don't trigger workflows)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -8,12 +8,29 @@ name: Desktop Release
 # (`desktop-build.yml` is the workflow_dispatch "does it compile on every OS" check;
 # this one is the tag-driven publish.)
 #
+# Triggered three ways: `workflow_call` from the Release workflow (the normal path —
+# a GITHUB_TOKEN-pushed tag does NOT fire the `push: tags` event, so Release invokes
+# this directly), a `push` of a `v*` tag (a manually pushed tag still works), and a
+# manual `workflow_dispatch` to (re)build a specific existing tag.
+#
 # The public server URL is baked in from the `API_ORIGIN` repo variable — the same
 # server-origin var `.env` uses — into VITE_API_URL. Unset ⇒ a local-only build that
 # asks the user to connect a server.
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to build installers for and attach (e.g. v0.3.61)
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: Version tag to build installers for and attach (e.g. v0.3.61)
+        required: true
+        type: string
 
 permissions:
   contents: write # create the release + upload assets
@@ -30,6 +47,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # push: builds the pushed tag. call/dispatch: build the requested tag
+          # (the reusable-workflow default would otherwise be the caller's ref).
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -118,9 +139,9 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: ${{ inputs.tag || github.ref_name }}
+          prerelease: ${{ contains(inputs.tag || github.ref_name, '-') }}
           generate_release_notes: true
           files: dist/**
           fail_on_unmatched_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,14 @@ jobs:
       ref: refs/tags/v${{ needs.release.outputs.version }}
       push_latest: true
     secrets: inherit
+
+  # Build + attach the desktop installers. Called directly (not via the tag event)
+  # because the release tag is pushed with GITHUB_TOKEN, which does not fire
+  # `push: tags` in other workflows.
+  desktop:
+    needs: release
+    if: needs.release.outputs.has_changes == 'true'
+    uses: ./.github/workflows/desktop-release.yml
+    with:
+      tag: v${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Problem
Releases ship with **no desktop installers** — `install.sh` reports "no macOS build found in vX.Y.Z". Desktop Release never runs.

**Root cause:** Release pushes the `v*` tag using the workflow `GITHUB_TOKEN`. GitHub deliberately does **not** fire `on: push: tags` in other workflows for refs pushed by `GITHUB_TOKEN` (prevents recursive runs). Desktop Release listened only on `push: tags`, so it never triggered. (Docker Publish was unaffected — Release calls it via `workflow_call`.)

## Fix
Wire Desktop Release into Release the same way Docker Publish already is:
- `desktop-release.yml` gains `workflow_call` + `workflow_dispatch`, each with a `tag` input. The build checks out that tag (`inputs.tag || github.ref_name`) and the publish step attaches to it.
- `release.yml` gains a `desktop` job that calls `desktop-release.yml` via `workflow_call` with `tag: vX.Y.Z`.
- The original `push: tags` trigger stays, so a **manually** pushed tag still builds.

After this, one `Release` run tags → publishes → builds Docker **and** desktop installers.

## Backfilling v0.3.61
Once merged, `gh workflow run desktop-release.yml -f tag=v0.3.61` builds + attaches the installers to the existing v0.3.61 release (no re-tagging needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)