### PR TITLE
fix(board): active topbar buttons get the same border as hover (incl. view button)

### DIFF
--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -76,7 +76,10 @@ const SHAPE_TOOL_IDS = new Set(SHAPE_TOOLS.map((t) => t.id))
 const baseButtonClass =
   "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent"
 const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
-const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground`
+// Active buttons carry the same border as the hover state (the base's transparent
+// border keeps the box size constant), so active + hovered read consistently —
+// including the always-active view button (board/list/files).
+const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground border-secondary-foreground/30`
 
 
 /**


### PR DESCRIPTION
Follow-up to the topbar hover-border fix. Active buttons (a selected tool, and the always-active **board/list/files** view button) kept a *transparent* border while a hovered inactive button showed one — so the two states read inconsistently.

Add `border-secondary-foreground/30` to `activeClass` so active matches hover. The base class's `border border-transparent` is still present on every state, so the box size doesn't shift. Since the view dropdown trigger and every active tool button already use `activeClass`, this one change covers all of them.

CSS-only; `check-all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)