### PR TITLE
perf(webui): bounded keep-alive for mini-app iframes on scroll

### DIFF
--- a/webui/src/features/board/harness/node-types/mini-app/use-keep-alive.ts
+++ b/webui/src/features/board/harness/node-types/mini-app/use-keep-alive.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react"
+import { create } from "zustand"
+
+
+// Max mini-app iframes kept mounted while off-screen. Comfortably above how many
+// fit on one screen, so the eviction below never tears down a *visible* node
+// (in-view nodes stay mounted regardless — see useMiniAppKeepAlive). It bounds
+// the retained iframes — and their still-running event loops — on boards with
+// many mini-apps.
+const CAP = 8
+
+
+type KeepAliveState = {
+  live: string[]
+  touch: (id: string) => void
+  release: (id: string) => void
+}
+
+
+/**
+ * Module-wide LRU of mounted mini-app iframes (MRU first). `touch` promotes a
+ * node and evicts the least-recently-seen beyond CAP; `release` drops a node
+ * that has been removed from the board entirely.
+ */
+const useKeepAliveStore = create<KeepAliveState>((set) => ({
+  live: [],
+  touch: (id) =>
+    set((s) => {
+      const next = [id, ...s.live.filter((x) => x !== id)]
+      return { live: next.length > CAP ? next.slice(0, CAP) : next }
+    }),
+  release: (id) => set((s) => ({ live: s.live.filter((x) => x !== id) })),
+}))
+
+
+/**
+ * Whether a mini-app node should keep its iframe mounted. True while in view,
+ * and kept true for the most-recently-seen CAP nodes after they scroll off — so
+ * scrolling back re-uses the live iframe instead of re-parsing the ~5 MB runtime.
+ * Because the result is `isInView || isLive`, an in-view node is never unmounted
+ * even if eviction drops it from the live set; only off-screen nodes are torn
+ * down, keeping memory bounded.
+ */
+export function useMiniAppKeepAlive(id: string, isInView: boolean): boolean {
+  const isLive = useKeepAliveStore((s) => s.live.includes(id))
+  const touch = useKeepAliveStore((s) => s.touch)
+  const release = useKeepAliveStore((s) => s.release)
+
+  useEffect(() => {
+    if (isInView) touch(id)
+  }, [isInView, id, touch])
+
+  useEffect(() => () => release(id), [id, release])
+
+  return isInView || isLive
+}

--- a/webui/src/features/board/harness/node-types/mini-app/use-keep-alive.ts
+++ b/webui/src/features/board/harness/node-types/mini-app/use-keep-alive.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { create } from "zustand"
 
 
@@ -38,16 +38,26 @@ const useKeepAliveStore = create<KeepAliveState>((set) => ({
  * and kept true for the most-recently-seen CAP nodes after they scroll off — so
  * scrolling back re-uses the live iframe instead of re-parsing the ~5 MB runtime.
  * Because the result is `isInView || isLive`, an in-view node is never unmounted
- * even if eviction drops it from the live set; only off-screen nodes are torn
- * down, keeping memory bounded.
+ * even if eviction drops it from the live set; only OFF-SCREEN retention is
+ * bounded (in-view nodes always mount — matching the pre-existing behavior).
+ *
+ * Recency is stamped both on view-enter AND on view-exit, so the node the user
+ * just scrolled away from is the most-recently-used (survives eviction longest);
+ * stamping only on enter would age the just-left node toward the tail. A node
+ * that is never observed in view (see `initialInView: false` at the call site)
+ * never enters the set, so initial load doesn't seed it with off-screen nodes.
  */
 export function useMiniAppKeepAlive(id: string, isInView: boolean): boolean {
   const isLive = useKeepAliveStore((s) => s.live.includes(id))
   const touch = useKeepAliveStore((s) => s.touch)
   const release = useKeepAliveStore((s) => s.release)
+  const wasInView = useRef(false)
 
   useEffect(() => {
-    if (isInView) touch(id)
+    if (isInView) wasInView.current = true
+    // Touch on enter (in view now) and on exit (was in view, just left) — but
+    // never for a node that has never been observed in view.
+    if (isInView || wasInView.current) touch(id)
   }, [isInView, id, touch])
 
   useEffect(() => () => release(id), [id, release])

--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -2,9 +2,11 @@
 //
 // Wraps the host-side MiniAppMount (which owns the sandboxed iframe,
 // state hydration, and RPC routing) with the standard canvas chrome:
-// traffic lights for delete/expand, a label caption below the card,
-// off-screen suspension via useIsInView so the iframe doesn't pin the
-// event loop on boards with many mini-apps.
+// traffic lights for delete/expand, a label caption below the card.
+// Iframe lifecycle is a bounded keep-alive (useMiniAppKeepAlive): in-view
+// nodes plus the most-recently-seen CAP off-screen nodes stay mounted, so
+// scrolling back re-uses the live iframe instead of re-parsing the ~5 MB
+// runtime; nodes beyond that (and never-seen ones) show a placeholder.
 //
 // Mirrors the shape of WidgetView in node-types/widget/view.tsx — the
 // canvas chrome conventions live there.
@@ -47,9 +49,10 @@ export interface MiniAppViewProps {
 
 
 /**
- * Canvas view for a mini-app note. Renders the iframe via MiniAppMount
- * when the node is in view; otherwise shows a paused-state placeholder
- * card so the rest of the board stays responsive.
+ * Canvas view for a mini-app note. Renders the iframe via MiniAppMount while the
+ * node should stay mounted (in view, or a recently-seen off-screen node kept
+ * alive by useMiniAppKeepAlive); otherwise shows a paused-state placeholder card
+ * so the rest of the board stays responsive.
  */
 export function MiniAppView({ id }: MiniAppViewProps) {
   const node = useNode(id)
@@ -57,7 +60,10 @@ export function MiniAppView({ id }: MiniAppViewProps) {
   const openNodeSurface = useBoardAppStore((s) => s.openNodeSurface)
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const wrapRef = useRef<HTMLDivElement>(null)
-  const isInView = useIsInView(wrapRef, "200px")
+  // initialInView: false — don't mount every node on first load before the
+  // observer reports which are actually visible (and don't seed the keep-alive
+  // LRU with never-seen nodes).
+  const isInView = useIsInView(wrapRef, "200px", false)
   // Keep recently-seen iframes mounted (bounded LRU) so scrolling a node back
   // into view re-uses the live iframe instead of re-parsing the ~5 MB runtime.
   const shouldMount = useMiniAppKeepAlive(id as unknown as string, isInView)
@@ -80,8 +86,34 @@ export function MiniAppView({ id }: MiniAppViewProps) {
   const pendingHeightRef = useRef<number | null>(null)
   const rafIdRef = useRef<number | null>(null)
   const lastAppliedHRef = useRef<number>(0)
+  const latestWidgetHRef = useRef<number | null>(null)
+  // A kept-alive node can stay mounted off-screen, so gate the store write on
+  // visibility — otherwise an off-screen widget's resize would grow the node
+  // (and broadcast a collab op) with nothing visible to justify it. The latest
+  // reported height is stashed and flushed when the node returns to view.
+  const inViewRef = useRef(isInView)
+  useEffect(() => {
+    inViewRef.current = isInView
+  }, [isInView])
+
+  const applyHeight = useCallback(
+    (widgetH: number) => {
+      const target = Math.min(widgetH + CARD_CHROME_PX, MAX_AUTO_GROW_PX)
+      const current = store.getNode(id)?.h ?? 0
+      // Grow only, and only by a meaningful delta (avoid storms from
+      // sub-pixel oscillation).
+      if (target <= current + 1) return
+      if (target === lastAppliedHRef.current) return
+      lastAppliedHRef.current = target
+      store.updateNode(id, { h: target })
+    },
+    [id, store],
+  )
+
   const onContentHeightChange = useCallback(
     (widgetH: number) => {
+      latestWidgetHRef.current = widgetH
+      if (!inViewRef.current) return
       pendingHeightRef.current = widgetH
       if (rafIdRef.current != null) return
       rafIdRef.current = requestAnimationFrame(() => {
@@ -89,18 +121,16 @@ export function MiniAppView({ id }: MiniAppViewProps) {
         const pending = pendingHeightRef.current
         pendingHeightRef.current = null
         if (pending == null) return
-        const target = Math.min(pending + CARD_CHROME_PX, MAX_AUTO_GROW_PX)
-        const current = store.getNode(id)?.h ?? 0
-        // Grow only, and only by a meaningful delta (avoid storms from
-        // sub-pixel oscillation).
-        if (target <= current + 1) return
-        if (target === lastAppliedHRef.current) return
-        lastAppliedHRef.current = target
-        store.updateNode(id, { h: target })
+        applyHeight(pending)
       })
     },
-    [id, store],
+    [applyHeight],
   )
+
+  // Flush the height reported while off-screen when the node returns to view.
+  useEffect(() => {
+    if (isInView && latestWidgetHRef.current != null) applyHeight(latestWidgetHRef.current)
+  }, [isInView, applyHeight])
 
   useEffect(() => {
     return () => {

--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -26,6 +26,7 @@ import {
   useIsInView,
 } from "../../shared-views"
 import { useBoardAppStore } from "../../store/board-app-store"
+import { useMiniAppKeepAlive } from "./use-keep-alive"
 
 
 // Card chrome (padding + traffic-lights row + title slot). Subtracted
@@ -57,6 +58,9 @@ export function MiniAppView({ id }: MiniAppViewProps) {
   const canEdit = useBoardAppStore((s) => s.canEdit)
   const wrapRef = useRef<HTMLDivElement>(null)
   const isInView = useIsInView(wrapRef, "200px")
+  // Keep recently-seen iframes mounted (bounded LRU) so scrolling a node back
+  // into view re-uses the live iframe instead of re-parsing the ~5 MB runtime.
+  const shouldMount = useMiniAppKeepAlive(id as unknown as string, isInView)
   // Gate iframe interaction on selection so canvas pan/zoom gestures
   // pass cleanly through unselected mini-apps. Without this, the
   // iframe's `pointer-events-auto` captures the pointer the moment
@@ -121,7 +125,7 @@ export function MiniAppView({ id }: MiniAppViewProps) {
         )}
       >
         <div className="relative h-full w-full overflow-hidden rounded-xl border border-border/50 bg-background">
-          {source && isInView ? (
+          {source && shouldMount ? (
             <MiniAppMount
               noteId={id as unknown as string}
               source={source}

--- a/webui/src/features/board/harness/shared-views/use-is-in-view.ts
+++ b/webui/src/features/board/harness/shared-views/use-is-in-view.ts
@@ -5,14 +5,19 @@ import { useEffect, useState, type RefObject } from "react"
  * Returns whether the given element currently intersects the viewport.
  * Backed by IntersectionObserver, so it auto-handles pan/zoom (canvas
  * transforms still update the visual bounding rect) without coupling
- * to canvas-harness camera state. Defaults to `true` until the first
- * observation fires.
+ * to canvas-harness camera state.
+ *
+ * `initialInView` is the value returned until the first observation fires
+ * (default `true`). Pass `false` when a false→true correction is cheaper than
+ * a true→false one — e.g. to avoid mounting every node on initial load before
+ * the observer reports which are actually visible.
  */
 export const useIsInView = (
   ref: RefObject<HTMLElement | null>,
   rootMargin = "0px",
+  initialInView = true,
 ): boolean => {
-  const [inView, setInView] = useState(true)
+  const [inView, setInView] = useState(initialInView)
   useEffect(() => {
     const el = ref.current
     if (!el || typeof IntersectionObserver === "undefined") return


### PR DESCRIPTION
## Problem
Mini-app node views gated the iframe on `useIsInView(…, "200px")` and **unmounted** it once a node scrolled >200 px off-screen. Scrolling back rebuilt the iframe and **re-parsed the ~5 MB runtime every time** — a big contributor to the sluggish feel on boards with several mini-apps.

## Change
A module-wide **bounded LRU** (`use-keep-alive.ts`, cap 8) keeps the most-recently-seen iframes mounted while off-screen, so scrolling a node back into view **re-uses the live iframe** instead of re-parsing. The cap bounds how many iframes (and their still-running event loops) are retained, so many mini-apps don't pile up unbounded — directly answering the "what if there are too many mini-apps" concern.

- `shouldMount = isInView || isLive` → an **in-view node is never unmounted**, even if eviction drops it from the live set; only off-screen nodes are torn down, keeping memory bounded.
- `touch(id)` on view-enter promotes to MRU + evicts the least-recently-seen beyond the cap; `release(id)` on node removal.
- Cap is a single constant, easy to tune.

## Scope
Lifecycle-only change to the canvas mini-app view. Does **not** touch the bundle, fonts, CORS, or the SW. Independent of the SW cache-share PR (#214). Complementary follow-ups discussed but not included: a prefetch warm-up for first-open, and (only if profiling still shows re-parse dominating) externalizing the runtime JS as a classic IIFE for cross-iframe compile-cache reuse — both compatible with keeping non-latin fonts inlined.

## Verification
- `npm run check-all` clean (type-check + eslint).