### PR TITLE
fix(ci): desktop release publish — scope artifacts + derive app version

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -138,6 +138,11 @@ jobs:
       - name: Download all installers
         uses: actions/download-artifact@v4
         with:
+          # Only the desktop build artifacts (dim0-<platform>). When invoked via
+          # workflow_call from Release, the run also holds the docker job's
+          # `*.dockerbuild` artifact; downloading everything pulls that in and the
+          # step dies on it ("failed after 5 retries").
+          pattern: dim0-*
           path: dist
           merge-multiple: true
 


### PR DESCRIPTION
Two desktop-release-correctness fixes.

## 1. Publish downloads only its own artifacts
`desktop / publish` failed: `Unable to download artifact(s): ... failed after 5 retries`. Run via `workflow_call` inside the Release run, the publish step's `download-artifact` (no filter) grabbed **all** run artifacts — including Docker's `vcmf~dim0~*.dockerbuild` blob, which is the one that fails. Scope it: `pattern: dim0-*`.

## 2. Desktop app version was stuck at 0.3.59
`tauri.conf.json` hardcoded `"version": "0.3.59"` and `sync_version.py` never updated it, so builds shipped stamped `0.3.59` regardless of the release (installers named `Dim0_0.3.59_*`). Remove the field → Tauri v2 derives the version from `Cargo.toml`, which the release already bumps.

## Note
v0.3.63 is already published + installable (built via a standalone dispatch), but its app version reads 0.3.59 due to #2. The next release (v0.3.64) will be correctly versioned once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)