### PR TITLE
perf(webui): suspend off-screen-but-alive mini-app iframes via content-visibility

### DIFF
--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -154,7 +154,15 @@ export function MiniAppView({ id }: MiniAppViewProps) {
           "absolute inset-0 flex flex-col overflow-hidden rounded-2xl border border-dashed border-border bg-background px-2 pb-2 pt-10",
         )}
       >
-        <div className="relative h-full w-full overflow-hidden rounded-xl border border-border/50 bg-background">
+        <div
+          className="relative h-full w-full overflow-hidden rounded-xl border border-border/50 bg-background"
+          // Kept-alive but off-screen: skip rendering the iframe subtree so the
+          // browser stops painting it and can throttle its rAF, while the iframe
+          // stays mounted (no re-parse). Restores instantly when back in view.
+          // `h-full` is explicit sizing, so `contain: size` doesn't collapse the
+          // box. No-op on webviews without content-visibility (older WebKit).
+          style={{ contentVisibility: shouldMount && !isInView ? "hidden" : undefined }}
+        >
           {source && shouldMount ? (
             <MiniAppMount
               noteId={id as unknown as string}

--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -153,16 +153,15 @@ export function MiniAppView({ id }: MiniAppViewProps) {
         className={cn(
           "absolute inset-0 flex flex-col overflow-hidden rounded-2xl border border-dashed border-border bg-background px-2 pb-2 pt-10",
         )}
+        // Kept-alive but off-screen: skip rendering this whole card subtree
+        // (chrome + iframe) so the browser stops its render/paint work and can
+        // throttle the iframe's rAF, while the iframe stays mounted (no re-parse).
+        // Restores instantly on return. `inset-0` is explicit sizing, so
+        // `contain: size` doesn't collapse the box. No-op on webviews without
+        // content-visibility (older WebKit).
+        style={{ contentVisibility: shouldMount && !isInView ? "hidden" : undefined }}
       >
-        <div
-          className="relative h-full w-full overflow-hidden rounded-xl border border-border/50 bg-background"
-          // Kept-alive but off-screen: skip rendering the iframe subtree so the
-          // browser stops painting it and can throttle its rAF, while the iframe
-          // stays mounted (no re-parse). Restores instantly when back in view.
-          // `h-full` is explicit sizing, so `contain: size` doesn't collapse the
-          // box. No-op on webviews without content-visibility (older WebKit).
-          style={{ contentVisibility: shouldMount && !isInView ? "hidden" : undefined }}
-        >
+        <div className="relative h-full w-full overflow-hidden rounded-xl border border-border/50 bg-background">
           {source && shouldMount ? (
             <MiniAppMount
               noteId={id as unknown as string}


### PR DESCRIPTION
## Context
Keep-alive (#215) keeps the most-recently-seen mini-app iframes mounted while off-screen so scrolling back re-uses them instead of re-parsing the ~5 MB runtime. But those off-screen iframes kept painting and running their rAF.

## Change
Set `content-visibility: hidden` on the iframe container while a node is **alive but out of view** (`shouldMount && !isInView`). The browser then skips rendering that subtree — no paint, and the iframe's rendering-driven work (rAF) is throttled — while the iframe **stays mounted** (no re-parse). It restores instantly when the node scrolls back into view.

- Explicit `h-full`/`w-full` sizing means `contain: size` (implied by `content-visibility`) doesn't collapse the box.
- Progressive enhancement: a no-op on webviews without `content-visibility` (older WebKit / macOS < 15), where behavior is unchanged.
- CSS-only, one element; composes with keep-alive (mounted = no re-parse; hidden = no paint/CPU).

## Verification
- `npm run check-all` clean.