### PR TITLE
fix(board): active toolbar button border + view-button hover/active states

### DIFF
--- a/webui/src/features/board/harness/chrome/toolbar.tsx
+++ b/webui/src/features/board/harness/chrome/toolbar.tsx
@@ -70,17 +70,20 @@ const SHAPE_TOOLS: ReadonlyArray<ShapeTool> = [
 const SHAPE_TOOL_IDS = new Set(SHAPE_TOOLS.map((t) => t.id))
 
 
-// A transparent border sits on EVERY state so toggling a visible one on hover
-// doesn't shift the icon — the tray fill (`bg-sidebar`) and the hover fill
-// (`bg-secondary`) are close enough that the fill change alone reads as no hover,
-// so the border carries the affordance.
+// The `border` width sits on EVERY state so toggling a visible border on
+// hover/active doesn't shift the icon — the tray fill (`bg-sidebar`) and the
+// hover fill (`bg-secondary`) are close enough that the fill change alone reads
+// as no hover, so the border carries the affordance. The border COLOR is set
+// per-state (not on the base): these strings are assigned straight to
+// `className` and never pass through tailwind-merge, so a base
+// `border-transparent` would collide with the active `border-…/30` and win by
+// CSS source order — swallowing the active border entirely.
 const baseButtonClass =
-  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border border-transparent"
-const inactiveClass = `${baseButtonClass} text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
-// Active buttons carry the same border as the hover state (the base's transparent
-// border keeps the box size constant), so active + hovered read consistently —
-// including the always-active view button (board/list/files).
-const activeClass = `${baseButtonClass} bg-secondary text-secondary-foreground border-secondary-foreground/30`
+  "transition-colors !p-2.5 rounded-lg flex items-center justify-center gap-2 border"
+const inactiveClass = `${baseButtonClass} border-transparent text-card-foreground hover:bg-secondary hover:text-secondary-foreground hover:border-secondary-foreground/30`
+// Active buttons carry the same border color as the hover state, so active +
+// hovered read consistently.
+const activeClass = `${baseButtonClass} border-secondary-foreground/30 bg-secondary text-secondary-foreground`
 
 
 /**
@@ -221,6 +224,11 @@ export function HarnessToolbar({ local = false }: { local?: boolean } = {}) {
   const setSlidesPanelOpen = useBoardAppStore((s) => s.setSlidesPanelOpen)
   const viewMode = useBoardAppStore((s) => s.viewMode)
   const setViewMode = useBoardAppStore((s) => s.setViewMode)
+  // Controlled so the trigger can show hover feedback normally and flip to the
+  // active style only while its menu is open (uncontrolled gives no open signal
+  // for styling, and the nested Tooltip/Dropdown triggers both write
+  // `data-state`, so a `data-[state=open]:` variant would be ambiguous).
+  const [viewMenuOpen, setViewMenuOpen] = useState(false)
 
   const isBoard = viewMode === "board"
   const isPan = tool === "pan"
@@ -238,14 +246,15 @@ export function HarnessToolbar({ local = false }: { local?: boolean } = {}) {
       aria-label="Board toolbar"
       data-coachmark="toolbar"
     >
-      <DropdownMenu>
+      <DropdownMenu open={viewMenuOpen} onOpenChange={setViewMenuOpen}>
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
                 aria-label="Change view"
-                className={activeClass}
+                aria-pressed={viewMenuOpen}
+                className={viewMenuOpen ? activeClass : inactiveClass}
               >
                 <ActiveViewIcon className="size-4 shrink-0" weight="fill" />
                 <span className="sr-only text-[10px] md:not-sr-only">


### PR DESCRIPTION
## What

Two affordance bugs in the canvas top toolbar (`chrome/toolbar.tsx`):

1. **Active buttons showed no border.** On hover a button gets a visible border, but a button in its *active* state (selected tool, open slides panel, etc.) had none.
2. **The view button (board / files / list) had no hover or active feedback** — it looked static.

## Why

1. `baseButtonClass` hardcoded `border border-transparent` and `activeClass` appended `border-secondary-foreground/30`. These strings are assigned **straight to `className`** and never pass through `tailwind-merge`, so both border-color utilities survived and the browser applied whichever came later in the compiled CSS — `border-transparent` won and swallowed the active border. Hover worked only because it used a `hover:` *variant* (higher precedence).
2. The view button was hardcoded to `className={activeClass}` with an **uncontrolled** dropdown, so it was permanently active-styled and had no open/hover signal to react to.

## Fix

- Move the border **color** off the base class onto each state: base keeps only the `border` width (constant box size, no icon shift), `inactiveClass` gets `border-transparent` + the `hover:` color, `activeClass` gets the visible color. No more collision.
- Control the view dropdown (`viewMenuOpen`); the trigger now uses `inactiveClass` normally (hover feedback) and flips to `activeClass` only while its menu is open. Added `aria-pressed`.

## Behavior after

| | Before | After |
|---|---|---|
| Active tool/panel button | no border | visible border (matches hover) |
| View button at rest | always filled, static | unfilled, like tool buttons |
| View button on hover | nothing | fill + border |
| View button while menu open | nothing | active (fill + border) |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [ ] Select a tool (pan/select/shape/text/note) → active button shows a border
- [ ] Hover the view button → hover feedback; open it → active styling; close → back to rest