### PR TITLE
perf(webui): share one mini-app runtime cache entry across themes

### DIFF
--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -153,11 +153,22 @@ export default defineConfig({
         // Runtime-cache the mini-app runtime (excluded from precache above) so it
         // loads offline. StaleWhileRevalidate: instant from cache, refreshed in
         // the background so a redeploy propagates on the next load.
+        //
+        // The iframe src carries `?theme=&mode=` (read by theme-bootstrap.js for
+        // first-paint), but the served bytes are theme-independent — the same
+        // static /mini-app/index.html. `ignoreSearch` matches every theme/mode
+        // variant to ONE cache entry, so the 5.4 MB runtime is downloaded once
+        // and shared instead of a cold fetch per palette; `maxEntries: 1` keeps
+        // that single copy (all variants are byte-identical) from accumulating.
         runtimeCaching: [
           {
             urlPattern: /\/mini-app\//,
             handler: "StaleWhileRevalidate",
-            options: { cacheName: "mini-app-runtime" },
+            options: {
+              cacheName: "mini-app-runtime",
+              matchOptions: { ignoreSearch: true },
+              expiration: { maxEntries: 1 },
+            },
           },
         ],
       },

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -154,20 +154,36 @@ export default defineConfig({
         // loads offline. StaleWhileRevalidate: instant from cache, refreshed in
         // the background so a redeploy propagates on the next load.
         //
-        // The iframe src carries `?theme=&mode=` (read by theme-bootstrap.js for
-        // first-paint), but the served bytes are theme-independent — the same
-        // static /mini-app/index.html. `ignoreSearch` matches every theme/mode
-        // variant to ONE cache entry, so the 5.4 MB runtime is downloaded once
-        // and shared instead of a cold fetch per palette; `maxEntries: 1` keeps
-        // that single copy (all variants are byte-identical) from accumulating.
+        // Two distinct assets live under /mini-app/: the 5.4 MB `index.html` and
+        // the tiny `theme-bootstrap.js` it loads. They MUST use separate caches —
+        // a single cache with `maxEntries: 1` would make them evict each other,
+        // re-downloading the 5.4 MB doc on every load and breaking offline.
         runtimeCaching: [
           {
-            urlPattern: /\/mini-app\//,
+            // The 5.4 MB runtime document. Its src carries `?theme=&mode=` (read
+            // by theme-bootstrap.js for first-paint), but the served bytes are
+            // theme-independent — the same static file. `ignoreSearch` matches
+            // every palette/mode variant to ONE entry (downloaded once, shared,
+            // no cold fetch per theme); `maxEntries: 1` keeps just that single
+            // byte-identical copy. This rule is registered first, so index.html
+            // is handled here and never falls through to the catch-all below.
+            urlPattern: /\/mini-app\/index\.html/,
             handler: "StaleWhileRevalidate",
             options: {
               cacheName: "mini-app-runtime",
               matchOptions: { ignoreSearch: true },
               expiration: { maxEntries: 1 },
+            },
+          },
+          {
+            // Everything else under /mini-app/ (theme-bootstrap.js today, plus any
+            // future sidecar asset) — a separate cache so it can never evict the
+            // runtime document above. Bounded, and offline-safe.
+            urlPattern: /\/mini-app\//,
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "mini-app-assets",
+              expiration: { maxEntries: 16 },
             },
           },
         ],


### PR DESCRIPTION
## Problem
The mini-app iframe `src` bakes in `?theme=<id>&mode=<light|dark>` (read by `theme-bootstrap.js` for correct first-paint). The service worker caches `/mini-app/*` as `StaleWhileRevalidate` keyed on the **full URL including the query**, so each palette/mode became a **separate 5.4 MB cache entry**. First open in any theme = a cold 5.4 MB download with nothing shared.

## Change
`/mini-app/` serves **two** assets — the 5.4 MB `index.html` and the tiny `theme-bootstrap.js` it loads — so they get **separate caches** (a single cache with `maxEntries: 1` would make them evict each other):

- **`/mini-app/index.html`** → cache `mini-app-runtime`, `matchOptions: { ignoreSearch: true }` + `maxEntries: 1`. The bytes are theme-independent, so `ignoreSearch` collapses every `?theme/?mode` variant onto **one** shared entry (downloaded once, no cold fetch per palette); the cap keeps just that byte-identical copy. Registered first, so `index.html` never falls through to the catch-all.
- **`/mini-app/` catch-all** → cache `mini-app-assets`, `maxEntries: 16`. Holds `theme-bootstrap.js` (and any future sidecar) in its own cache so it can't evict the runtime doc. Offline-safe, bounded.

SW-config only (`vite.config.ts`) — no app-code or iframe-lifecycle change; `theme-bootstrap.js` still reads its query param (no first-paint flash); `StaleWhileRevalidate` kept so redeploys propagate.

Verified the emitted `dist/sw.js` registers both routes in order with the right caches (`mini-app-runtime` w/ `ignoreSearch`+`maxEntries:1`; `mini-app-assets` w/ `maxEntries:16`).

## Scope / not included
Fixes the **cold-download-per-theme** cost only. Does **not** address the bigger per-mount cost — each iframe re-parses the full 5.4 MB inlined bundle on (re)mount (e.g. scrolling a node out and back), because `viteSingleFile` inlining defeats the browser's cross-realm JS code cache. Separate, larger follow-up (de-inline → hashed external chunks + precache).

## Verification
- `npm run build` clean; PWA `generateSW` succeeds.
- Confirmed both routes/caches present and correctly ordered in `dist/sw.js`.

## Review
Round-1 `/code-review` caught a genuine bug in the first commit (single rule + `maxEntries: 1` → the two `/mini-app/` assets evicted each other, re-downloading the 5.4 MB every load and breaking offline). Fixed by the two-cache split above.