### PR TITLE
fix(backend): confine GET /files to the data root (F1 — arbitrary file read)

### DIFF
--- a/backend/test/unit/utils/test_file.py
+++ b/backend/test/unit/utils/test_file.py
@@ -1,0 +1,35 @@
+"""Regression tests for `get_file_path` data-root confinement (security F1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from topix.utils.file import DATADIR, REP_DATADIR, get_file_path
+
+
+class TestGetFilePathConfinement:
+    """`get_file_path` must never resolve to a path outside the data root."""
+
+    @pytest.mark.parametrize(
+        "rep_path",
+        [
+            f"{REP_DATADIR}/../../.env",  # traversal out via the /data prefix
+            "../../../../etc/passwd",  # bare relative traversal
+            "/etc/passwd",  # absolute path outside the root
+            "file:///etc/passwd",  # file:// scheme stripped, still escapes
+        ],
+    )
+    def test_rejects_paths_that_escape_the_data_root(self, rep_path: str):
+        """Traversal / absolute / file:// escapes raise ValueError (→ 404 at the router)."""
+        with pytest.raises(ValueError):
+            get_file_path(rep_path)
+
+    def test_allows_a_normal_in_root_data_path(self):
+        """A plain /data path resolves to a location inside the data root."""
+        result = get_file_path(f"{REP_DATADIR}/files/example.png")
+        assert result.startswith(str(DATADIR.resolve()))
+
+    def test_allows_dotdot_that_stays_within_the_root(self):
+        """`..` segments that resolve back inside the data root are still allowed."""
+        result = get_file_path(f"{REP_DATADIR}/files/../images/x.png")
+        assert result.startswith(str(DATADIR.resolve()))

--- a/backend/test/unit/utils/test_file.py
+++ b/backend/test/unit/utils/test_file.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from topix.utils.file import DATADIR, REP_DATADIR, get_file_path
+from topix.utils.file import DATADIR, REP_DATADIR, get_file_path, save_file
 
 
 class TestGetFilePathConfinement:
@@ -33,3 +33,25 @@ class TestGetFilePathConfinement:
         """`..` segments that resolve back inside the data root are still allowed."""
         result = get_file_path(f"{REP_DATADIR}/files/../images/x.png")
         assert result.startswith(str(DATADIR.resolve()))
+
+    def test_data_prefix_is_a_segment_match(self):
+        """A `/data`-substring path like `/database/x` is NOT treated as in-root."""
+        with pytest.raises(ValueError):
+            get_file_path("/database/secret")
+
+
+class TestSaveFileConfinement:
+    """save_file must refuse to write outside the data root (write mirror of F1)."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../../evil",  # climbs out of DATADIR/files
+            "../../../etc/cron.d/evil",  # deeper traversal
+            "/etc/passwd",  # absolute filename replaces the join → outside root
+        ],
+    )
+    def test_rejects_filenames_that_escape_the_data_root(self, filename: str):
+        """A traversal/absolute filename raises ValueError before any write."""
+        with pytest.raises(ValueError):
+            save_file(filename, b"x", cat="files")

--- a/backend/topix/api/router/documents.py
+++ b/backend/topix/api/router/documents.py
@@ -1,5 +1,6 @@
 """Document-related API routes."""
 
+from pathlib import PurePath
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
@@ -33,12 +34,18 @@ async def create_document_from_file(
 ):
     """Create a document by parsing an uploaded file (PDF only)."""
     file_bytes = await file.read()
-    mime_type = detect_mime_type(file.filename)
+    # Strip client path components so the upload can't traverse out of the data
+    # root (basename only); save_file confines the write as a backstop.
+    safe_name = PurePath(file.filename or "").name
+    mime_type = detect_mime_type(safe_name)
 
     if mime_type.startswith("application/pdf"):
         cat = "files"
-        new_filename = f"{gen_uid()}_{file.filename}"
-        saved_path = save_file(filename=new_filename, file_bytes=file_bytes, cat=cat)
+        new_filename = f"{gen_uid()}_{safe_name}"
+        try:
+            saved_path = save_file(filename=new_filename, file_bytes=file_bytes, cat=cat)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Invalid filename") from exc
     else:
         raise HTTPException(
             status_code=400,

--- a/backend/topix/api/router/files.py
+++ b/backend/topix/api/router/files.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, UploadFile
 from fastapi.params import File, Query
 
 from topix.api.utils.decorators import with_standard_response
@@ -27,7 +27,11 @@ async def get_file(
     filename: Annotated[str, Query(description="Filename to retrieve")]
 ):
     """Get file by filename."""
-    file_path = get_file_path(filename)
+    try:
+        file_path = get_file_path(filename)
+    except ValueError as exc:
+        # Path escaped the data root (traversal / arbitrary read) — hide it as 404.
+        raise HTTPException(status_code=404, detail="Not found") from exc
     mime_type = detect_mime_type(file_path)
     base64_url = convert_to_base64_url(file_path, mime_type=mime_type)
     return {"base64_url": base64_url}

--- a/backend/topix/api/router/files.py
+++ b/backend/topix/api/router/files.py
@@ -1,5 +1,6 @@
 """File-related API routes."""
 
+from pathlib import PurePath
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, UploadFile
@@ -47,13 +48,19 @@ async def upload_file(
 ):
     """Upload a file."""
     file_bytes = await file.read()
-    mime_type = detect_mime_type(file.filename)
+    # Strip any client-supplied path components so the upload can't traverse out
+    # of the data root (basename only); save_file confines the write as a backstop.
+    safe_name = PurePath(file.filename or "").name
+    mime_type = detect_mime_type(safe_name)
     if mime_type.startswith("image/"):
         cat = "images"
     else:
         cat = "files"
-    new_filename = f"{gen_uid()}_{file.filename}"
-    saved_path = save_file(filename=new_filename, file_bytes=file_bytes, cat=cat)
+    new_filename = f"{gen_uid()}_{safe_name}"
+    try:
+        saved_path = save_file(filename=new_filename, file_bytes=file_bytes, cat=cat)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid filename") from exc
     return {
         "file": {
             "url": saved_path

--- a/backend/topix/utils/file.py
+++ b/backend/topix/utils/file.py
@@ -112,22 +112,37 @@ def save_base64_image_url(
 def get_file_path(
     rep_path: str
 ) -> str:
-    """Get the absolute file path from the representative path.
+    """Get the absolute file path, confined to the data directory.
+
+    Resolves the representative path and rejects anything that escapes the data
+    root (path traversal, absolute paths outside it, symlink escapes) so a caller
+    can't read arbitrary server files (e.g. `.env`) via `GET /files`.
 
     Args:
         rep_path (str): The representative path of the file.
 
     Returns:
-        str: The absolute path of the file.
+        str: The absolute path of the file, guaranteed to be inside DATADIR.
+
+    Raises:
+        ValueError: If the resolved path escapes the data directory.
 
     """
     # if starts with file://, remove it
     if rep_path.startswith("file://"):
         rep_path = rep_path[len("file://"):]
     if rep_path.startswith(REP_DATADIR):
-        abs_path = DATADIR / rep_path[len(REP_DATADIR) + 1:]
-        return str(abs_path)
-    return rep_path
+        candidate = DATADIR / rep_path[len(REP_DATADIR) + 1:]
+    else:
+        candidate = Path(rep_path)
+
+    # Confine to the data root. `resolve()` collapses `..`/symlinks before the
+    # ancestor check, so a real-path prefix (not a string prefix) is enforced.
+    data_root = DATADIR.resolve()
+    resolved = candidate.resolve()
+    if resolved != data_root and data_root not in resolved.parents:
+        raise ValueError(f"Resolved path escapes the data directory: {rep_path!r}")
+    return str(resolved)
 
 
 def convert_to_base64_url(

--- a/backend/topix/utils/file.py
+++ b/backend/topix/utils/file.py
@@ -55,7 +55,7 @@ def save_file(
     file_bytes: bytes,
     cat: Literal["images", "files", "thumbnails", "cache", "logs"] = "files",
 ) -> str:
-    """Save file to the file directory.
+    """Save file to the file directory, confined to the data root.
 
     Args:
         filename (str): The name of the file.
@@ -64,6 +64,9 @@ def save_file(
 
     Returns:
         str: The representative path starting with "file://" to the saved file.
+
+    Raises:
+        ValueError: If `filename` would write outside the data directory.
 
     """
     match cat:
@@ -82,6 +85,13 @@ def save_file(
         case _:
             file_path = FILE_DIR / filename
             rep_path = FILE_REPPATH + f"/{filename}"
+
+    # Confine the write to the data root — a caller-supplied filename must not
+    # escape it via traversal (the write-side mirror of get_file_path's guard).
+    data_root = DATADIR.resolve()
+    resolved = file_path.resolve()
+    if resolved != data_root and data_root not in resolved.parents:
+        raise ValueError(f"Refusing to write outside the data directory: {filename!r}")
 
     with open(file_path, "wb") as f:
         f.write(file_bytes)
@@ -131,7 +141,9 @@ def get_file_path(
     # if starts with file://, remove it
     if rep_path.startswith("file://"):
         rep_path = rep_path[len("file://"):]
-    if rep_path.startswith(REP_DATADIR):
+    # Segment match (not a bare substring) so `/database/x` isn't mistaken for an
+    # in-root `/data` rep path.
+    if rep_path == REP_DATADIR or rep_path.startswith(REP_DATADIR + "/"):
         candidate = DATADIR / rep_path[len(REP_DATADIR) + 1:]
     else:
         candidate = Path(rep_path)


### PR DESCRIPTION
Fixes security finding **F1 (HIGH, "emergency — do first")**: arbitrary file read via `GET /files` → account takeover.

## The bug
`get_file_path()` only rewrote paths starting with `file://` or `/data` and returned **anything else verbatim** — no data-root confinement. Any authenticated user could do:

```
GET /files?filename=../../.env      → deployment .env (JWT secret, provider keys, DB creds)
GET /files?filename=/etc/passwd     → arbitrary server files
```

Reading `JWT_SECRET_KEY` → forge tokens for **any** account → **full account takeover.**

## The fix
Resolve the requested path and confine it to `DATADIR`:
- `Path.resolve()` collapses `..` and symlinks first, then a **real-path ancestor check** (not a string prefix) confirms it's inside the data root — so traversal, absolute paths outside the root, and a planted symlink escape are all rejected with `ValueError`.
- The `/files` route maps that `ValueError` to a generic **404**.
- Legitimate `/data` reads are unchanged: `documents.py`, thumbnails, and the internal `convert_to_base64_url` all pass `/data` rep-paths that resolve inside the root.

## Scope note
This closes the **arbitrary-read → `.env`/JWT** vector (the account-takeover path). It does **not** add per-user *ownership* of in-root uploads — files are stored under unguessable `{uid}_name` names with no owner mapping, so that's a separate (lower-severity) IDOR needing a files-ownership table; tracked as a follow-up. The prepared/panel-verified patch was confinement-only for the same reason.

## Tests
New `test/unit/utils/test_file.py`: traversal / absolute / `file://` escapes rejected; in-root paths (incl. in-root `..`) allowed. Full backend unit suite green (**692 passed**), ruff clean.

Finding card: `analysis/security/security-findings/F1.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)