### PR TITLE
feat(sidebar): active-row highlight + filled kind icon for the open surface

### DIFF
--- a/webui/src/components/sidebar/board-tree-node.tsx
+++ b/webui/src/components/sidebar/board-tree-node.tsx
@@ -54,6 +54,13 @@ type BoardTreeNodeProps = {
    * board row from the on-device store; each level filters by `parentId`.
    */
   treeContents: BoardContentItem[]
+  /**
+   * Id of the currently-open surface (sheet/code-sandbox/widget) or scoped
+   * folder for this board, from the URL — computed once by the board row and
+   * threaded down. The matching row renders active (highlight + filled kind
+   * icon). `null`/absent when this board isn't the one on screen.
+   */
+  activeId?: string | null
 }
 
 
@@ -71,6 +78,7 @@ export function BoardTreeNode({
   parentFolderId,
   local = false,
   treeContents,
+  activeId,
 }: BoardTreeNodeProps) {
   const navigate = useNavigate()
   const [expanded, setExpanded] = useState(false)
@@ -78,6 +86,7 @@ export function BoardTreeNode({
   const isFolder = item.kind === "folder"
   const isSheet = item.kind === "sheet"
   const isExpandable = isFolder || isSheet
+  const isActive = !!activeId && item.id === activeId
   const KindIcon = ICON_BY_KIND[item.kind]
   const customIcon = item.iconData ?? null
 
@@ -137,7 +146,11 @@ export function BoardTreeNode({
       <div
         role="button"
         tabIndex={0}
-        className="group/tree-row flex items-center gap-2 rounded-md text-xs text-sidebar-foreground hover:bg-sidebar-accent transition-colors cursor-pointer min-h-7 pr-1.5"
+        aria-current={isActive ? "page" : undefined}
+        className={cn(
+          "group/tree-row flex items-center gap-2 rounded-md text-xs text-sidebar-foreground hover:bg-sidebar-accent transition-colors cursor-pointer min-h-7 pr-1.5",
+          isActive && "bg-sidebar-accent font-medium text-sidebar-accent-foreground",
+        )}
         style={{ paddingLeft }}
         onClick={handleNavigate}
         onKeyDown={(e) => {
@@ -167,10 +180,12 @@ export function BoardTreeNode({
             ) : (
               <KindIcon
                 className={cn(
-                  "size-4 text-muted-foreground transition-opacity",
+                  "size-4 transition-opacity",
+                  isActive ? "text-sidebar-accent-foreground" : "text-muted-foreground",
                   "group-hover/tree-row:hidden",
                   expanded && "hidden",
                 )}
+                weight={isActive ? "fill" : undefined}
                 strokeWidth={2}
               />
             )}
@@ -189,7 +204,11 @@ export function BoardTreeNode({
             {customIcon ? (
               <IconPropertyView icon={customIcon} size={16} />
             ) : (
-              <KindIcon className="size-4 text-muted-foreground" strokeWidth={2} />
+              <KindIcon
+                className={cn("size-4", isActive ? "text-sidebar-accent-foreground" : "text-muted-foreground")}
+                weight={isActive ? "fill" : undefined}
+                strokeWidth={2}
+              />
             )}
           </span>
         )}
@@ -225,6 +244,7 @@ export function BoardTreeNode({
                 parentFolderId={isFolder ? item.id : parentFolderId}
                 local={local}
                 treeContents={treeContents}
+                activeId={activeId}
               />
             ))
           )}

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -4,7 +4,7 @@ import { useDeleteBoard } from "@/features/board/api/delete-board"
 import { trimText } from "@/lib/common"
 import { cn } from "@/lib/utils"
 import { UNTITLED_LABEL } from "@/features/board/const"
-import { useNavigate, useRouterState } from "@tanstack/react-router"
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "../ui/context-menu"
 import { Collapsible, CollapsibleContent } from "../ui/collapsible"
 import { BoardContextIcon, ChatHistoryIcon, ChevronRightIcon, CloudArrowUpIcon, DashboardAddIcon, DeleteIcon, EditIcon } from "@/components/icons"
@@ -19,6 +19,21 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 import { useAppStore } from "@/store"
 import { FREE_PLAN_BOARD_LIMIT_TOOLTIP, isBoardCreationLimited } from "@/features/board/lib/board-limit"
 import { useListBoards } from "@/features/board/api/list-boards"
+
+/**
+ * The open surface (sheet/code-sandbox/widget) — or scoped folder — node id for
+ * `boardId`, read from the URL. Drives the sidebar tree's active-row highlight;
+ * `null` unless this is the board on screen. Surface `noteId` wins over a folder
+ * `root_id` so opening a note highlights the note, not its parent folder.
+ */
+function useActiveTreeId(boardId: string): string | null {
+  const params = useParams({ strict: false }) as { id?: string; boardId?: string; noteId?: string }
+  const rootId = useRouterState({ select: (s) => (s.location.search as { root_id?: string }).root_id })
+  const openBoardId = params.id ?? params.boardId
+  if (openBoardId !== boardId) return null
+  return params.noteId ?? rootId ?? null
+}
+
 
 /**
  * Dashboard menu item component
@@ -158,6 +173,7 @@ export function LocalBoardItem({
     enabled: isOpen,
   })
   const rootContents = allContents.filter((c) => (c.parentId ?? null) === null)
+  const activeTreeId = useActiveTreeId(boardId)
 
   const handleToggle = (e: MouseEvent) => {
     e.stopPropagation()
@@ -241,6 +257,7 @@ export function LocalBoardItem({
                     depth={1}
                     local
                     treeContents={allContents}
+                    activeId={activeTreeId}
                   />
                 ))}
               </ul>
@@ -325,6 +342,7 @@ export function BoardItem({
     { enabled: isOpen && canShowTree },
   )
   const rootContents = allContents.filter((c) => (c.parentId ?? null) === null)
+  const activeTreeId = useActiveTreeId(boardId)
 
   const handleClick = () => {
     navigate({ to: "/boards/$id", params: { id: boardId } })
@@ -434,6 +452,7 @@ export function BoardItem({
                     item={item}
                     depth={1}
                     treeContents={allContents}
+                    activeId={activeTreeId}
                   />
                 ))}
               </ul>

--- a/webui/src/components/sidebar/board.tsx
+++ b/webui/src/components/sidebar/board.tsx
@@ -14,6 +14,7 @@ import { BoardTreeNode } from "./board-tree-node"
 import { BoardOfflineAction } from "./board-offline-action"
 import { useLocalBoardContents } from "@/features/board/api/list-local-board-contents"
 import { useBoardOfflineStatus } from "@/features/board/api/board-offline-status"
+import { nodeSurfaceKindFromPath } from "@/features/board/utils/node-surface-url"
 import { useState, type MouseEvent } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 import { useAppStore } from "@/store"
@@ -23,15 +24,24 @@ import { useListBoards } from "@/features/board/api/list-boards"
 /**
  * The open surface (sheet/code-sandbox/widget) — or scoped folder — node id for
  * `boardId`, read from the URL. Drives the sidebar tree's active-row highlight;
- * `null` unless this is the board on screen. Surface `noteId` wins over a folder
- * `root_id` so opening a note highlights the note, not its parent folder.
+ * `null` unless this is the board on screen. A tree-rendered surface `noteId`
+ * wins over a folder `root_id` (highlight the note, not its parent); a mini-app
+ * (no tree row) falls through to the scoped folder instead of suppressing it.
  */
 function useActiveTreeId(boardId: string): string | null {
   const params = useParams({ strict: false }) as { id?: string; boardId?: string; noteId?: string }
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
   const rootId = useRouterState({ select: (s) => (s.location.search as { root_id?: string }).root_id })
+
+  // Only board routes drive the tree highlight — other routes (`/chats/$id`,
+  // `/subscriptions/$id`) reuse the `$id` param for an unrelated entity.
+  if (!pathname.startsWith("/boards/") && !pathname.startsWith("/local/")) return null
   const openBoardId = params.id ?? params.boardId
   if (openBoardId !== boardId) return null
-  return params.noteId ?? rootId ?? null
+
+  const kind = nodeSurfaceKindFromPath(pathname)
+  const surfaceInTree = kind === "sheet" || kind === "code-sandbox" || kind === "widget"
+  return (surfaceInTree ? params.noteId : undefined) ?? rootId ?? null
 }
 
 


### PR DESCRIPTION
Two small sidebar-tree touches:

1. **Active row highlight** — when a surface panel (sheet / code-sandbox / widget) is open, or a folder is the scoped `root_id`, for the board currently on screen, that tree row now renders active (`bg-sidebar-accent` + `font-medium`). Before, opening a note gave no active indication in the tree.
2. **Filled main icon** — the active row's **kind icon** switches to the Phosphor **fill** variant (like the board-row `BoardContextIcon`). Custom user-picked icons are left as-is (no fill concept); only the default kind icons fill.

## How
- `useActiveTreeId(boardId)` reads the open surface from the URL — `noteId` param, else the `root_id` search — and returns it only when this board is the one on screen. `noteId` wins over `root_id` so opening a note highlights the note, not its parent folder.
- Computed once per board row (`BoardItem` + `LocalBoardItem`) and threaded down the recursive `BoardTreeNode` via a new `activeId` prop; each row is active when `item.id === activeId`.

Covers the reported case: opening a sheet ("sticky note") or code-sandbox now marks its sidebar row active.

## Notes
- If a surface is opened while its folder is collapsed in the sidebar, there's no rendered row to highlight (expected) — no auto-expand in this PR.
- CSS/URL-only; `check-all` clean, full suite **1127 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)