### PR TITLE
ci(desktop): pass build env from repo variables, never write .env in CI

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,11 +56,10 @@ jobs:
         run: npm ci
         working-directory: webui
 
-      # The frontend build script loads ../.env via dotenv; the desktop app
-      # resolves its server URL at runtime, so the sample values suffice to build.
-      - name: Provide build env
-        run: cp .env.sample .env
-
+      # No .env: this is only the "does it compile on every OS" check (nothing is
+      # distributed). The build's `dotenv -e ../.env` no-ops on the absent file
+      # and Vite falls back to code defaults for the unset VITE_* vars. The
+      # release workflow passes the real VITE_API_URL via the build step's env.
       - name: Build desktop app (installers)
         uses: tauri-apps/tauri-action@v0
         with:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,9 +13,10 @@ name: Desktop Release
 # this directly), a `push` of a `v*` tag (a manually pushed tag still works), and a
 # manual `workflow_dispatch` to (re)build a specific existing tag.
 #
-# The public server URL is baked in from the `API_ORIGIN` repo variable — the same
-# server-origin var `.env` uses — into VITE_API_URL. Unset ⇒ a local-only build that
-# asks the user to connect a server.
+# The public server URL is baked from the `API_ORIGIN` repo VARIABLE into
+# VITE_API_URL, passed via the build step's env (no .env file is written in CI —
+# see the build step). Unset ⇒ a local-only build that asks the user to connect a
+# server.
 on:
   push:
     tags: ["v*"]
@@ -84,24 +85,20 @@ jobs:
         run: npm ci
         working-directory: webui
 
-      # Bake VITE_API_URL (the server users sign in to) from the API_ORIGIN repo
-      # variable — the same server-origin var `.env` uses. Unset ⇒ drop it entirely
-      # → a local-only build. bash so it runs the same on the Windows runner (git-bash).
-      - name: Prepare build env
-        shell: bash
-        run: |
-          cp .env.sample .env
-          grep -v '^VITE_API_URL=' .env > .env.tmp && mv .env.tmp .env
-          if [ -n "${API_ORIGIN}" ]; then
-            echo "VITE_API_URL=${API_ORIGIN}" >> .env
-          fi
-        env:
-          API_ORIGIN: ${{ vars.API_ORIGIN }}
-
       - name: Build desktop installers
         run: npm run tauri-build
         working-directory: webui
         env:
+          # The one build-time value the desktop app needs: the public server URL
+          # users sign in to, from the API_ORIGIN repo VARIABLE (a public URL, not
+          # a secret). Passed straight into the environment — Vite bakes
+          # process.env.VITE_*, so NO .env file is written in CI (the build's
+          # `dotenv -e ../.env` no-ops on the absent file). We deliberately do NOT
+          # copy the dev `.env.sample` (localhost origins, empty secret
+          # placeholders) into a release. Unset ⇒ VITE_API_URL empty ⇒ local-only
+          # build (falls back in code); mini-app runs single-frontend from the
+          # bundled runtime since no origin is baked.
+          VITE_API_URL: ${{ vars.API_ORIGIN }}
           # Pin the V8 heap: Node auto-sizes to available RAM, so the ~7 GB macOS
           # runner defaults to ~2 GB and OOMs on the main `vite build` (works
           # locally on 16 GB+). 4 GB matches a dev machine and fits every runner.


### PR DESCRIPTION
Redo of the closed #202 — fixes the desktop mini-app failure at the **root cause** (CI env), not with a client-side special-case.

## Why mini-apps failed on desktop
The desktop workflows did `cp .env.sample .env` before building. That dev file has `VITE_MINI_APP_ORIGIN=http://localhost:5176`, and Vite bakes `VITE_*` into the compiled app — so the shipped desktop app tried to load the mini-app iframe from a **dead localhost port** on the user's machine → "loading failed". (Web is unaffected: docker injects `config.js` at runtime.)

## Why this is the right fix
Writing `.env` in CI is the wrong practice — env should come from the environment (repo **variables**/secrets), not a rendered file. And:
- Vite exposes `process.env.VITE_*` directly, and the build's `dotenv -e ../.env` **no-ops on an absent file** (verified), so CI needs no `.env` at all.
- The desktop app needs exactly **one** baked value: `VITE_API_URL` — a **public URL** from `vars.API_ORIGIN`, not a secret. Every real secret is backend-side; Vite wouldn't bake non-`VITE_` vars anyway.

## Changes
- **`desktop-release.yml`:** removed the `.env`-writing step; pass `VITE_API_URL: ${{ vars.API_ORIGIN }}` via the build step's `env:`. Nothing else is baked.
- **`desktop-build.yml`** (compile check): dropped the `.env` step entirely — builds with code defaults.
- **No client code change.** With no `VITE_MINI_APP_ORIGIN` baked, the app resolves `RUNTIME_ORIGIN=""` → single-frontend → loads the **bundled** mini-app runtime. (This supersedes #202's `mount.tsx` special-case, which was treating the symptom.)

## Sweep for other `.env` pollution
- `release.yml`: no `.env` writes. ✅
- `tests.yml`: keeps `cp .env.sample .env` — but that's a **test harness** booting the dev flow (needs the sample ports), not a distributed artifact. Left as-is.

## Action for you
Ensure the repo **variable `API_ORIGIN` = `https://api.dim0.net`** (the backend), then re-run **desktop-release**. The installer will bake the right server URL and run mini-apps from the bundled runtime. Local `make desktop-build` is unchanged (still uses `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)