### PR TITLE
fix(build): honor ENVFILE in the desktop make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,20 @@ up-build: ## Force rebuild images, then start all services for $(PROFILE)
 build: ## Just (re)build images (no start)
 	$(COMPOSE) --profile $(PROFILE) build
 
+# ENVFILE reaches the webui build via npm_config_envfile, which its scripts read
+# as `dotenv -e ../$npm_config_envfile`. Set it explicitly (not `npm --envfile=`,
+# which leans on npm's unknown-flag→config passthrough) so it can't regress on a
+# future npm; it then propagates through `tauri {dev,build}` → its before*Command.
+# $(strip) drops the trailing spaces the ENVFILE default carries from its inline
+# comment. ENVFILE must be repo-root-relative (the build prefixes `../`), same as
+# the default `.env`; an absolute path won't resolve.
 .PHONY: desktop-dev
 desktop-dev: ## Run the Tauri desktop app in dev (native window + hot reload); needs Rust
-	cd webui && npm run tauri-dev --envfile=$(ENVFILE)
+	cd webui && npm_config_envfile="$(strip $(ENVFILE))" npm run tauri-dev
 
 .PHONY: desktop-build
 desktop-build: ## Build the desktop installer for this OS → webui/src-tauri/target/release/bundle
-	cd webui && npm run tauri-build --envfile=$(ENVFILE)
+	cd webui && npm_config_envfile="$(strip $(ENVFILE))" npm run tauri-build
 
 .PHONY: pull
 pull: ## Pull published backend and webui images for DIM0_VERSION

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ build: ## Just (re)build images (no start)
 
 .PHONY: desktop-dev
 desktop-dev: ## Run the Tauri desktop app in dev (native window + hot reload); needs Rust
-	cd webui && npm run tauri-dev
+	cd webui && npm run tauri-dev --envfile=$(ENVFILE)
 
 .PHONY: desktop-build
 desktop-build: ## Build the desktop installer for this OS → webui/src-tauri/target/release/bundle
-	cd webui && npm run tauri-build
+	cd webui && npm run tauri-build --envfile=$(ENVFILE)
 
 .PHONY: pull
 pull: ## Pull published backend and webui images for DIM0_VERSION


### PR DESCRIPTION
## Problem
`ENVFILE=.env.prod` overrides correctly for every docker-compose target (`--env-file $(ENVFILE)`), but **not** for `make desktop-dev` / `make desktop-build` — they ran `npm run tauri-{dev,build}` without forwarding it. The webui build reads a different knob (`${npm_config_envfile:-.env}`), so those targets always used `.env`, silently baking the wrong `VITE_API_URL` on a prod desktop build.

## Fix
Forward `ENVFILE` into npm: `npm run tauri-{dev,build} --envfile=$(ENVFILE)`. npm exposes it as `npm_config_envfile`, which propagates through `tauri build` → its `beforeBuildCommand` (`npm run build`) → the `dotenv -e ../$npm_config_envfile` call.

Verified with `make -n`:
```
make desktop-build ENVFILE=.env.prod
  → cd webui && npm run tauri-build --envfile=.env.prod
```
Default stays `--envfile=.env`. CI desktop releases are unaffected (they bake from the `API_ORIGIN` repo variable, not an envfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)