### PR TITLE
fix(mini-app): correct iframe runtime-origin on desktop + web

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,10 +56,13 @@ jobs:
         run: npm ci
         working-directory: webui
 
-      # The frontend build script loads ../.env via dotenv; the desktop app
-      # resolves its server URL at runtime, so the sample values suffice to build.
+      # The frontend build loads ../.env via dotenv, so one must exist. This is
+      # only the compile check (nothing is distributed), so an empty file is
+      # enough — VITE_* fall back in code. The release workflow bakes the real
+      # VITE_API_URL from the API_ORIGIN repo variable.
       - name: Provide build env
-        run: cp .env.sample .env
+        shell: bash
+        run: ': > .env'
 
       - name: Build desktop app (installers)
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -84,16 +84,22 @@ jobs:
         run: npm ci
         working-directory: webui
 
-      # Bake VITE_API_URL (the server users sign in to) from the API_ORIGIN repo
-      # variable — the same server-origin var `.env` uses. Unset ⇒ drop it entirely
-      # → a local-only build. bash so it runs the same on the Windows runner (git-bash).
+      # Write a MINIMAL build .env from GitHub repo variables — do NOT copy the
+      # dev `.env.sample` (localhost origins + empty secret placeholders) into a
+      # release artifact. The desktop app is compiled: Vite bakes only `VITE_*`
+      # into the client, and the only one that matters is VITE_API_URL (the
+      # server users sign in to; a public URL → a repo VARIABLE, not a secret).
+      # Mini-app/host origins are unused on desktop (bundled single-frontend), and
+      # every real secret lives on the backend, so nothing else is baked. Unset
+      # API_ORIGIN ⇒ empty .env ⇒ a local-only build (VITE_API_URL falls back in
+      # code). bash so it runs the same on the Windows runner (git-bash).
       - name: Prepare build env
         shell: bash
         run: |
-          cp .env.sample .env
-          grep -v '^VITE_API_URL=' .env > .env.tmp && mv .env.tmp .env
           if [ -n "${API_ORIGIN}" ]; then
-            echo "VITE_API_URL=${API_ORIGIN}" >> .env
+            echo "VITE_API_URL=${API_ORIGIN}" > .env
+          else
+            : > .env
           fi
         env:
           API_ORIGIN: ${{ vars.API_ORIGIN }}

--- a/webui/src/features/mini-app/mount.tsx
+++ b/webui/src/features/mini-app/mount.tsx
@@ -42,18 +42,20 @@ import { fetchMiniAppState, saveMiniAppState } from "./state-client"
 const HANDSHAKE_TIMEOUT_MS = 5000
 
 
-// Runtime origin resolution priority:
-//   1. window.__APP_CONFIG__.miniAppOrigin  — set by docker-entrypoint.sh
-//      from VITE_MINI_APP_ORIGIN at container start. Lets one image
-//      ship to dev / staging / prod without rebuilding.
-//   2. import.meta.env.VITE_MINI_APP_ORIGIN — build-time fallback for
-//      vite-dev (no entrypoint runs there).
-//   3. "" — empty string makes the broken state obvious in devtools.
+// Runtime origin resolution:
+//   - If runtime config was injected (docker-entrypoint's `/config.js` on web),
+//     it is AUTHORITATIVE — including an intentional empty string, which means
+//     single-frontend mode (load `/mini-app` same-origin). We must NOT let a
+//     build-time-baked `VITE_MINI_APP_ORIGIN` (e.g. a dev `localhost` port) leak
+//     through when the config says empty — that's what made a single-frontend
+//     prod deploy try to load the iframe from an unreachable localhost origin.
+//   - Only when there's no injected config at all (vite-dev, no entrypoint) do
+//     we fall back to the build-time value.
 // See mini-app-archi.md §6.1.
-const RUNTIME_ORIGIN =
-  (typeof window !== "undefined" ? window.__APP_CONFIG__?.miniAppOrigin : undefined) ||
-  import.meta.env.VITE_MINI_APP_ORIGIN ||
-  ""
+const injectedConfig = typeof window !== "undefined" ? window.__APP_CONFIG__ : undefined
+const RUNTIME_ORIGIN = injectedConfig
+  ? injectedConfig.miniAppOrigin ?? ""
+  : import.meta.env.VITE_MINI_APP_ORIGIN || ""
 
 
 // Single-frontend (default): no separate runtime origin configured, so load the

--- a/webui/src/features/mini-app/mount.tsx
+++ b/webui/src/features/mini-app/mount.tsx
@@ -30,6 +30,7 @@ import { toast } from "sonner"
 
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
+import { isTauri } from "@/platform"
 
 import { createMessageHandler } from "./dispatch"
 import { fetchMiniAppState, saveMiniAppState } from "./state-client"
@@ -53,9 +54,17 @@ const HANDSHAKE_TIMEOUT_MS = 5000
 //     we fall back to the build-time value.
 // See mini-app-archi.md §6.1.
 const injectedConfig = typeof window !== "undefined" ? window.__APP_CONFIG__ : undefined
-const RUNTIME_ORIGIN = injectedConfig
-  ? injectedConfig.miniAppOrigin ?? ""
-  : import.meta.env.VITE_MINI_APP_ORIGIN || ""
+const RUNTIME_ORIGIN = isTauri()
+  // Desktop is a compiled, offline-first app: the runtime is BUNDLED under
+  // `/mini-app` and served same-origin by Tauri, with no runtime config.js to
+  // inject an origin. Force single-frontend and IGNORE any baked
+  // VITE_MINI_APP_ORIGIN — `.env.sample` (which the desktop build bakes) points
+  // it at a dev localhost port that doesn't exist on a user's machine, so a
+  // cross-origin load just fails ("loading failed").
+  ? ""
+  : injectedConfig
+    ? injectedConfig.miniAppOrigin ?? ""
+    : import.meta.env.VITE_MINI_APP_ORIGIN || ""
 
 
 // Single-frontend (default): no separate runtime origin configured, so load the


### PR DESCRIPTION
Mini-app nodes fail to load on the **standalone desktop app** (and the same class of bug could bite a single-frontend web deploy). Two related fixes to the host's runtime-origin resolution in `mount.tsx`.

## The mechanism
The host picks the mini-app iframe origin from `window.__APP_CONFIG__.miniAppOrigin` (runtime, injected by docker `config.js`), else the build-time-baked `VITE_MINI_APP_ORIGIN`, else `""` (= single-frontend, load `/mini-app/index.html` same-origin in an opaque iframe).

**Desktop (the reported bug):** the desktop app is *compiled* — the frontend build bakes `.env`, and the desktop workflows do `cp .env.sample .env`, where `.env.sample` has `VITE_MINI_APP_ORIGIN=http://localhost:5176`. There's **no `config.js` on desktop** to override it, so the iframe pointed at `http://localhost:5176` — a dev port that doesn't exist on a user's machine → **"loading failed."** (Web/prod is fine: docker injects `config.js` at container start.)

**Web (latent):** `config.miniAppOrigin || baked || ""` — an *intentional* empty config (`""`, single-frontend) is falsy, so `||` fell through to a baked value.

## Fixes
1. **Desktop:** on `isTauri()`, force single-frontend (`""`) and ignore any baked origin — the runtime is bundled under `/mini-app` (`frontendDist=../dist` includes `public/mini-app`) and served same-origin by Tauri.
2. **Web:** an injected `config.js` is now authoritative, empty string included (single-frontend); only fall back to the baked env when there's no injected config at all (vite-dev).

## Answering the deploy question
- `make desktop-build` **does** read `.env` (the frontend build runs `dotenv -e ../.env`), and on GitHub the desktop workflows `cp .env.sample .env`, so **`.env.sample` (+ `VITE_API_URL` from the `API_ORIGIN` repo var) is baked into the compiled app**. Unlike the docker web/backend (which read `.env` only at *container startup*), the desktop app has everything baked at *build time* — exactly as you reasoned.
- After this fix, desktop no longer depends on `VITE_MINI_APP_ORIGIN` at all (always bundled/same-origin), so the stale `.env.sample` value is harmless.

Verified: `check-all` clean, mini-app (55) + full suite (1127) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)