### PR TITLE
fix(board): require drag-to-size placement, drop single-click node creation

### DIFF
--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -210,7 +210,7 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
   })
   useLocalPresence(store, wrapRef, ready)
 
-  const { handleCreateDrag, handleClick } = useCreateHandlers(store, boardId, rootId, styleMemory)
+  const { handleCreateDrag } = useCreateHandlers(store, boardId, rootId, styleMemory)
   // Recompute every render — NOT memoized on `styleMemory`. The memory
   // object is intentionally identity-stable for its whole lifetime, so a
   // `useMemo([styleMemory])` would compute once at mount and freeze the
@@ -428,7 +428,6 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
             canCollab={!local}
             arrowDefaults={arrowDefaults}
             onCreateDrag={handleCreateDrag}
-            onClick={handleClick}
             onDoubleClick={handleDoubleClick}
             onRenderer={handleRenderer}
           />
@@ -448,7 +447,6 @@ type InnerProps = {
   canCollab: boolean
   arrowDefaults: ArrowToolDefaults
   onCreateDrag: ReturnType<typeof useCreateHandlers>["handleCreateDrag"]
-  onClick: ReturnType<typeof useCreateHandlers>["handleClick"]
   onDoubleClick: (e: CanvasPointerEvent) => void
   onRenderer: (r: Renderer) => void
 }
@@ -462,7 +460,6 @@ function HarnessCanvasInner({
   canCollab,
   arrowDefaults,
   onCreateDrag,
-  onClick,
   onDoubleClick,
   onRenderer,
 }: InnerProps) {
@@ -492,7 +489,6 @@ function HarnessCanvasInner({
             editorAdapter={createHarnessTextareaEditor}
             arrowDefaults={arrowDefaults}
             onCreateDrag={onCreateDrag}
-            onClick={onClick}
             onDoubleClick={onDoubleClick}
             onRenderer={onRenderer}
           />

--- a/webui/src/features/board/harness/canvas/use-create-handlers.ts
+++ b/webui/src/features/board/harness/canvas/use-create-handlers.ts
@@ -60,20 +60,14 @@ const CREATE_LABELS: Record<string, string> = {
 
 /**
  * Subset of shape tools where a bare click (no drag) still places a
- * node. Click-to-place is the established UX for text and for fixed-
- * size surfaces (folders / sheets / code-sandboxes / widgets); the
- * resizable shapes (rect, ellipse, diamond, …) require an actual
- * drag — sub-5px drags fall through to onClick as a no-op so
- * accidental taps don't litter the canvas with default-size shapes.
+ * node. Intentionally empty: every shape tool now requires a real
+ * drag-to-size gesture, so a bare click (or sub-5px drag) falls
+ * through to onClick as a no-op and never litters the canvas with an
+ * accidental default-size node. Text nodes keep their dedicated
+ * double-click-empty-canvas creation path (`handleDoubleClick` in
+ * harness-canvas.tsx); this set does not affect that.
  */
-const CLICK_PLACE_TOOLS = new Set([
-  "text",
-  "folder",
-  "sheet",
-  "code-sandbox",
-  "widget",
-  "mini-app",
-])
+const CLICK_PLACE_TOOLS = new Set<string>([])
 
 
 /**

--- a/webui/src/features/board/harness/canvas/use-create-handlers.ts
+++ b/webui/src/features/board/harness/canvas/use-create-handlers.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { toast } from "sonner"
 import type { CanvasStore, Node } from "@canvas-harness/core"
-import type { CanvasCreateDragEvent, CanvasPointerEvent } from "@canvas-harness/react"
+import type { CanvasCreateDragEvent } from "@canvas-harness/react"
 import {
   MAX_BOARD_DEPTH,
   canCreateSubBoard,
@@ -59,15 +59,27 @@ const CREATE_LABELS: Record<string, string> = {
 
 
 /**
- * Subset of shape tools where a bare click (no drag) still places a
- * node. Intentionally empty: every shape tool now requires a real
- * drag-to-size gesture, so a bare click (or sub-5px drag) falls
- * through to onClick as a no-op and never litters the canvas with an
- * accidental default-size node. Text nodes keep their dedicated
+ * Tools whose node has a canonical default size. A drag-to-create with
+ * one of these places the node at *at least* that default size (drag
+ * only picks the position; the size is floored), so a small drag can't
+ * materialize an unusably tiny fixed surface — e.g. a mini-app or
+ * code-sandbox too small to render its content. Freeform shapes
+ * (rect / ellipse / diamond / …) are absent: drag-to-size is their point.
+ *
+ * Node creation now requires a real drag. A bare click (or sub-5px tap)
+ * has no create handler wired at all, so accidental taps no longer
+ * litter the canvas with default-size nodes. Text keeps its separate
  * double-click-empty-canvas creation path (`handleDoubleClick` in
- * harness-canvas.tsx); this set does not affect that.
+ * harness-canvas.tsx), unaffected by this.
  */
-const CLICK_PLACE_TOOLS = new Set<string>([])
+const DEFAULT_SIZE_TOOLS = new Set([
+  "text",
+  "folder",
+  "sheet",
+  "code-sandbox",
+  "widget",
+  "mini-app",
+])
 
 
 /**
@@ -105,18 +117,20 @@ export const applyStyleMemory = (node: Node, styleMemory: StyleMemoryApi): Node 
 
 
 /**
- * onCreateDrag / onClick handlers for `<Canvas>`. Routes shape-tool
- * gestures into the conversion layer:
+ * onCreateDrag handler for `<Canvas>`. Routes a shape-tool drag-to-create
+ * gesture into the conversion layer:
  *
  *   1. Build a fresh Dim0 Note via `createDefaultNote` so it carries
  *      the right default style + properties for round-trip persistence.
- *   2. Override its `nodePosition` / `nodeSize` from the gesture rect
- *      (drag) or the world click (click + default size).
+ *   2. Set its `nodePosition` from the drag rect, and its `nodeSize`
+ *      from the drag rect (freeform shapes) or floored at the type's
+ *      default (fixed-size surfaces — see `DEFAULT_SIZE_TOOLS`).
  *   3. Convert to a canvas-harness Node and merge the user's sticky
  *      style memory before adding to the store.
  *
- * Select, pan, and arrow tools are handled by the lib internally — we
- * skip them here.
+ * Creation is drag-only: a bare click never places a node (no onClick
+ * create handler is wired). Select, pan, and arrow tools are handled by
+ * the lib internally — we skip them here.
  */
 export const useCreateHandlers = (
   store: CanvasStore,
@@ -125,7 +139,6 @@ export const useCreateHandlers = (
   styleMemory: StyleMemoryApi,
 ): {
   handleCreateDrag: (e: CanvasCreateDragEvent) => void
-  handleClick: (e: CanvasPointerEvent) => void
 } => {
   const userPlan = useAppStore((s) => s.userPlan)
   const currentFolderDepth = useBoardAppStore((s) => s.currentFolderDepth)
@@ -163,9 +176,24 @@ export const useCreateHandlers = (
         type: "position",
         position: { x: e.rect.x, y: e.rect.y },
       }
-      note.properties.nodeSize = {
-        type: "size",
-        size: { width: e.rect.w, height: e.rect.h },
+      // Fixed-size surfaces keep (at least) their canonical default
+      // size: the drag picks the position, but a small drag can't
+      // shrink them into an unusable node. Freeform shapes take the
+      // drag rect as-is (drag-to-size is the point).
+      if (DEFAULT_SIZE_TOOLS.has(e.tool)) {
+        const def = note.properties.nodeSize.size ?? { width: 200, height: 120 }
+        note.properties.nodeSize = {
+          type: "size",
+          size: {
+            width: Math.max(e.rect.w, def.width),
+            height: Math.max(e.rect.h, def.height),
+          },
+        }
+      } else {
+        note.properties.nodeSize = {
+          type: "size",
+          size: { width: e.rect.w, height: e.rect.h },
+        }
       }
       // Auto-select the freshly-created node so the user can
       // immediately resize / style / move it without round-tripping
@@ -177,24 +205,5 @@ export const useCreateHandlers = (
     [store, boardId, rootId, styleMemory, guardCreate],
   )
 
-  const handleClick = useCallback(
-    (e: CanvasPointerEvent): void => {
-      if (!CLICK_PLACE_TOOLS.has(e.tool)) return
-      const dim0Type = canvasTypeToDim0(e.tool)
-      if (!guardCreate(dim0Type)) return
-      const note = createDefaultNote({ boardId: boardId ?? "", nodeType: dim0Type })
-      if (rootId) note.parentId = rootId
-      const size = note.properties.nodeSize.size ?? { width: 200, height: 120 }
-      const { width, height } = size
-      note.properties.nodePosition = {
-        type: "position",
-        position: { x: e.world.x - width / 2, y: e.world.y - height / 2 },
-      }
-      const id = store.addNode(applyStyleMemory(noteToNode(note), styleMemory))
-      store.setSelection([id])
-    },
-    [store, boardId, rootId, styleMemory, guardCreate],
-  )
-
-  return { handleCreateDrag, handleClick }
+  return { handleCreateDrag }
 }

--- a/webui/src/features/board/harness/canvas/use-create-handlers.ts
+++ b/webui/src/features/board/harness/canvas/use-create-handlers.ts
@@ -58,28 +58,14 @@ const CREATE_LABELS: Record<string, string> = {
 }
 
 
-/**
- * Tools whose node has a canonical default size. A drag-to-create with
- * one of these places the node at *at least* that default size (drag
- * only picks the position; the size is floored), so a small drag can't
- * materialize an unusably tiny fixed surface — e.g. a mini-app or
- * code-sandbox too small to render its content. Freeform shapes
- * (rect / ellipse / diamond / …) are absent: drag-to-size is their point.
- *
- * Node creation now requires a real drag. A bare click (or sub-5px tap)
- * has no create handler wired at all, so accidental taps no longer
- * litter the canvas with default-size nodes. Text keeps its separate
- * double-click-empty-canvas creation path (`handleDoubleClick` in
- * harness-canvas.tsx), unaffected by this.
- */
-const DEFAULT_SIZE_TOOLS = new Set([
-  "text",
-  "folder",
-  "sheet",
-  "code-sandbox",
-  "widget",
-  "mini-app",
-])
+// Creation is drag-only. A bare click never places a node — no onClick
+// create handler is wired, and the lib's DRAG_CREATE_MIN_SIZE_PX (5px on
+// screen) drops any too-small gesture before it ever reaches
+// onCreateDrag, so accidental taps create nothing. A committed drag
+// materializes the node at exactly the size the user drew. Text keeps
+// its separate double-click-empty-canvas path (`handleDoubleClick` in
+// harness-canvas.tsx); the lib also excludes the text tool from
+// drag-create entirely.
 
 
 /**
@@ -122,15 +108,14 @@ export const applyStyleMemory = (node: Node, styleMemory: StyleMemoryApi): Node 
  *
  *   1. Build a fresh Dim0 Note via `createDefaultNote` so it carries
  *      the right default style + properties for round-trip persistence.
- *   2. Set its `nodePosition` from the drag rect, and its `nodeSize`
- *      from the drag rect (freeform shapes) or floored at the type's
- *      default (fixed-size surfaces — see `DEFAULT_SIZE_TOOLS`).
+ *   2. Set its `nodePosition` / `nodeSize` from the drag rect.
  *   3. Convert to a canvas-harness Node and merge the user's sticky
  *      style memory before adding to the store.
  *
  * Creation is drag-only: a bare click never places a node (no onClick
- * create handler is wired). Select, pan, and arrow tools are handled by
- * the lib internally — we skip them here.
+ * create handler is wired), and the lib drops sub-5px gestures before
+ * they reach us — so accidental taps create nothing. Select, pan, and
+ * arrow tools are handled by the lib internally — we skip them here.
  */
 export const useCreateHandlers = (
   store: CanvasStore,
@@ -176,24 +161,9 @@ export const useCreateHandlers = (
         type: "position",
         position: { x: e.rect.x, y: e.rect.y },
       }
-      // Fixed-size surfaces keep (at least) their canonical default
-      // size: the drag picks the position, but a small drag can't
-      // shrink them into an unusable node. Freeform shapes take the
-      // drag rect as-is (drag-to-size is the point).
-      if (DEFAULT_SIZE_TOOLS.has(e.tool)) {
-        const def = note.properties.nodeSize.size ?? { width: 200, height: 120 }
-        note.properties.nodeSize = {
-          type: "size",
-          size: {
-            width: Math.max(e.rect.w, def.width),
-            height: Math.max(e.rect.h, def.height),
-          },
-        }
-      } else {
-        note.properties.nodeSize = {
-          type: "size",
-          size: { width: e.rect.w, height: e.rect.h },
-        }
+      note.properties.nodeSize = {
+        type: "size",
+        size: { width: e.rect.w, height: e.rect.h },
       }
       // Auto-select the freshly-created node so the user can
       // immediately resize / style / move it without round-tripping


### PR DESCRIPTION
## What

Placing a node on the canvas now **requires a two-click drag-to-size gesture**. A bare single click (or an accidental sub-5px tap) no longer creates anything.

Previously, tools in `CLICK_PLACE_TOOLS` (text, folder, sheet, code-sandbox, widget, mini-app) would drop a **default-size node on a single click**, which made it easy to litter the board with notes you didn't want — most annoyingly the large 440×440 sheet note.

## Change

One-line policy change in `use-create-handlers.ts`: `CLICK_PLACE_TOOLS` is now empty, so every shape tool falls through the `onClick` handler as a no-op and only `handleCreateDrag` (a real drag) materializes a node. The resizable shapes (rect/ellipse/diamond/…) already behaved this way — this brings the custom surfaces in line.

## Behavior after this change

| Tool | Before | After |
|---|---|---|
| sheet / folder / code-sandbox / widget / mini-app | bare click → default-size node | **drag-to-size only**; bare click does nothing |
| text (text tool) | bare click → default-size | drag-to-size only |
| **text (double-click empty canvas)** | creates + edits | **unchanged — still works** |
| rect / ellipse / diamond / … | already drag-only | unchanged |

## Not affected

Text's dedicated **double-click-on-empty-canvas** creation path (`handleDoubleClick` in `harness-canvas.tsx`) is separate and untouched — double-click still drops a text note and opens it for editing.

## Notes

- The text *tool* (toolbar button / `T` shortcut) now needs a drag to place; a single click with it selected does nothing. Text-via-double-click is the quick path.
- Discoverability: a bare click silently doing nothing while a tool is selected could read as "broken" to some users. The resizable shapes already behaved this way, so it's not a new pattern, but a "drag to place" hint/cursor could be a nice follow-up.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Select sheet tool → single click does nothing; drag creates a sized sheet
- [ ] Repeat for folder / code-sandbox / mini-app / widget / text tool
- [ ] Double-click empty canvas (select tool) still creates + edits a text note