### PR TITLE
fix(desktop): derive app version from Cargo.toml, not a stale tauri.conf.json pin

### DIFF
--- a/webui/src-tauri/tauri.conf.json
+++ b/webui/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Dim0",
-  "version": "0.3.59",
   "identifier": "com.topix.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Fixes the #203-review finding #1: the desktop bundle version was stuck at **0.3.59** while `VERSION`/`Cargo.toml`/`package.json` are at 0.3.7x.

## Why
`tauri.conf.json` hard-coded `"version": "0.3.59"`. The release tooling bumps `VERSION` (`.cz.toml`) and `release.yml` syncs `Cargo.toml`/`package.json`/`pyproject.toml` — but **nothing bumps `tauri.conf.json`**. Since Tauri uses `tauri.conf.json`'s explicit `version` for the bundle when present, **every desktop release shipped as 0.3.59**, and auto-update version comparisons ran against the wrong number.

## Fix
Remove the `version` key. With it absent, Tauri **derives the app version from `Cargo.toml`'s package version** — which `release.yml` already bumps on every release. One source of truth, no drift. (Currently `Cargo.toml` = 0.3.75, so the next desktop build reports 0.3.75.)

One-line deletion; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)