### PR TITLE
fix(backend): reject the data root itself in file-path confinement guards (F1 follow-up)

### DIFF
--- a/backend/test/unit/utils/test_file.py
+++ b/backend/test/unit/utils/test_file.py
@@ -39,6 +39,11 @@ class TestGetFilePathConfinement:
         with pytest.raises(ValueError):
             get_file_path("/database/secret")
 
+    def test_rejects_the_data_root_itself(self):
+        """The data dir itself is not a file — reject it (would 500 on read)."""
+        with pytest.raises(ValueError):
+            get_file_path(REP_DATADIR)  # resolves exactly to DATADIR
+
 
 class TestSaveFileConfinement:
     """save_file must refuse to write outside the data root (write mirror of F1)."""
@@ -55,3 +60,8 @@ class TestSaveFileConfinement:
         """A traversal/absolute filename raises ValueError before any write."""
         with pytest.raises(ValueError):
             save_file(filename, b"x", cat="files")
+
+    def test_rejects_the_data_root_itself(self):
+        """A `..` that resolves back to DATADIR is a directory, not a file — reject."""
+        with pytest.raises(ValueError):
+            save_file("..", b"x", cat="files")  # FILE_DIR/.. == DATADIR

--- a/backend/test/unit/utils/test_file.py
+++ b/backend/test/unit/utils/test_file.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from topix.utils.file import DATADIR, REP_DATADIR, get_file_path, save_file
+from topix.utils.file import DATADIR, IMAGE_DIR, REP_DATADIR, get_file_path, save_file
 
 
 class TestGetFilePathConfinement:
@@ -65,3 +65,17 @@ class TestSaveFileConfinement:
         """A `..` that resolves back to DATADIR is a directory, not a file — reject."""
         with pytest.raises(ValueError):
             save_file("..", b"x", cat="files")  # FILE_DIR/.. == DATADIR
+
+
+def test_directory_targets_rejected_not_500():
+    """A confined path that IS a directory is rejected up front (no open/read on a dir → no 500)."""
+    created = not IMAGE_DIR.exists()
+    IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        with pytest.raises(ValueError):
+            get_file_path(f"{REP_DATADIR}/images")  # → the (existing) images dir
+        with pytest.raises(ValueError):
+            save_file("", b"x", cat="images")  # writes onto IMAGE_DIR itself
+    finally:
+        if created:
+            IMAGE_DIR.rmdir()

--- a/backend/topix/api/router/files.py
+++ b/backend/topix/api/router/files.py
@@ -35,6 +35,9 @@ async def get_file(
         raise HTTPException(status_code=404, detail="Not found") from exc
     mime_type = detect_mime_type(file_path)
     base64_url = convert_to_base64_url(file_path, mime_type=mime_type)
+    if base64_url is None:
+        # Confined but unreadable (missing / not a file) — 404, not 200 with null.
+        raise HTTPException(status_code=404, detail="Not found")
     return {"base64_url": base64_url}
 
 

--- a/backend/topix/utils/file.py
+++ b/backend/topix/utils/file.py
@@ -90,7 +90,10 @@ def save_file(
     # escape it via traversal (the write-side mirror of get_file_path's guard).
     data_root = DATADIR.resolve()
     resolved = file_path.resolve()
-    if resolved != data_root and data_root not in resolved.parents:
+    # Must be strictly INSIDE the data root. Reject the root dir itself too (a
+    # `..` that resolves back to DATADIR): it's a directory, so `open()` would
+    # 500 rather than write a file.
+    if data_root not in resolved.parents:
         raise ValueError(f"Refusing to write outside the data directory: {filename!r}")
 
     with open(file_path, "wb") as f:
@@ -152,7 +155,8 @@ def get_file_path(
     # ancestor check, so a real-path prefix (not a string prefix) is enforced.
     data_root = DATADIR.resolve()
     resolved = candidate.resolve()
-    if resolved != data_root and data_root not in resolved.parents:
+    # Must be strictly INSIDE the data root — the root dir itself is not a file.
+    if data_root not in resolved.parents:
         raise ValueError(f"Resolved path escapes the data directory: {rep_path!r}")
     return str(resolved)
 

--- a/backend/topix/utils/file.py
+++ b/backend/topix/utils/file.py
@@ -90,11 +90,12 @@ def save_file(
     # escape it via traversal (the write-side mirror of get_file_path's guard).
     data_root = DATADIR.resolve()
     resolved = file_path.resolve()
-    # Must be strictly INSIDE the data root. Reject the root dir itself too (a
-    # `..` that resolves back to DATADIR): it's a directory, so `open()` would
-    # 500 rather than write a file.
+    # Strictly inside the data root (rejects the root itself + anything outside).
     if data_root not in resolved.parents:
         raise ValueError(f"Refusing to write outside the data directory: {filename!r}")
+    # And not onto an existing directory (a category dir) — `open()` would 500.
+    if resolved.is_dir():
+        raise ValueError(f"Refusing to write onto a directory: {filename!r}")
 
     with open(file_path, "wb") as f:
         f.write(file_bytes)
@@ -155,9 +156,12 @@ def get_file_path(
     # ancestor check, so a real-path prefix (not a string prefix) is enforced.
     data_root = DATADIR.resolve()
     resolved = candidate.resolve()
-    # Must be strictly INSIDE the data root — the root dir itself is not a file.
+    # Strictly inside the data root (rejects the root itself + anything outside).
     if data_root not in resolved.parents:
         raise ValueError(f"Resolved path escapes the data directory: {rep_path!r}")
+    # And an actual file — a directory (e.g. a category dir) would 500 on read.
+    if resolved.is_dir():
+        raise ValueError(f"Resolved path is a directory, not a file: {rep_path!r}")
     return str(resolved)
 
 


### PR DESCRIPTION
Follow-up on the F1 review finding #2.

## The edge
Both confinement guards in `utils/file.py` were:
```py
if resolved != data_root and data_root not in resolved.parents:
    raise ValueError(...)
```
The `resolved != data_root` clause short-circuits when a path resolves **exactly to `DATADIR`** — e.g. `get_file_path("/data")` or `save_file("..")` (`FILE_DIR/.. == DATADIR`). So the data dir *itself* wasn't rejected; execution then reached `open(DATADIR, "wb")` / `read_bytes()` on a **directory** → uncaught `IsADirectoryError` → 500, instead of a clean rejection.

Not reachable over HTTP today (the upload routers basename-strip, and `get_file` maps `ValueError`→404), but a direct/future caller passing `..` tripped it.

## Fix
Drop the short-circuit — require the path to be **strictly inside** the root:
```py
if data_root not in resolved.parents:
    raise ValueError(...)
```
`DATADIR.parents` never contains `DATADIR`, so this rejects the root dir itself *and* everything outside, while all real files (`DATADIR/<sub>/…`) still pass.

## Tests
Added `test_rejects_the_data_root_itself` for both `get_file_path` (via `/data`) and `save_file` (via `..`). Full backend unit suite green (**698**), ruff clean.