### PR TITLE
fix(desktop): paint title bar as chrome (sidebar surface + border)

### DIFF
--- a/webui/src/routes/root-layout.tsx
+++ b/webui/src/routes/root-layout.tsx
@@ -175,7 +175,7 @@ export function RootLayout() {
                       so the board toolbar (which floats below) never overlaps it. */}
                   <div
                     data-tauri-drag-region
-                    className="z-50 flex h-11 shrink-0 items-center gap-2 border-b border-border/60 bg-background/95 px-3 [.tauri-fullscreen_&]:hidden"
+                    className="z-50 flex h-11 shrink-0 items-center gap-2 border-b border-sidebar-border bg-sidebar px-3 [.tauri-fullscreen_&]:hidden"
                   >
                     {navCluster}
                     <div className="ml-auto flex items-center gap-2 self-stretch">


### PR DESCRIPTION
## What

The frameless desktop title line (brand + window controls) now uses the **sidebar** surface and border instead of the content background, so the title bar and sidebar read as one continuous chrome frame.

## Why

`root-layout.tsx` painted the title line with `bg-background/95` + `border-border/60` — i.e. as *content*. But it's window chrome, like the sidebar. The design tokens already tier surfaces deliberately: content sits at `--background`, chrome sits at `--sidebar` (slightly recessed in light, slightly elevated in dark). The title bar was the one obvious piece of chrome breaking that rule.

## Change

`root-layout.tsx:178`:
- `bg-background/95` → `bg-sidebar`
- `border-border/60` → `border-sidebar-border`

The pre-auth title bar (sign-in screen) stays transparent over `AuthBackground` — unchanged.

## Result

| | Before | After |
|---|---|---|
| Title-bar fill | `background` (content tone) | `sidebar` (chrome tone) |
| Title-bar divider | `border/60` | `sidebar-border` |
| Cohesion | title bar blended into content | title bar + sidebar = one chrome frame |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [ ] Desktop build: title bar tone matches the sidebar in light + dark themes
- [ ] Divider under the title bar aligns with the sidebar's borders