### PR TITLE
fix(ci): raise Node heap for desktop builds (macOS runner OOM)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -65,6 +65,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: webui
+        env:
+          # See desktop-release.yml: the ~7 GB macOS runner OOMs the main
+          # `vite build` at Node's default heap; pin it to 4 GB.
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Upload installers
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -101,6 +101,11 @@ jobs:
       - name: Build desktop installers
         run: npm run tauri-build
         working-directory: webui
+        env:
+          # Pin the V8 heap: Node auto-sizes to available RAM, so the ~7 GB macOS
+          # runner defaults to ~2 GB and OOMs on the main `vite build` (works
+          # locally on 16 GB+). 4 GB matches a dev machine and fits every runner.
+          NODE_OPTIONS: --max-old-space-size=4096
 
       # install.sh curls a zip of the .app (not the .dmg): a terminal download isn't
       # Gatekeeper-quarantined, so the ad-hoc-signed app launches with no prompt.


### PR DESCRIPTION
## Problem
The desktop **macOS** build fails with `FATAL ERROR: ... JavaScript heap out of memory` (`beforeBuildCommand npm run build` → exit 134). The mini-app build succeeds; the larger **main `vite build`** OOMs.

## Cause
Node auto-sizes its V8 old-space heap to available RAM. The `macos-latest` (M1) runner has ~7 GB → default heap ~2 GB, where a 16 GB+ dev machine gets ~4 GB. The build peaks above ~2 GB, so it OOMs only on CI.

## Fix
Pin `NODE_OPTIONS=--max-old-space-size=4096` on the tauri build step in both `desktop-release.yml` and `desktop-build.yml`.

## After merge
Re-build installers for the current tag: `gh workflow run desktop-release.yml -f tag=v0.3.62`

🤖 Generated with [Claude Code](https://claude.com/claude-code)