### PR TITLE
fix(board): visible hover on top toolbar buttons via border

### DIFF
--- a/webui/src/features/board/harness/chrome/toolbar-more.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar-more.tsx
@@ -32,8 +32,10 @@ import { IconSearchDialog } from "./icon-search-dialog"
 import { ImageSearchDialog } from "./image-search-dialog"
 
 
+// Always-present transparent border so the hover border doesn't shift the icon;
+// the fill change alone is near-invisible against the tray (see toolbar.tsx).
 const moreButtonClass =
-  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 text-card-foreground hover:bg-secondary hover:text-secondary-foreground"
+  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30"
 
 
 /**

--- a/webui/src/features/board/harness/chrome/toolbar-more.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar-more.tsx
@@ -35,7 +35,7 @@ import { ImageSearchDialog } from "./image-search-dialog"
 // Always-present transparent border so the hover border doesn't shift the icon;
 // the fill change alone is near-invisible against the tray (see toolbar.tsx).
 const moreButtonClass =
-  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30"
+  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-border"
 
 
 /**

--- a/webui/src/features/board/harness/chrome/toolbar-more.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar-more.tsx
@@ -35,7 +35,7 @@ import { ImageSearchDialog } from "./image-search-dialog"
 // Always-present transparent border so the hover border doesn't shift the icon;
 // the fill change alone is near-invisible against the tray (see toolbar.tsx).
 const moreButtonClass =
-  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-border"
+  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30"
 
 
 /**

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -69,9 +69,13 @@ const SHAPE_TOOLS: ReadonlyArray<ShapeTool> = [
 const SHAPE_TOOL_IDS = new Set(SHAPE_TOOLS.map((t) => t.id))
 
 
+// A transparent border sits on EVERY state so toggling a visible one on hover
+// doesn't shift the icon — the tray fill (`bg-sidebar`) and the hover fill
+// (`bg-secondary`) are close enough that the fill change alone reads as no hover,
+// so the border carries the affordance.
 const baseButtonClass =
-  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2"
-const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground`
+  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent"
+const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
 const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground`
 
 

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -75,7 +75,7 @@ const SHAPE_TOOL_IDS = new Set(SHAPE_TOOLS.map((t) => t.id))
 // so the border carries the affordance.
 const baseButtonClass =
   "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent"
-const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
+const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-border`
 const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground`
 
 

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -75,7 +75,7 @@ const SHAPE_TOOL_IDS = new Set(SHAPE_TOOLS.map((t) => t.id))
 // so the border carries the affordance.
 const baseButtonClass =
   "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent"
-const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-border`
+const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
 const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground`
 
 


### PR DESCRIPTION
The top toolbar's buttons showed no visible hover: the tray fill (`bg-sidebar`) and the button hover fill (`bg-secondary`) are close enough that the fill change alone reads as nothing happening.

**Fix:** add a hover border to carry the affordance. A transparent border sits on **every** state (`border border-transparent` in the base class) so toggling a visible one on hover doesn't shift the icon — per the requested behavior. Inactive buttons get `hover:border-secondary-foreground/30`; active buttons keep the transparent border (the fill still marks them).

Applied to the shared `toolbar.tsx` button classes (view/pan/select/shapes/connector/text + all tools) and the `toolbar-more.tsx` "…" button's own copy of the class.

CSS-only; `check-all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)