### PR TITLE
feat(dashboard): signed-out sync/share CTA + desktop logout → dashboard

### DIFF
--- a/webui/src/features/board/screens/boards-home.test.tsx
+++ b/webui/src/features/board/screens/boards-home.test.tsx
@@ -2,9 +2,9 @@
 //
 // Mirrors the harness pattern (no @testing-library/react): mount with vanilla
 // `react-dom/client` under `act`, mocking the data hooks + card leaves via
-// hoisted mutable state. We assert the group behaviour — signed-out shows only
-// "On this device"; signed-in adds "Synced" — and that each group renders one
-// card per partitioned board.
+// hoisted mutable state. We assert the group behaviour — signed-out shows the
+// on-device boards plus a sign-in CTA under "Synced"; signed-in fills "Synced"
+// with boards — and that each group renders one card per partitioned board.
 
 import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
@@ -100,14 +100,16 @@ describe("BoardsHome", () => {
     container.remove()
   })
 
-  it("signed out (root sentinel): renders only the on-device group", () => {
+  it("signed out (root sentinel): on-device boards + a sign-in CTA under Synced", () => {
     state.userId = "root" // the real logged-out value — truthy, so a naive !!userId would leak
     state.localBoards = [local("a"), local("b")]
     render()
-    expect(headings()).toEqual(["On this device"])
+    // Synced group still renders (reveals the feature), but with the CTA — no boards.
+    expect(headings()).toEqual(["On this device", "Synced"])
     expect(count("local-card")).toBe(2)
     expect(count("new-local")).toBe(1)
     expect(count("synced-card")).toBe(0)
+    expect(container.textContent).toContain("Sync & share your boards")
   })
 
   it("signed in: renders both groups, deduped by id", () => {

--- a/webui/src/features/board/screens/boards-home.tsx
+++ b/webui/src/features/board/screens/boards-home.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { ThemedWelcome } from "@/features/agent/components/chat/welcome-message"
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { CloudArrowUpIcon } from "@/components/icons"
 import { useAppStore } from "@/store"
 import { isSignedIn } from "@/lib/auth"
 import { useListBoards } from "../api/list-boards"
@@ -88,25 +90,31 @@ export function BoardsHome({
           ))}
         </Section>
 
-        {signedIn && (
-          <Section
-            title="Synced"
-            hint="Backed up, multi-device, shareable"
-            footer={
-              isLoading
+        <Section
+          title="Synced"
+          hint="Backed up, multi-device, shareable"
+          footer={
+            signedIn && !isLoading && synced.length === 0
+              ? "No synced boards yet. Enable sync on a local board to back it up and share it."
+              : signedIn && isLoading
                 ? "Loading…"
-                : synced.length === 0
-                  ? "No synced boards yet. Enable sync on a local board to back it up and share it."
-                  : null
-            }
-          >
-            {synced.map((board) => (
+                : null
+          }
+        >
+          {signedIn ? (
+            synced.map((board) => (
               <CardCell key={board.uid}>
                 <BoardCard board={board} />
               </CardCell>
-            ))}
-          </Section>
-        )}
+            ))
+          ) : (
+            // Signed-out: reveal the feature with a calm, ignorable CTA where the
+            // boards would be — not a modal/nag. Local-first stays the default.
+            <CardCell>
+              <SyncedSignInCta onSignIn={() => void navigate({ to: "/signin" })} />
+            </CardCell>
+          )}
+        </Section>
       </div>
     </div>
   )
@@ -152,5 +160,28 @@ function Section({
 function CardCell({ children }: { children: ReactNode }) {
   return (
     <div className="w-full h-full flex justify-center items-center">{children}</div>
+  )
+}
+
+
+/**
+ * Signed-out placeholder for the Synced group: a calm, value-first card inviting
+ * sign-in to unlock sync/share. Deliberately non-blocking — it sits where boards
+ * would, and ignoring it costs nothing (local-first stays the default).
+ */
+function SyncedSignInCta({ onSignIn }: { onSignIn: () => void }) {
+  return (
+    <div className="w-64 h-60 flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-border p-6 text-center">
+      <CloudArrowUpIcon className="size-8 text-muted-foreground" strokeWidth={2} />
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">Sync &amp; share your boards</p>
+        <p className="text-xs text-muted-foreground">
+          Sign in to back them up and open them on any device.
+        </p>
+      </div>
+      <Button variant="secondary" size="sm" onClick={onSignIn}>
+        Sign in
+      </Button>
+    </div>
   )
 }

--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -61,7 +61,9 @@ export function RootLayout() {
     setUserPlan('free')
     setEmailVerificationEnabled(false)
     setEmailVerified(true)
-    navigate({ to: '/signin', replace: true })
+    // Local-first desktop: signing out drops back to the local dashboard, not a
+    // login wall you don't need. Web keeps the sign-in screen.
+    navigate({ to: isTauri() ? '/' : '/signin', replace: true })
   }, [navigate, queryClient, setEmailVerificationEnabled, setEmailVerified, setUserEmail, setUserId, setUserPlan])
 
   const isAuthed = isSignedIn(userId)


### PR DESCRIPTION
Two local-first UX touches (both from the design discussion).

## Reveal sync/share to signed-out users
The **Synced** dashboard group was hidden entirely when signed out (`{signedIn && …}`), so a signed-out user never learned sync/share existed. Now it **always renders**, and signed-out shows a **calm, non-blocking CTA card** where boards would go:

> ☁ **Sync & share your boards**
> Sign in to back them up and open them on any device.  **[ Sign in ]**

Design intent (per the discussion): contextual (teaches the feature where it lands), **ignorable** (no modal/nag/banner — skipping it costs nothing), value-first copy, and consistent with the sidebar's existing "Sign in to sync & share." Local-first stays the default.

## Desktop logout → dashboard (not a login wall)
On `isTauri()`, logging out returns to the local dashboard (`/`) instead of `/signin` — a local-first app shouldn't strand you at a login screen you don't need. Web keeps `/signin`.

## On "start on the dashboard, not sign-in"
Turns out the app **already** lands signed-out users on the local dashboard (`index-home`: signed-out → `BoardsHome`), with **no auth guard** — so sign-in was never gating the front door. Combined with the logout change, sign-in is now reached **only via explicit CTAs**. (If your desktop build is still opening on `/signin` at launch, that's a stale route, not a redirect in code — let me know and I'll dig in.)

Verified: `check-all` clean, full suite **1127 passing** (updated the boards-home test for the always-rendered Synced group + CTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)