### PR TITLE
feat(webui): clarify local-boards link + free-signup tooltips on sign-in CTAs

### DIFF
--- a/webui/src/features/board/screens/boards-home.tsx
+++ b/webui/src/features/board/screens/boards-home.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { ThemedWelcome } from "@/features/agent/components/chat/welcome-message"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { CloudArrowUpIcon } from "@/components/icons"
 import { useAppStore } from "@/store"
 import { isSignedIn } from "@/lib/auth"
@@ -179,9 +180,16 @@ function SyncedSignInCta({ onSignIn }: { onSignIn: () => void }) {
           Sign in to back them up and open them on any device.
         </p>
       </div>
-      <Button variant="secondary" size="sm" onClick={onSignIn}>
-        Sign in
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="secondary" size="sm" onClick={onSignIn}>
+            Sign in
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Signing up is completely free — no credit card required
+        </TooltipContent>
+      </Tooltip>
     </div>
   )
 }

--- a/webui/src/features/desktop/sign-in-cta.tsx
+++ b/webui/src/features/desktop/sign-in-cta.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router"
 import { SidebarMenuButton } from "@/components/ui/sidebar"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { UserProfileIcon } from "@/components/icons"
 
 
@@ -9,14 +10,22 @@ const CTA_CLASS =
 
 /**
  * Signed-out account CTA: sign in to sync & share. The remote server comes from
- * the build-time `VITE_API_URL` — there is no in-app server picker.
+ * the build-time `VITE_API_URL` — there is no in-app server picker. The tooltip
+ * reassures that account creation is free and card-less, to lower sign-up friction.
  */
 export function SignInCta() {
   const navigate = useNavigate()
   return (
-    <SidebarMenuButton className={CTA_CLASS} onClick={() => navigate({ to: "/signin" })}>
-      <UserProfileIcon className="size-4 shrink-0" strokeWidth={2} />
-      <span>Sign in to sync &amp; share</span>
-    </SidebarMenuButton>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <SidebarMenuButton className={CTA_CLASS} onClick={() => navigate({ to: "/signin" })}>
+          <UserProfileIcon className="size-4 shrink-0" strokeWidth={2} />
+          <span>Sign in to sync &amp; share</span>
+        </SidebarMenuButton>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        Signing up is completely free — no credit card required
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/webui/src/features/signin/screens/sign-in.tsx
+++ b/webui/src/features/signin/screens/sign-in.tsx
@@ -309,7 +309,7 @@ export function SigninPage() {
 
             <div className="text-center">
               <Link to="/" className="text-sm text-muted-foreground underline underline-offset-2">
-                ← Back to boards
+                ← Back to local boards
               </Link>
             </div>
           </form>


### PR DESCRIPTION
Two small UI-copy improvements for signed-out users.

## 1. Clarify the sign-in back link
`sign-in.tsx`: **"← Back to boards"** → **"← Back to local boards"**. For a signed-out visitor `/` shows the on-device boards, so the old label was ambiguous.

## 2. Free-signup reassurance tooltip on both sign-in CTAs
Hovering either sign-in CTA now shows: **"Signing up is completely free — no credit card required."** Lowers sign-up friction, and the claim is scoped to *signing up* (not the product), so it stays accurate despite the paid Basic/Plus tiers.

- Dashboard synced-section CTA (`SyncedSignInCta` in `boards-home.tsx`)
- Sidebar footer CTA (`SignInCta` in `sign-in-cta.tsx`)

Deliberately avoids any "private"/"encrypted" claim — those wait until the scope-by-owner authz pass (F3/F4/F7/F8) lands and real encryption exists.

## Checked, not changed
The dashboard `SyncedSignInCta` renders for signed-out users on **both web and desktop** (only gate is `!signedIn`) — it was never standalone-only. Confirmed that's intended; the "Sign in" label stays as-is.

## Verification
`npm run check-all` clean (type-check + eslint).