### PR TITLE
feat(board): expandable sidebar hierarchy + deep-link routes for local boards

### DIFF
--- a/webui/src/components/sidebar/app-sidebar.tsx
+++ b/webui/src/components/sidebar/app-sidebar.tsx
@@ -112,7 +112,9 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
           key={b.id}
           boardId={b.id}
           label={b.title}
-          isActive={pathname === `/local/${b.id}`}
+          isActive={
+            pathname === `/local/${b.id}` || pathname.startsWith(`/local/${b.id}/`)
+          }
           syncing={pendingId === b.id}
           onOpen={() => openLocal(b.id)}
           onEnableSync={() => {

--- a/webui/src/components/sidebar/app-sidebar.tsx
+++ b/webui/src/components/sidebar/app-sidebar.tsx
@@ -110,6 +110,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
       localOnly.map((b) => (
         <LocalBoardItem
           key={b.id}
+          boardId={b.id}
           label={b.title}
           isActive={pathname === `/local/${b.id}`}
           syncing={pendingId === b.id}

--- a/webui/src/components/sidebar/board-tree-node.tsx
+++ b/webui/src/components/sidebar/board-tree-node.tsx
@@ -12,6 +12,7 @@ import {
 import { IconPropertyView } from "@/components/icons/icon-property-view"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useBoardContents, type BoardContentItem, type BoardContentKind } from "@/features/board/api/list-board-contents"
+import { nodeSurfacePath } from "@/features/board/utils/node-surface-url"
 import { trimText } from "@/lib/common"
 import { UNTITLED_LABEL } from "@/features/board/const"
 
@@ -105,27 +106,17 @@ export function BoardTreeNode({
       delete rest.root_id
       return rest
     }
-    // Open a surface panel: same shape for synced/local, only the route family
-    // and the board param name (`id` vs `boardId`) differ. Conditional `to`+
-    // `params` can't be expressed in TanStack's typed navigate, hence the cast.
-    const openSurface = (syncedTo: string, localTo: string) => {
+    // Surface leaves open the panel route (kind→URL mapping owned by
+    // nodeSurfacePath); only the board param name (`id` vs `boardId`) differs.
+    // Conditional `params` can't be expressed in TanStack's typed navigate,
+    // hence the cast.
+    if (item.kind === "sheet" || item.kind === "code-sandbox" || item.kind === "widget") {
       navigate({
-        to: local ? localTo : syncedTo,
+        to: nodeSurfacePath(item.kind, local),
         params: local ? { boardId, noteId: item.id } : { id: boardId, noteId: item.id },
         search: scopeToParentFolder,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
-    }
-    if (item.kind === "sheet") {
-      openSurface("/boards/$id/sheets/$noteId", "/local/$boardId/sheets/$noteId")
-      return
-    }
-    if (item.kind === "code-sandbox") {
-      openSurface("/boards/$id/code-sandbox/$noteId", "/local/$boardId/code-sandbox/$noteId")
-      return
-    }
-    if (item.kind === "widget") {
-      openSurface("/boards/$id/widgets/$noteId", "/local/$boardId/widgets/$noteId")
       return
     }
     // Folder (or fallback): stay on the board route, scope the canvas via root_id.

--- a/webui/src/components/sidebar/board-tree-node.tsx
+++ b/webui/src/components/sidebar/board-tree-node.tsx
@@ -41,6 +41,15 @@ type BoardTreeNodeProps = {
    * note the panel just opened.
    */
   parentFolderId?: string
+  /**
+   * Local mode: children come from `localContents` (filtered by `parentId`) rather
+   * than the backend, and navigation targets the `/local/$boardId/*` routes. Local
+   * persistence has no per-level query, so the whole tree is loaded once by the
+   * board row and threaded down here.
+   */
+  local?: boolean
+  /** Full flat surface-node list for a local board (all levels). Ignored unless `local`. */
+  localContents?: BoardContentItem[]
 }
 
 
@@ -51,7 +60,14 @@ type BoardTreeNodeProps = {
  * canvas children. The kind icon morphs to a chevron on row-hover so
  * the user can expand/collapse without leaving the current view.
  */
-export function BoardTreeNode({ boardId, item, depth, parentFolderId }: BoardTreeNodeProps) {
+export function BoardTreeNode({
+  boardId,
+  item,
+  depth,
+  parentFolderId,
+  local = false,
+  localContents,
+}: BoardTreeNodeProps) {
   const navigate = useNavigate()
   const [expanded, setExpanded] = useState(false)
 
@@ -67,9 +83,16 @@ export function BoardTreeNode({ boardId, item, depth, parentFolderId }: BoardTre
   const fullLabel = item.label?.trim() || UNTITLED_LABEL
   const displayLabel = trimText(fullLabel, 40)
 
-  const { data: children = [], isLoading } = useBoardContents(boardId, item.id, {
-    enabled: isExpandable && expanded,
+  // Synced: fetch this level from the backend on expand. Local: the whole board's
+  // surface list is already in memory (threaded via `localContents`), so filter
+  // children by parentId — the hook is still called (disabled) to keep hook order.
+  const syncedQuery = useBoardContents(boardId, item.id, {
+    enabled: !local && isExpandable && expanded,
   })
+  const children: BoardContentItem[] = local
+    ? (localContents ?? []).filter((c) => (c.parentId ?? null) === item.id)
+    : (syncedQuery.data ?? [])
+  const isLoading = local ? false : syncedQuery.isLoading
 
   const handleNavigate = () => {
     // Keep `current_chat_id` etc. but realign `root_id` to the closest
@@ -82,43 +105,37 @@ export function BoardTreeNode({ boardId, item, depth, parentFolderId }: BoardTre
       delete rest.root_id
       return rest
     }
-    if (item.kind === "sheet") {
+    // Open a surface panel: same shape for synced/local, only the route family
+    // and the board param name (`id` vs `boardId`) differ. Conditional `to`+
+    // `params` can't be expressed in TanStack's typed navigate, hence the cast.
+    const openSurface = (syncedTo: string, localTo: string) => {
       navigate({
-        to: "/boards/$id/sheets/$noteId",
-        params: { id: boardId, noteId: item.id },
+        to: local ? localTo : syncedTo,
+        params: local ? { boardId, noteId: item.id } : { id: boardId, noteId: item.id },
         search: scopeToParentFolder,
-      })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+    }
+    if (item.kind === "sheet") {
+      openSurface("/boards/$id/sheets/$noteId", "/local/$boardId/sheets/$noteId")
       return
     }
     if (item.kind === "code-sandbox") {
-      navigate({
-        to: "/boards/$id/code-sandbox/$noteId",
-        params: { id: boardId, noteId: item.id },
-        search: scopeToParentFolder,
-      })
+      openSurface("/boards/$id/code-sandbox/$noteId", "/local/$boardId/code-sandbox/$noteId")
       return
     }
     if (item.kind === "widget") {
-      navigate({
-        to: "/boards/$id/widgets/$noteId",
-        params: { id: boardId, noteId: item.id },
-        search: scopeToParentFolder,
-      })
+      openSurface("/boards/$id/widgets/$noteId", "/local/$boardId/widgets/$noteId")
       return
     }
-    if (item.kind === "folder") {
-      navigate({
-        to: "/boards/$id",
-        params: { id: boardId },
-        search: (prev: Record<string, unknown>) => ({ ...prev, root_id: item.id }),
-      })
-      return
-    }
+    // Folder (or fallback): stay on the board route, scope the canvas via root_id.
     navigate({
-      to: "/boards/$id",
-      params: { id: boardId },
-      search: (prev: Record<string, unknown>) => prev,
-    })
+      to: local ? "/local/$boardId" : "/boards/$id",
+      params: local ? { boardId } : { id: boardId },
+      search: (prev: Record<string, unknown>) =>
+        item.kind === "folder" ? { ...prev, root_id: item.id } : prev,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
   }
 
   const handleToggle = (e: MouseEvent) => {
@@ -225,6 +242,8 @@ export function BoardTreeNode({ boardId, item, depth, parentFolderId }: BoardTre
                 // Folders bound a new canvas scope; sheets/sub-pages
                 // inherit the closest folder ancestor unchanged.
                 parentFolderId={isFolder ? item.id : parentFolderId}
+                local={local}
+                localContents={localContents}
               />
             ))
           )}

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -12,6 +12,7 @@ import { ChatsDialog } from "./chats-dialog"
 import { ConfirmDeleteBoardAlert } from "./confirm-delete-board"
 import { BoardTreeNode } from "./board-tree-node"
 import { useBoardContents } from "@/features/board/api/list-board-contents"
+import { useLocalBoardContents } from "@/features/board/api/list-local-board-contents"
 import { useState, type MouseEvent } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 import { useAppStore } from "@/store"
@@ -125,10 +126,12 @@ export function NewLocalBoardItem({ onClick }: { onClick: () => void }) {
  * A local-only board row in the sidebar's LOCAL group. Presentational — the
  * sidebar owns the local registry + enable-sync hooks and passes callbacks.
  * Routes to `/local/$boardId`; context menu offers Enable sync (one-way promote)
- * and Delete. No sub-tree expansion (local board contents aren't served by the
- * backend contents API the synced BoardItem uses).
+ * and Delete. Expands to its surface-node hierarchy (sheets/folders/…) read from
+ * the on-device store via `useLocalBoardContents` — the local analog of the
+ * synced BoardItem's backend-served tree.
  */
 export function LocalBoardItem({
+  boardId,
   label,
   isActive,
   syncing = false,
@@ -136,6 +139,7 @@ export function LocalBoardItem({
   onEnableSync,
   onDelete,
 }: {
+  boardId: string
   label?: string
   isActive: boolean
   syncing?: boolean
@@ -144,54 +148,104 @@ export function LocalBoardItem({
   onDelete: () => void
 }) {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
   const boardLabel = label || UNTITLED_LABEL
   const boardDisplayLabel = trimText(boardLabel, 20)
+
+  // Whole-board surface list, loaded once on expand; each level filters in memory.
+  const { data: allContents = [], isLoading } = useLocalBoardContents(boardId, {
+    enabled: isOpen,
+  })
+  const rootContents = allContents.filter((c) => (c.parentId ?? null) === null)
+
+  const handleToggle = (e: MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    setIsOpen((v) => !v)
+  }
 
   return (
     <SidebarMenuItem>
       <ContextMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <ContextMenuTrigger asChild>
-              <SidebarMenuButton
-                onClick={onOpen}
-                className="text-xs font-medium truncate"
-                isActive={isActive}
-              >
-                <BoardContextIcon
-                  className="size-4 shrink-0"
-                  weight={isActive ? "fill" : undefined}
-                />
-                <span className="truncate">{boardDisplayLabel}</span>
-              </SidebarMenuButton>
-            </ContextMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="right" align="center" className="max-w-64">
-            <p className="text-xs">{boardLabel}</p>
-            <p className="mt-1 text-[10px] text-muted-foreground">On this device</p>
-          </TooltipContent>
-        </Tooltip>
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ContextMenuTrigger asChild>
+                <SidebarMenuButton
+                  onClick={onOpen}
+                  className="group/board-row text-xs font-medium truncate"
+                  isActive={isActive}
+                >
+                  <span
+                    role="button"
+                    aria-label={isOpen ? "Collapse board" : "Expand board"}
+                    onClick={handleToggle}
+                    className="size-4 shrink-0 grid place-items-center cursor-pointer"
+                  >
+                    <BoardContextIcon
+                      className="size-4 group-hover/board-row:hidden"
+                      weight={isActive ? "fill" : undefined}
+                    />
+                    <ChevronRightIcon
+                      className={cn(
+                        "size-4 hidden group-hover/board-row:block transition-transform",
+                        isOpen && "rotate-90",
+                      )}
+                      strokeWidth={2}
+                    />
+                  </span>
+                  <span className="truncate">{boardDisplayLabel}</span>
+                </SidebarMenuButton>
+              </ContextMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="right" align="center" className="max-w-64">
+              <p className="text-xs">{boardLabel}</p>
+              <p className="mt-1 text-[10px] text-muted-foreground">On this device</p>
+            </TooltipContent>
+          </Tooltip>
 
-        <ContextMenuContent className="w-44">
-          <ContextMenuItem
-            onSelect={() => onEnableSync()}
-            disabled={syncing}
-            className="text-xs flex flex-row items-center"
-          >
-            <CloudArrowUpIcon className="mr-2 size-4" strokeWidth={2} />
-            <span>{syncing ? "Enabling sync…" : "Enable sync"}</span>
-          </ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() =>
-              window.setTimeout(() => setIsConfirmOpen(true), 0)
-            }
-            variant="destructive"
-            className="text-xs flex flex-row items-center"
-          >
-            <DeleteIcon className="mr-2 size-4" strokeWidth={2} />
-            <span>Delete board</span>
-          </ContextMenuItem>
-        </ContextMenuContent>
+          <ContextMenuContent className="w-44">
+            <ContextMenuItem
+              onSelect={() => onEnableSync()}
+              disabled={syncing}
+              className="text-xs flex flex-row items-center"
+            >
+              <CloudArrowUpIcon className="mr-2 size-4" strokeWidth={2} />
+              <span>{syncing ? "Enabling sync…" : "Enable sync"}</span>
+            </ContextMenuItem>
+            <ContextMenuItem
+              onSelect={() =>
+                window.setTimeout(() => setIsConfirmOpen(true), 0)
+              }
+              variant="destructive"
+              className="text-xs flex flex-row items-center"
+            >
+              <DeleteIcon className="mr-2 size-4" strokeWidth={2} />
+              <span>Delete board</span>
+            </ContextMenuItem>
+          </ContextMenuContent>
+
+          <CollapsibleContent>
+            {isLoading && rootContents.length === 0 ? (
+              <p className="pl-7 py-1 text-[11px] italic text-muted-foreground">Loading…</p>
+            ) : rootContents.length === 0 ? (
+              <p className="pl-7 py-1 text-[11px] italic text-muted-foreground">Empty</p>
+            ) : (
+              <ul className="flex flex-col">
+                {rootContents.map((item) => (
+                  <BoardTreeNode
+                    key={item.id}
+                    boardId={boardId}
+                    item={item}
+                    depth={1}
+                    local
+                    localContents={allContents}
+                  />
+                ))}
+              </ul>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
       </ContextMenu>
 
       {/* Visible one-click promote-to-sync (also in the context menu above).

--- a/webui/src/features/board/api/list-local-board-contents.ts
+++ b/webui/src/features/board/api/list-local-board-contents.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query"
+import { getLocalStores } from "@/features/local-stores"
+import { BoardPersistence } from "@/features/board/persist/local/board-persistence"
+import type { NoteNodeData } from "@/features/board/harness/convert/note-to-node"
+import type { BoardContentItem, BoardContentKind } from "./list-board-contents"
+
+
+const SURFACE_KINDS = new Set<BoardContentKind>([
+  "sheet",
+  "folder",
+  "code-sandbox",
+  "widget",
+])
+
+
+/**
+ * Reconstruct a local board's surface-node hierarchy (sheet / folder /
+ * code-sandbox / widget) from the on-device store — the client analog of the
+ * synced `/boards/:id/contents` projection (select by `style.type`, echo
+ * parent / label / icon).
+ *
+ * Local persistence is snapshot + oplog, not a per-node table, so there's no
+ * lazy per-level query: load the whole board once and return a flat list with
+ * `parentId`. Consumers filter per level in memory (mirrors the backend's
+ * `get_graph(root_id)` via `filterContentByLayer`).
+ */
+export async function listLocalBoardContents(boardId: string): Promise<BoardContentItem[]> {
+  const { engine } = await getLocalStores()
+  const content = await new BoardPersistence(boardId, { engine }).load()
+
+  const items: BoardContentItem[] = []
+  for (const node of content.nodes) {
+    // Runtime `data` is `NoteNodeData` (the converter's payload) even though the
+    // model types it as the leaner `DimNodeData`; read the surface fields off it.
+    const data = node.data as NoteNodeData | undefined
+    const kind = data?.styleType as BoardContentKind | undefined
+    if (!kind || !SURFACE_KINDS.has(kind)) continue
+    // label is `RichText` at runtime; fall back to a plain string defensively.
+    const label =
+      typeof data?.label === "string" ? data.label : (data?.label?.markdown ?? null)
+    items.push({
+      id: node.id,
+      label,
+      kind,
+      parentId: data?.parentId ?? null,
+      iconData: data?.properties?.iconData?.icon ?? null,
+    })
+  }
+  return items
+}
+
+
+/**
+ * React Query hook for a local board's full surface-node list. Unlike the synced
+ * `useBoardContents` (one level per fetch), this returns every level at once —
+ * callers filter by `parentId`. Pass `enabled: false` until the board is
+ * expanded so we don't replay the oplog eagerly.
+ */
+export const useLocalBoardContents = (
+  boardId: string,
+  options: { enabled?: boolean } = {},
+) => {
+  const { enabled = true } = options
+  return useQuery<BoardContentItem[]>({
+    queryKey: ["localBoardContents", boardId],
+    queryFn: () => listLocalBoardContents(boardId),
+    enabled: enabled && Boolean(boardId),
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/webui/src/features/board/api/list-local-board-contents.ts
+++ b/webui/src/features/board/api/list-local-board-contents.ts
@@ -65,6 +65,12 @@ export const useLocalBoardContents = (
     queryKey: ["localBoardContents", boardId],
     queryFn: () => listLocalBoardContents(boardId),
     enabled: enabled && Boolean(boardId),
-    staleTime: 1000 * 60 * 5,
+    // The on-device board is mutable and there's no invalidation wired to local
+    // canvas edits (unlike the synced `invalidateBoardContents`), so keep it
+    // `stale` — each expand re-reads the store and reflects created / renamed /
+    // deleted surfaces. Local boards are small, so the snapshot+oplog replay is
+    // cheap; `refetchOnWindowFocus` off so we only pay it on an actual expand.
+    staleTime: 0,
+    refetchOnWindowFocus: false,
   })
 }

--- a/webui/src/features/board/harness/hooks/use-surface-from-url.tsx
+++ b/webui/src/features/board/harness/hooks/use-surface-from-url.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from "react"
 import { useNavigate, useParams, useRouterState } from "@tanstack/react-router"
-import { BoardUrl } from "@/routes"
-import { nodeSurfaceKindFromPath } from "@/features/board/utils/node-surface-url"
+import { BoardUrl, LocalBoardUrl } from "@/routes"
+import {
+  nodeSurfaceKindFromPath,
+  nodeSurfacePath,
+} from "@/features/board/utils/node-surface-url"
 import {
   setNodeSurfaceNavigator,
   useBoardAppStore,
@@ -14,18 +17,21 @@ import {
  * but pointed at `useBoardAppStore` instead of `useGraphStore`.
  *
  * 1. URL → state: when the route is
- *    `/boards/:id/{sheets,code-sandbox,widgets}/:noteId`, write
- *    `activeNodeSurface` to that note. When the route is just the
- *    board, clear it.
+ *    `/{boards/$id,local/$boardId}/{sheets,code-sandbox,widgets,mini-apps}/:noteId`,
+ *    write `activeNodeSurface` to that note. When the route is just the
+ *    board, clear it. (`nodeSurfaceKindFromPath` is substring-based, so it
+ *    matches synced and local paths alike.)
  * 2. State → URL: register navigate callbacks via
  *    `setNodeSurfaceNavigator` so `openNodeSurface` / `closeNodeSurface`
  *    push the matching route. Search params (`root_id`,
  *    `current_chat_id`) are preserved so navigating in / out of a
  *    surface keeps the user's folder context.
  *
- * Both directions guard against redundant updates so they don't loop.
+ * `local` selects the `/local/$boardId/*` route family (param `boardId`) over
+ * the synced `/boards/$id/*` one (param `id`). Both directions guard against
+ * redundant updates so they don't loop.
  */
-export function useHarnessSurfaceFromUrl(): void {
+export function useHarnessSurfaceFromUrl(local = false): void {
   const navigate = useNavigate()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const params = useParams({ strict: false }) as { noteId?: string }
@@ -33,26 +39,27 @@ export function useHarnessSurfaceFromUrl(): void {
   const kind = nodeSurfaceKindFromPath(pathname)
 
   // State → URL: register navigate fns the store can call when actions
-  // fire. Re-register on every `navigate` identity change.
+  // fire. Re-register on every `navigate` / `local` identity change.
   useEffect(() => {
     setNodeSurfaceNavigator(
-      (path, navParams) => {
+      (surfaceKind, boardId, nodeId) => {
         navigate({
-          to: path,
-          params: navParams,
+          to: nodeSurfacePath(surfaceKind, local),
+          params: local ? { boardId, noteId: nodeId } : { id: boardId, noteId: nodeId },
           search: (prev: Record<string, unknown>) => prev,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any)
       },
       (boardId) => {
         navigate({
-          to: BoardUrl,
-          params: { id: boardId },
+          to: local ? LocalBoardUrl : BoardUrl,
+          params: local ? { boardId } : { id: boardId },
           search: (prev: Record<string, unknown>) => prev,
-        })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
       },
     )
-  }, [navigate])
+  }, [navigate, local])
 
   // URL → state.
   useEffect(() => {

--- a/webui/src/features/board/harness/store/board-app-store.ts
+++ b/webui/src/features/board/harness/store/board-app-store.ts
@@ -8,7 +8,6 @@ import {
   setBoardBackground as persistSetBoardBackground,
   setBoardBackgroundTexture as persistSetBoardBackgroundTexture,
 } from "@/features/board/utils/board-background"
-import { nodeSurfacePath } from "@/features/board/utils/node-surface-url"
 
 
 export type NodeSurfaceKind = "sheet" | "code-sandbox" | "widget" | "mini-app"
@@ -33,7 +32,10 @@ export type ChromeDialog =
  * create a cycle through the screen components). Mirrors prod's
  * `setBoardNavigate` pattern in graph-store.ts.
  */
-type SurfaceNavigateOpen = (path: string, params: { id: string; noteId: string }) => void
+// The host hook (synced vs local) owns URL construction — it knows the route
+// family (`/boards/$id/*` vs `/local/$boardId/*`) and param names — so the store
+// stays route-agnostic and only forwards the surface kind + ids.
+type SurfaceNavigateOpen = (kind: NodeSurfaceKind, boardId: string, nodeId: string) => void
 type SurfaceNavigateClose = (boardId: string) => void
 let _navigateOpen: SurfaceNavigateOpen | null = null
 let _navigateClose: SurfaceNavigateClose | null = null
@@ -238,7 +240,7 @@ export const useBoardAppStore = create<BoardAppState & BoardAppActions>((set, ge
     set({ activeNodeSurface: { nodeId, kind } })
     const boardId = get().boardId
     if (!boardId || !_navigateOpen) return
-    _navigateOpen(nodeSurfacePath(kind), { id: boardId, noteId: nodeId })
+    _navigateOpen(kind, boardId, nodeId)
   },
   closeNodeSurface: () => {
     set({ activeNodeSurface: null })

--- a/webui/src/features/board/local/local-board-screen.tsx
+++ b/webui/src/features/board/local/local-board-screen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useParams, useSearch } from "@tanstack/react-router"
+import { Outlet, useParams, useSearch } from "@tanstack/react-router"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button"
 import { ArrowExpandIcon, SparklesIcon } from "@/components/icons"
@@ -10,6 +10,7 @@ import { HarnessCanvas } from "@/features/board/harness/canvas"
 import { LocalFolderBreadcrumb } from "@/features/board/local/local-folder-breadcrumb"
 import { NotesSearchDialog } from "@/features/board/local/notes-search-dialog"
 import { useBoardAppStore } from "@/features/board/harness/store/board-app-store"
+import { useHarnessSurfaceFromUrl } from "@/features/board/harness/hooks/use-surface-from-url"
 import { FloatingAssistant } from "@/features/board/components/flow/floating-assistant/floating-assistant"
 import { requestPersistentStorage } from "@/features/board/persist/local/persist-storage"
 
@@ -43,10 +44,18 @@ export function LocalBoardScreen() {
     if (boardId) void openBoard(boardId)
   }, [boardId, openBoard])
 
+  // Sync the /local/$boardId/{sheets,code-sandbox,widgets,mini-apps}/$noteId
+  // surface routes ⇄ activeNodeSurface (the panel is mounted inside the canvas).
+  useHarnessSurfaceFromUrl(true)
+
   return (
     <div className="absolute inset-0 h-full w-full overflow-hidden bg-background">
       <div className="relative h-full w-full">
         <HarnessCanvas local />
+
+        {/* Null-component surface child routes render here; the actual panel is
+            mounted inside the canvas (NodeSurfaceHost), driven by the URL sync. */}
+        <Outlet />
 
         {/* Off-board tool (fetch/code) confirmation. Mounted at screen level
             (not inside FloatingAssistant) so it stays present when the full

--- a/webui/src/features/board/utils/node-surface-url.ts
+++ b/webui/src/features/board/utils/node-surface-url.ts
@@ -1,18 +1,28 @@
-import { CodeSandboxUrl, MiniAppUrl, SheetUrl, WidgetUrl } from "@/routes"
+import {
+  CodeSandboxUrl,
+  LocalCodeSandboxUrl,
+  LocalMiniAppUrl,
+  LocalSheetUrl,
+  LocalWidgetUrl,
+  MiniAppUrl,
+  SheetUrl,
+  WidgetUrl,
+} from "@/routes"
 import type { NodeSurfaceKind } from "../harness/store/board-app-store"
 
 
 /**
  * Map a node-surface kind to its URL path. The dialog system shares one
  * sub-tree under the board route — only the path segment (`sheets`,
- * `code-sandbox`, `widgets`, `mini-apps`) differs per kind.
+ * `code-sandbox`, `widgets`, `mini-apps`) differs per kind. `local` selects the
+ * `/local/$boardId/*` mirror of the synced `/boards/$id/*` routes.
  */
-export function nodeSurfacePath(kind: NodeSurfaceKind): string {
+export function nodeSurfacePath(kind: NodeSurfaceKind, local = false): string {
   switch (kind) {
-    case "sheet": return SheetUrl
-    case "code-sandbox": return CodeSandboxUrl
-    case "widget": return WidgetUrl
-    case "mini-app": return MiniAppUrl
+    case "sheet": return local ? LocalSheetUrl : SheetUrl
+    case "code-sandbox": return local ? LocalCodeSandboxUrl : CodeSandboxUrl
+    case "widget": return local ? LocalWidgetUrl : WidgetUrl
+    case "mini-app": return local ? LocalMiniAppUrl : MiniAppUrl
   }
 }
 

--- a/webui/src/routes/index.ts
+++ b/webui/src/routes/index.ts
@@ -289,9 +289,46 @@ const localBoardRoute = createRoute({
   component: LocalBoardScreen,
 })
 
+// Local surface routes mirror the synced `/boards/$id/*` children (same
+// null-component pattern): LocalBoardScreen reads URL state via
+// `useHarnessSurfaceFromUrl(local)` and mounts the panel over the still-mounted
+// canvas. Param is `$boardId` (not `$id`).
+export const LocalSheetUrl = "/local/$boardId/sheets/$noteId"
+const localSheetRoute = createRoute({
+  getParentRoute: () => localBoardRoute,
+  path: "/sheets/$noteId",
+  component: () => null,
+})
+
+export const LocalCodeSandboxUrl = "/local/$boardId/code-sandbox/$noteId"
+const localCodeSandboxRoute = createRoute({
+  getParentRoute: () => localBoardRoute,
+  path: "/code-sandbox/$noteId",
+  component: () => null,
+})
+
+export const LocalWidgetUrl = "/local/$boardId/widgets/$noteId"
+const localWidgetRoute = createRoute({
+  getParentRoute: () => localBoardRoute,
+  path: "/widgets/$noteId",
+  component: () => null,
+})
+
+export const LocalMiniAppUrl = "/local/$boardId/mini-apps/$noteId"
+const localMiniAppRoute = createRoute({
+  getParentRoute: () => localBoardRoute,
+  path: "/mini-apps/$noteId",
+  component: () => null,
+})
+
 const routeTree = rootRoute.addChildren([
   localDashboardRoute,
-  localBoardRoute,
+  localBoardRoute.addChildren([
+    localSheetRoute,
+    localCodeSandboxRoute,
+    localWidgetRoute,
+    localMiniAppRoute,
+  ]),
   signinRoute,
   signupRoute,
   verifyEmailRoute,


### PR DESCRIPTION
## What
Local boards now have full parity with synced boards in the sidebar: expand a local board to see its surface-node hierarchy (sheets / folders / code-sandbox / widgets), and click a node to open it — with real deep-link URLs.

Before, only synced boards had this (fed by the backend `GET /boards/:id/contents` + `/boards/$id/{sheets,…}/$noteId` routes); local boards were flat rows.

## How
- **`list-local-board-contents.ts` (new):** reconstructs the `BoardContentItem[]` hierarchy entirely client-side from the on-device store — `getLocalStores().engine` → `BoardPersistence(boardId).load()` → project surface-kind nodes (`data.styleType ∈ {sheet,folder,code-sandbox,widget}`, echoing `parentId`/`label`/`iconData`). The client analog of the backend's pure projection. Local persistence is snapshot+oplog (no per-level query), so the whole board loads once and levels are filtered in memory.
- **`LocalBoardItem`:** now expandable (Collapsible + toggle), rendering `BoardTreeNode` in local mode.
- **`BoardTreeNode`:** gains a `local` mode — children come from the in-memory list, navigation targets `/local/$boardId/*`.
- **Routes:** added `/local/$boardId/{sheets,code-sandbox,widgets,mini-apps}/$noteId` as children of the local board route (mirror of the synced children).
- **Navigator seam:** the injected surface navigator now owns URL construction (store passes `kind`+ids), so the store stays route-agnostic. `useHarnessSurfaceFromUrl(local)` picks the route family + param name (`boardId` vs `id`). `LocalBoardScreen` renders `<Outlet/>` and calls the hook.

The canvas, surface panels (`NodeSurfaceHost`) and store were already board-agnostic and mounted for local — this adds the missing URL layer + sidebar tree.

## Verify
- tsc + eslint clean; **1103 tests pass**; production build green.
- Expand a local board in the sidebar → its notes/folders appear; click a sheet → panel opens at `/local/$boardId/sheets/$noteId`; folders scope the canvas via `root_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)