### PR TITLE
feat(webui): open stripe billing in os browser on desktop

### DIFF
--- a/webui/src-tauri/src/lib.rs
+++ b/webui/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use tauri::Manager;
 
 mod oauth;
+mod shell;
 mod storage;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -36,7 +37,8 @@ pub fn run() {
       storage::sql_execute,
       storage::sql_select,
       storage::sql_tx,
-      oauth::google_oauth
+      oauth::google_oauth,
+      shell::open_external
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/webui/src-tauri/src/shell.rs
+++ b/webui/src-tauri/src/shell.rs
@@ -1,0 +1,13 @@
+//! Open a URL in the user's default browser (external to the webview).
+
+/// Open `url` in the OS default browser. Used to push Stripe checkout/portal out
+/// of the WKWebView so payment flows run in a real browser, not the embedded one.
+#[tauri::command]
+pub async fn open_external(url: String) -> Result<(), String> {
+    // Only ever hand off http(s) — never file://, tauri://, or shell targets — so
+    // this command can't be repurposed as a general "launch anything" primitive.
+    if !(url.starts_with("https://") || url.starts_with("http://")) {
+        return Err("refusing to open non-http(s) url".into());
+    }
+    open::that(url).map_err(|e| e.to_string())
+}

--- a/webui/src/features/user-settings/screens/billing-screen.tsx
+++ b/webui/src/features/user-settings/screens/billing-screen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { BracketsCurly, CardsThree, GithubLogo, Headset, UsersThree } from "@phosphor-icons/react"
 import {
   AwardIcon,
@@ -29,6 +29,7 @@ import {
 } from "@/features/user-settings/api/billing"
 import { getAccessToken } from "@/features/signin/auth-storage"
 import { decodeJwt, resolveBillingPlan } from "@/lib/decode-jwt"
+import { isTauri, openExternalUrl } from "@/platform"
 import { useAppStore } from "@/store"
 
 
@@ -80,40 +81,71 @@ export function BillingScreen() {
     })()
   }, [billingActive])
 
+  // Re-pull the authoritative plan: refresh the token (its claim is updated by
+  // the Stripe webhook), re-derive the plan, and re-read the summary. Idempotent
+  // (pure reads + a token refresh), so it's safe to call on every focus.
+  const refreshBillingState = useCallback(async () => {
+    await refresh()
+    const token = getAccessToken()
+    if (!token) return
+    setUserPlan(resolveBillingPlan(decodeJwt(token)))
+    setBillingSummary(await getBillingSummary())
+  }, [setUserPlan])
+
+  // Web: Stripe redirects the tab back to `?checkout=success`; refresh once.
   useEffect(() => {
     if (!billingActive) return
     if (refreshedAfterReturn.current) return
     if (searchParams.get("checkout") !== "success") return
 
     refreshedAfterReturn.current = true
-    void (async () => {
-      try {
-        await refresh()
-        const token = getAccessToken()
-        if (!token) return
-        const payload = decodeJwt(token)
-        setUserPlan(resolveBillingPlan(payload))
-        const summary = await getBillingSummary()
-        setBillingSummary(summary)
-      } catch {
-        setErrorMessage("Could not refresh billing plan after checkout.")
-      }
-    })()
-  }, [billingActive, searchParams, setUserPlan])
+    void refreshBillingState().catch(() =>
+      setErrorMessage("Could not refresh billing plan after checkout."),
+    )
+  }, [billingActive, searchParams, refreshBillingState])
+
+  // Desktop: Stripe opens in the OS browser, so the `?checkout=success` redirect
+  // never reaches this webview. Refresh whenever the app window regains focus —
+  // i.e. when the user clicks back after finishing in the browser. Also catches
+  // portal-side changes (cancel/resume/switch) that have no success URL.
+  useEffect(() => {
+    if (!isTauri() || !billingActive) return
+    let unlisten: (() => void) | undefined
+    let cancelled = false
+    void import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+      if (cancelled) return
+      void getCurrentWindow()
+        .onFocusChanged(({ payload: focused }) => {
+          if (focused) void refreshBillingState().catch(() => undefined)
+        })
+        .then((un) => {
+          if (cancelled) un()
+          else unlisten = un
+        })
+    })
+    return () => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [billingActive, refreshBillingState])
 
   const onUpgrade = async (plan: PaidPlan) => {
     setErrorMessage(null)
     setBusyAction(plan === "basic" ? "upgrade-basic" : "upgrade-plus")
     try {
-      const successUrl = `${window.location.origin}/settings/billing?checkout=success`
-      const cancelUrl = `${window.location.origin}/settings/billing?checkout=cancel`
-      const data = await createCheckoutSession({
-        plan,
-        success_url: successUrl,
-        cancel_url: cancelUrl,
-      })
+      // Desktop opens Stripe in the OS browser, which can't navigate back to the
+      // tauri:// webview origin — omit the return URLs so the backend defaults
+      // them to the hosted web app. Web keeps its origin-based round-trip.
+      const body = isTauri()
+        ? { plan }
+        : {
+            plan,
+            success_url: `${window.location.origin}/settings/billing?checkout=success`,
+            cancel_url: `${window.location.origin}/settings/billing?checkout=cancel`,
+          }
+      const data = await createCheckoutSession(body)
       if (!data.checkout_url) throw new Error("No checkout url returned")
-      window.location.assign(data.checkout_url)
+      await openExternalUrl(data.checkout_url)
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not create checkout session.")
     } finally {
@@ -125,10 +157,13 @@ export function BillingScreen() {
     setErrorMessage(null)
     setBusyAction("manage")
     try {
-      const returnUrl = `${window.location.origin}/settings/billing`
-      const data = await createPortalSession({ return_url: returnUrl })
+      // Desktop: omit return_url so the backend defaults it to the hosted web
+      // app (the OS browser can't return to the tauri:// origin). Web keeps it.
+      const data = isTauri()
+        ? await createPortalSession()
+        : await createPortalSession({ return_url: `${window.location.origin}/settings/billing` })
       if (!data.portal_url) throw new Error("No portal url returned")
-      window.location.assign(data.portal_url)
+      await openExternalUrl(data.portal_url)
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not open billing portal.")
     } finally {

--- a/webui/src/features/user-settings/screens/billing-screen.tsx
+++ b/webui/src/features/user-settings/screens/billing-screen.tsx
@@ -28,7 +28,7 @@ import {
   type PriceInfo
 } from "@/features/user-settings/api/billing"
 import { getAccessToken } from "@/features/signin/auth-storage"
-import { decodeJwt, resolveBillingPlan } from "@/lib/decode-jwt"
+import { decodeJwt, resolveBillingPlan, type BillingPlan } from "@/lib/decode-jwt"
 import { isTauri, openExternalUrl } from "@/platform"
 import { useAppStore } from "@/store"
 
@@ -63,6 +63,11 @@ export function BillingScreen() {
   const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null)
   const [billingPublicConfig, setBillingPublicConfig] = useState<BillingPublicConfig | null>(null)
   const refreshedAfterReturn = useRef(false)
+  // Desktop only: the plan we held when we sent the user out to Stripe, or null
+  // when no Stripe round-trip is in flight. Gates the focus-refresh so it fires
+  // only on return from checkout/portal — never on unrelated window focus.
+  const pendingReturnPlan = useRef<BillingPlan | null>(null)
+  const refreshing = useRef(false)
 
   const searchParams = useMemo(() => new URLSearchParams(window.location.search), [])
 
@@ -82,14 +87,23 @@ export function BillingScreen() {
   }, [billingActive])
 
   // Re-pull the authoritative plan: refresh the token (its claim is updated by
-  // the Stripe webhook), re-derive the plan, and re-read the summary. Idempotent
-  // (pure reads + a token refresh), so it's safe to call on every focus.
-  const refreshBillingState = useCallback(async () => {
-    await refresh()
-    const token = getAccessToken()
-    if (!token) return
-    setUserPlan(resolveBillingPlan(decodeJwt(token)))
-    setBillingSummary(await getBillingSummary())
+  // the Stripe webhook), re-derive the plan, and re-read the summary. Returns the
+  // resolved plan so callers can detect when the webhook has landed. An in-flight
+  // guard prevents two overlapping runs from racing on the summary write.
+  const refreshBillingState = useCallback(async (): Promise<BillingPlan | null> => {
+    if (refreshing.current) return null
+    refreshing.current = true
+    try {
+      await refresh()
+      const token = getAccessToken()
+      if (!token) return null
+      const plan = resolveBillingPlan(decodeJwt(token))
+      setUserPlan(plan)
+      setBillingSummary(await getBillingSummary())
+      return plan
+    } finally {
+      refreshing.current = false
+    }
   }, [setUserPlan])
 
   // Web: Stripe redirects the tab back to `?checkout=success`; refresh once.
@@ -105,18 +119,37 @@ export function BillingScreen() {
   }, [billingActive, searchParams, refreshBillingState])
 
   // Desktop: Stripe opens in the OS browser, so the `?checkout=success` redirect
-  // never reaches this webview. Refresh whenever the app window regains focus —
-  // i.e. when the user clicks back after finishing in the browser. Also catches
-  // portal-side changes (cancel/resume/switch) that have no success URL.
+  // never reaches this webview. When the app window regains focus AFTER we sent
+  // the user to Stripe (pendingReturnPlan set), re-pull the plan. The webhook may
+  // lag the user's return, so poll a few times until the plan changes, then stop
+  // — bounded so an unchanged plan (e.g. a portal visit with no purchase) can't
+  // loop forever. Gated on the pending flag so ordinary alt-tabbing never
+  // triggers a token refresh + fetch.
   useEffect(() => {
     if (!isTauri() || !billingActive) return
     let unlisten: (() => void) | undefined
     let cancelled = false
+
+    const onReturn = async () => {
+      const basePlan = pendingReturnPlan.current
+      if (basePlan === null) return
+      pendingReturnPlan.current = null
+      try {
+        for (let attempt = 0; attempt < 4 && !cancelled; attempt++) {
+          const plan = await refreshBillingState()
+          if (plan !== null && plan !== basePlan) break
+          await new Promise((r) => setTimeout(r, 1500))
+        }
+      } catch {
+        setErrorMessage("Could not refresh billing plan after checkout.")
+      }
+    }
+
     void import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
       if (cancelled) return
       void getCurrentWindow()
         .onFocusChanged(({ payload: focused }) => {
-          if (focused) void refreshBillingState().catch(() => undefined)
+          if (focused) void onReturn()
         })
         .then((un) => {
           if (cancelled) un()
@@ -145,6 +178,9 @@ export function BillingScreen() {
           }
       const data = await createCheckoutSession(body)
       if (!data.checkout_url) throw new Error("No checkout url returned")
+      // Desktop: arm the focus-refresh so returning from the browser re-pulls
+      // the plan (there's no redirect back into the webview).
+      if (isTauri()) pendingReturnPlan.current = userPlan
       await openExternalUrl(data.checkout_url)
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not create checkout session.")
@@ -159,10 +195,13 @@ export function BillingScreen() {
     try {
       // Desktop: omit return_url so the backend defaults it to the hosted web
       // app (the OS browser can't return to the tauri:// origin). Web keeps it.
+      // `createPortalSession({})` — not `()` — so apiFetch sends a JSON body; the
+      // endpoint requires one (empty `{}` is valid: return_url is optional).
       const data = isTauri()
-        ? await createPortalSession()
+        ? await createPortalSession({})
         : await createPortalSession({ return_url: `${window.location.origin}/settings/billing` })
       if (!data.portal_url) throw new Error("No portal url returned")
+      if (isTauri()) pendingReturnPlan.current = userPlan
       await openExternalUrl(data.portal_url)
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Could not open billing portal.")

--- a/webui/src/platform.ts
+++ b/webui/src/platform.ts
@@ -20,3 +20,19 @@ export const isTauri = (): boolean =>
  */
 export const isWebKitWebview = (): boolean =>
   isTauri() && typeof navigator !== "undefined" && !/Chrome\//.test(navigator.userAgent)
+
+
+/**
+ * Open an external URL. On desktop (Tauri) this hands off to the OS default
+ * browser via the `open_external` Rust command so payment/OAuth-style flows run
+ * in a real browser instead of taking over the webview; on web it stays a normal
+ * same-tab navigation, unchanged from the prior behavior.
+ */
+export const openExternalUrl = async (url: string): Promise<void> => {
+  if (isTauri()) {
+    const { invoke } = await import("@tauri-apps/api/core")
+    await invoke("open_external", { url })
+    return
+  }
+  window.location.assign(url)
+}


### PR DESCRIPTION
## Problem
On the Tauri desktop app, clicking **Upgrade** or **Manage subscription** ran `window.location.assign(stripeUrl)`, which navigates the WKWebView itself — the whole app is replaced by Stripe's page. Embedded webviews are also a poor (and less trusted) host for card entry / 3DS, the same reason desktop Google OAuth already refuses to run in-webview.

## Change
Route both Stripe flows (checkout + portal) through the **OS default browser** on desktop; web behavior is unchanged.

- **`open_external` Rust command** (`src-tauri/src/shell.rs`) — opens an http(s) URL via the `open` crate already used by `oauth.rs`. Scheme-guarded so it can't be repurposed as a general launcher. Registered in `lib.rs`; no new plugin or capability needed.
- **`openExternalUrl` helper** (`src/platform.ts`) — desktop → `invoke("open_external")`; web → the prior `window.location.assign`.
- **Billing screen** — on desktop, omit the origin-based `success_url`/`cancel_url`/`return_url` (the OS browser can't return to the `tauri://` origin) so the backend `_resolve_urls` defaults them to the hosted web app; and refresh the plan on **window focus** (the `?checkout=success` redirect never reaches the desktop webview). The shared refresh is idempotent and also picks up portal-side changes (cancel/resume/switch).

## Why focus-refresh (not a loopback catcher)
The authoritative plan change is webhook → backend → updated JWT claim on `refresh()`; the redirect is only a trigger we can't receive on desktop. Focus-refresh replaces it with a trigger we can observe, with far less machinery than mirroring the OAuth loopback server. If it ever proves too loose, the loopback approach is a localized follow-up.

## Verification
- `npm run check-all` clean (type-check + eslint).
- `cargo build` clean.
- Web: upgrade/manage still redirect the tab; `?checkout=success` return still refreshes. No regression.
- Desktop (manual): Stripe opens in the default browser, app stays put; returning to the window refreshes the plan.

## Files
- `webui/src-tauri/src/shell.rs` (new)
- `webui/src-tauri/src/lib.rs`
- `webui/src/platform.ts`
- `webui/src/features/user-settings/screens/billing-screen.tsx`