### PR TITLE
perf(desktop): unlock WKWebView 120fps + drop canvas-overlay backdrop-blur on WebKit

### DIFF
--- a/webui/src-tauri/Cargo.lock
+++ b/webui/src-tauri/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "app"
-version = "0.3.70"
+version = "0.3.71"
 dependencies = [
  "log",
  "open",
@@ -115,6 +115,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-http",
  "tauri-plugin-log",
+ "tauri-plugin-macos-fps",
  "tiny_http",
  "urlencoding",
 ]
@@ -4023,6 +4024,19 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.15",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-macos-fps"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11177f7c97f1322fbcb5d966ebb0378e411145d65f3f2a2f897d8389ebdba583"
+dependencies = [
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.1",
+ "serde",
+ "tauri",
 ]
 
 [[package]]

--- a/webui/src-tauri/Cargo.toml
+++ b/webui/src-tauri/Cargo.toml
@@ -34,3 +34,10 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 tiny_http = "0.12"
 open = "5"
 urlencoding = "2"
+
+# macOS only: unlock WKWebView's 60fps requestAnimationFrame cap so the canvas
+# renders at the display's native refresh (120Hz ProMotion). Toggles a private
+# WebKit flag (the same one Safari uses) — fine for direct distribution (NOT App
+# Store safe), and a harmless no-op on macOS 26+ where Apple dropped the cap.
+[target.'cfg(target_os = "macos")'.dependencies]
+tauri-plugin-macos-fps = "0.1"

--- a/webui/src-tauri/src/lib.rs
+++ b/webui/src-tauri/src/lib.rs
@@ -7,8 +7,14 @@ mod storage;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .plugin(tauri_plugin_http::init())
+  let builder = tauri::Builder::default().plugin(tauri_plugin_http::init());
+
+  // macOS: unlock WKWebView's 60fps rAF cap so the canvas runs at the display's
+  // native refresh (120Hz ProMotion). No-op on macOS 26+ (cap already gone).
+  #[cfg(target_os = "macos")]
+  let builder = builder.plugin(tauri_plugin_macos_fps::init());
+
+  builder
     .setup(|app| {
       // Open the local SQLite database in the app-data dir and hold the single
       // connection in state. The webui drives the schema via `sql_execute`.

--- a/webui/src-tauri/tauri.conf.json
+++ b/webui/src-tauri/tauri.conf.json
@@ -29,6 +29,11 @@
       "csp": null
     }
   },
+  "plugins": {
+    "macos-fps": {
+      "enabled": true
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",

--- a/webui/src/features/board/harness/chrome/collab-status.tsx
+++ b/webui/src/features/board/harness/chrome/collab-status.tsx
@@ -41,7 +41,7 @@ export function HarnessCollabStatus() {
   return (
     <div
       className={cn(
-        "rounded-md border border-border bg-background/95 px-2 py-1 text-xs shadow-sm backdrop-blur",
+        "rounded-md border border-border bg-background/95 px-2 py-1 text-xs shadow-sm backdrop-blur [.tauri-webkit_&]:backdrop-blur-none",
         STATUS_CLASS[state],
       )}
       aria-live="polite"

--- a/webui/src/features/board/harness/chrome/presentation-controls.tsx
+++ b/webui/src/features/board/harness/chrome/presentation-controls.tsx
@@ -50,7 +50,7 @@ export function PresentationControls() {
     <div
       role="toolbar"
       aria-label="Presentation controls"
-      className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-sidebar/90 px-3 py-2 shadow-lg backdrop-blur-md"
+      className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-sidebar/90 px-3 py-2 shadow-lg backdrop-blur-md [.tauri-webkit_&]:backdrop-blur-none"
     >
       <Button
         size="icon"

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -34,7 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { isTauri } from "@/platform"
+import { isWebKitWebview } from "@/platform"
 import { useBoardAppStore } from "../store/board-app-store"
 import { HarnessToolbarMore } from "./toolbar-more"
 
@@ -136,7 +136,8 @@ function FlaredTray({
   const rowRef = useRef<HTMLDivElement>(null)
   const [w, setW] = useState(0)
   const [hover, setHover] = useState(false)
-  const desktop = isTauri()
+  // WebKit webviews only (see isWebKitWebview) — Windows/Chromium keeps the blur.
+  const webkit = isWebKitWebview()
 
   useEffect(() => {
     const el = rowRef.current
@@ -166,10 +167,11 @@ function FlaredTray({
                 root" and silently no-ops backdrop-filter (the blur had nothing to
                 sample). So the drop-shadow lives on the sibling tint layer below,
                 never on a wrapper.
-                SKIPPED on desktop (Tauri/WebKit): `backdrop-filter` re-samples the
-                canvas behind the tray every pan frame, a real jank source on
-                WebKit — the tint below goes near-opaque there instead. */}
-            {!desktop && (
+                SKIPPED on WebKit webviews (macOS/Linux): `backdrop-filter`
+                re-samples the canvas behind the tray every pan frame, a real jank
+                source there — the tint below goes near-opaque instead. Kept on
+                Windows/Chromium (cheap) and web. */}
+            {!webkit && (
               <div
                 className="pointer-events-none absolute inset-0 backdrop-blur-xl backdrop-saturate-[1.8]"
                 style={{ clipPath: `path('${d}')` }}
@@ -177,9 +179,9 @@ function FlaredTray({
             )}
             {/* Translucent tint + the tray's drop-shadow. A sibling of the blur
                 layer (not an ancestor), so it doesn't isolate the backdrop. On
-                desktop it carries the fill alone (near-opaque, no blur). */}
+                WebKit it carries the fill alone (near-opaque, no blur). */}
             <div
-              className={cn("pointer-events-none absolute inset-0", desktop ? "bg-sidebar/95" : "bg-sidebar/60")}
+              className={cn("pointer-events-none absolute inset-0", webkit ? "bg-sidebar/95" : "bg-sidebar/60")}
               style={{
                 clipPath: `path('${d}')`,
                 filter: hover

--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -34,6 +34,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
+import { isTauri } from "@/platform"
 import { useBoardAppStore } from "../store/board-app-store"
 import { HarnessToolbarMore } from "./toolbar-more"
 
@@ -135,6 +136,7 @@ function FlaredTray({
   const rowRef = useRef<HTMLDivElement>(null)
   const [w, setW] = useState(0)
   const [hover, setHover] = useState(false)
+  const desktop = isTauri()
 
   useEffect(() => {
     const el = rowRef.current
@@ -163,15 +165,21 @@ function FlaredTray({
                 `filter`/`opacity`/`mask` — such an ancestor becomes a "backdrop
                 root" and silently no-ops backdrop-filter (the blur had nothing to
                 sample). So the drop-shadow lives on the sibling tint layer below,
-                never on a wrapper. */}
-            <div
-              className="pointer-events-none absolute inset-0 backdrop-blur-xl backdrop-saturate-[1.8]"
-              style={{ clipPath: `path('${d}')` }}
-            />
+                never on a wrapper.
+                SKIPPED on desktop (Tauri/WebKit): `backdrop-filter` re-samples the
+                canvas behind the tray every pan frame, a real jank source on
+                WebKit — the tint below goes near-opaque there instead. */}
+            {!desktop && (
+              <div
+                className="pointer-events-none absolute inset-0 backdrop-blur-xl backdrop-saturate-[1.8]"
+                style={{ clipPath: `path('${d}')` }}
+              />
+            )}
             {/* Translucent tint + the tray's drop-shadow. A sibling of the blur
-                layer (not an ancestor), so it doesn't isolate the backdrop. */}
+                layer (not an ancestor), so it doesn't isolate the backdrop. On
+                desktop it carries the fill alone (near-opaque, no blur). */}
             <div
-              className="pointer-events-none absolute inset-0 bg-sidebar/60"
+              className={cn("pointer-events-none absolute inset-0", desktop ? "bg-sidebar/95" : "bg-sidebar/60")}
               style={{
                 clipPath: `path('${d}')`,
                 filter: hover

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -7,7 +7,7 @@ import { queryClient } from './query-client'
 import { router } from './routes'
 import { RouterProvider } from '@tanstack/react-router'
 import { registerSW } from 'virtual:pwa-register'
-import { isTauri } from './platform'
+import { isTauri, isWebKitWebview } from './platform'
 
 /**
  * Registers the PWA service worker and keeps it up to date automatically.
@@ -20,6 +20,10 @@ if (!isTauri()) {
   // Desktop shell is frameless (decorations: false) with our own title bar +
   // window controls. This class drives the rounded-window CSS + title-bar chrome.
   document.documentElement.classList.add("tauri")
+  // WebKit webviews (macOS/Linux, not Windows' Chromium WebView2) drop
+  // canvas-overlay backdrop-blur via the `[.tauri-webkit_&]:` variant — it janks
+  // there but is cheap on Chromium.
+  if (isWebKitWebview()) document.documentElement.classList.add("tauri-webkit")
   // In fullscreen the title bar is hidden and the window is square.
   void import("./features/desktop/fullscreen-class").then(m => m.initFullscreenClass())
   // WKWebView treats Backspace as "history back"; stop it stealing node deletes.

--- a/webui/src/platform.ts
+++ b/webui/src/platform.ts
@@ -8,3 +8,15 @@
  */
 export const isTauri = (): boolean =>
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window
+
+
+/**
+ * True inside a **WebKit-based** Tauri webview — macOS (`WKWebView`) and Linux
+ * (`WebKitGTK`), where `backdrop-filter` re-samples the backdrop every frame and
+ * janks over a moving canvas. NOT Windows: `WebView2` is Chromium, where blur is
+ * cheap. Distinguished by the `Chrome/` UA token (present in Chromium/WebView2,
+ * absent in the Safari-family WebKit engines). Used to drop blur only where it
+ * actually hurts.
+ */
+export const isWebKitWebview = (): boolean =>
+  isTauri() && typeof navigator !== "undefined" && !/Chrome\//.test(navigator.userAgent)

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -173,7 +173,7 @@ export function RootLayout() {
                       so the board toolbar (which floats below) never overlaps it. */}
                   <div
                     data-tauri-drag-region
-                    className="z-50 flex h-11 shrink-0 items-center gap-2 border-b border-border/60 bg-background/80 px-3 backdrop-blur-md [.tauri-fullscreen_&]:hidden"
+                    className="z-50 flex h-11 shrink-0 items-center gap-2 border-b border-border/60 bg-background/95 px-3 [.tauri-fullscreen_&]:hidden"
                   >
                     {navCluster}
                     <div className="ml-auto flex items-center gap-2 self-stretch">


### PR DESCRIPTION
Two WebKit/Tauri-macOS smoothness fixes for the standalone app (both confirmed hitting us). Web build is untouched.

## 1. Unlock 120fps (the 60fps rAF cap)
WKWebView caps `requestAnimationFrame` at **60fps on macOS 13–15**, even on 120Hz ProMotion — while Safari/Chrome hit 120. For a rAF-driven canvas that's the "feels half as smooth as Chrome" symptom.

- Add [`tauri-plugin-macos-fps`](https://github.com/userFRM/tauri-plugin-macos-fps), which flips WebKit's private `PreferPageRenderingUpdatesNear60FPSEnabled` flag (same mechanism Safari uses).
- **macOS-gated in Cargo** (`[target.'cfg(target_os = "macos")'.dependencies]`) so the Linux CI build never compiles it; registered behind `#[cfg(target_os = "macos")]` in `lib.rs`.
- No-op on **macOS 26+** (Apple removed the cap). Private API → not App-Store-safe, which is fine for our direct distribution.

## 2. Drop `backdrop-blur` over the moving canvas
`backdrop-filter` is cheap on Blink but on WebKit it **re-samples every frame when the backdrop moves**. The board toolbar tray sits over the pannable canvas and used `backdrop-blur-xl backdrop-saturate` → re-blur on every pan tick.
- On desktop (`isTauri`), skip the blur layer and make the tint near-opaque (`bg-sidebar/95`) so it stays legible.
- The new desktop **title line** also drops its blur (it's solid top chrome — nothing behind it to blur anyway).
- Web keeps the frosted look.

`maxDpr` is already capped to `1.5` on desktop (a prior WebKit win), so this PR is the fps cap + compositing cost.

## ⚠️ Needs a native run to verify (no Rust/WebKit build in CI env for me)
- [ ] On a ProMotion Mac (macOS 13–15): canvas pan/zoom now runs at ~120fps (was 60). If you're on macOS 26+, the plugin is a no-op and #2 is the win.
- [ ] Toolbar tray + title line still look right without blur (near-opaque tint).
- Frontend verified: `check-all` clean, **1127** tests pass. Cargo.lock minimally updated (just the new plugin).

Follow-ups if still not smooth enough: extend the blur-drop to the side panels / node-surface host, and try `maxDpr: 1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)