### PR TITLE
fix(webui): load self-hosted fonts in the mini-app runtime

### DIFF
--- a/webui/mini-app-runtime/main.tsx
+++ b/webui/mini-app-runtime/main.tsx
@@ -19,6 +19,11 @@ import { handleHostMessage, setHostInitialState } from "./rpc"
 import { MINI_APP_SCOPE_NAMES, MINI_APP_SCOPE_VALUES } from "./scope"
 import { isSingleFrontend } from "./single-frontend"
 import "./runtime.css"
+// Self-hosted fonts (same as the main app). runtime.css re-uses src/index.css,
+// which only defines the `--font-*` vars — the actual @font-face declarations
+// live in src/fonts.ts. Import them here too or the mini-app falls back to
+// system fonts. viteSingleFile inlines the woff2 into the one-file bundle.
+import "../src/fonts"
 // Tailwind v4's browser build JIT-compiles utility classes at runtime
 // by scanning the live DOM. Critical for mini-apps: the agent's JSX is
 // a string at compile time, so the static @tailwindcss/vite plugin


### PR DESCRIPTION
## Problem
Mini-app text renders in macOS system fonts instead of the app's fonts — serif titles show as Snell Roundhand, body as system-ui, etc.

## Cause
The mini-app (`mini-app-runtime/`) reuses `src/index.css` via `runtime.css`, which is where the Google Fonts `@import` used to load the font *files*. Self-hosting moved the `@font-face` declarations into `src/fonts.ts`, imported only by the **main** app's `main.tsx`. The mini-app kept the `--font-*` vars but loaded no faces, so every `font-family: var(--font-*)` fell through to its generic fallback.

## Fix
Import `src/fonts` from `mini-app-runtime/main.tsx` too. `viteSingleFile` inlines the woff2 into the one-file bundle (verified: 82 inlined woff2, all five families declared). The generated `public/mini-app/index.html` is gitignored and regenerated by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)