### PR TITLE
perf(webui): prefetch mini-app runtime on idle to warm first open

### DIFF
--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -18,7 +18,7 @@ import { type NodeId } from "@canvas-harness/core"
 import { useCanvasStore, useNode, useSelection } from "@canvas-harness/react"
 import { removeNodeSubtree } from "@/features/board/harness/graph/subtree"
 
-import { MiniAppMount } from "@/features/mini-app"
+import { MiniAppMount, prefetchMiniAppRuntime } from "@/features/mini-app"
 import { cn } from "@/lib/utils"
 
 import type { NoteNodeData } from "../../convert/note-to-node"
@@ -75,6 +75,13 @@ export function MiniAppView({ id }: MiniAppViewProps) {
   // its inline editor (gated on `editing` instead of selection).
   const selection = useSelection()
   const isSelected = selection.includes(id)
+
+  // A mini-app node exists on this board → warm the runtime cache on idle (once
+  // per session) so the first open isn't a cold ~5 MB fetch, even for nodes that
+  // are still below the fold.
+  useEffect(() => {
+    prefetchMiniAppRuntime()
+  }, [])
 
   // rAF-throttled grow-only resize. The widget posts `mini-app:resize`
   // through MiniAppMount on every content-size change; we batch those

--- a/webui/src/features/mini-app/index.ts
+++ b/webui/src/features/mini-app/index.ts
@@ -7,4 +7,5 @@
 
 export { MiniAppMount } from "./mount"
 export type { MiniAppMountProps } from "./mount"
+export { prefetchMiniAppRuntime } from "./runtime-target"
 export { fetchMiniAppState, saveMiniAppState } from "./state-client"

--- a/webui/src/features/mini-app/mount.tsx
+++ b/webui/src/features/mini-app/mount.tsx
@@ -32,6 +32,13 @@ import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
 
 import { createMessageHandler } from "./dispatch"
+import {
+  EXPECTED_ORIGIN,
+  POST_TARGET,
+  RUNTIME_ORIGIN,
+  RUNTIME_PATH,
+  SANDBOX,
+} from "./runtime-target"
 import { fetchMiniAppState, saveMiniAppState } from "./state-client"
 
 
@@ -40,35 +47,6 @@ import { fetchMiniAppState, saveMiniAppState } from "./state-client"
 // cold sucrase compile but short enough that the user doesn't stare
 // at an empty rectangle wondering if anything's happening.
 const HANDSHAKE_TIMEOUT_MS = 5000
-
-
-// Runtime origin resolution priority:
-//   1. window.__APP_CONFIG__.miniAppOrigin  — set by docker-entrypoint.sh
-//      from VITE_MINI_APP_ORIGIN at container start. Lets one image
-//      ship to dev / staging / prod without rebuilding.
-//   2. import.meta.env.VITE_MINI_APP_ORIGIN — build-time fallback for
-//      vite-dev (no entrypoint runs there).
-//   3. "" — empty string makes the broken state obvious in devtools.
-// See mini-app-archi.md §6.1.
-const RUNTIME_ORIGIN =
-  (typeof window !== "undefined" ? window.__APP_CONFIG__?.miniAppOrigin : undefined) ||
-  import.meta.env.VITE_MINI_APP_ORIGIN ||
-  ""
-
-
-// Single-frontend (default): no separate runtime origin configured, so load the
-// self-contained runtime as a same-origin static asset into an OPAQUE-origin
-// iframe (sandbox WITHOUT allow-same-origin) — isolation without a second origin
-// (best practice for untrusted code; see mini-app-archi.md). Cross-origin mode
-// (with Vite HMR) is opt-in by setting VITE_MINI_APP_ORIGIN.
-const SINGLE_FRONTEND = RUNTIME_ORIGIN === ""
-const RUNTIME_PATH = SINGLE_FRONTEND ? "/mini-app/index.html" : `${RUNTIME_ORIGIN}/index.html`
-// postMessage target: an opaque iframe has no addressable origin → "*". The
-// inbound guard (source === contentWindow) is the real boundary either way.
-const POST_TARGET = SINGLE_FRONTEND ? "*" : RUNTIME_ORIGIN
-// Inbound origin to trust: an opaque-sandbox iframe posts with origin "null".
-const EXPECTED_ORIGIN = SINGLE_FRONTEND ? "null" : RUNTIME_ORIGIN
-const SANDBOX = SINGLE_FRONTEND ? "allow-scripts" : "allow-scripts allow-same-origin"
 
 
 // Deployment safeguard: the iframe is sandboxed with `allow-same-origin`

--- a/webui/src/features/mini-app/runtime-target.ts
+++ b/webui/src/features/mini-app/runtime-target.ts
@@ -1,0 +1,59 @@
+// Where the mini-app iframe runtime is loaded from, and how the host talks to
+// it. Kept in a non-component module so both MiniAppMount and the prefetch
+// helper share one resolution (and so the component file stays component-only
+// for react-refresh).
+
+// Runtime origin resolution priority:
+//   1. window.__APP_CONFIG__.miniAppOrigin  — set by docker-entrypoint.sh
+//      from VITE_MINI_APP_ORIGIN at container start. Lets one image
+//      ship to dev / staging / prod without rebuilding.
+//   2. import.meta.env.VITE_MINI_APP_ORIGIN — build-time fallback for
+//      vite-dev (no entrypoint runs there).
+//   3. "" — empty string makes the broken state obvious in devtools.
+// See mini-app-archi.md §6.1.
+export const RUNTIME_ORIGIN =
+  (typeof window !== "undefined" ? window.__APP_CONFIG__?.miniAppOrigin : undefined) ||
+  import.meta.env.VITE_MINI_APP_ORIGIN ||
+  ""
+
+
+// Single-frontend (default): no separate runtime origin configured, so load the
+// self-contained runtime as a same-origin static asset into an OPAQUE-origin
+// iframe (sandbox WITHOUT allow-same-origin) — isolation without a second origin
+// (best practice for untrusted code; see mini-app-archi.md). Cross-origin mode
+// (with Vite HMR) is opt-in by setting VITE_MINI_APP_ORIGIN.
+export const SINGLE_FRONTEND = RUNTIME_ORIGIN === ""
+export const RUNTIME_PATH = SINGLE_FRONTEND ? "/mini-app/index.html" : `${RUNTIME_ORIGIN}/index.html`
+// postMessage target: an opaque iframe has no addressable origin → "*". The
+// inbound guard (source === contentWindow) is the real boundary either way.
+export const POST_TARGET = SINGLE_FRONTEND ? "*" : RUNTIME_ORIGIN
+// Inbound origin to trust: an opaque-sandbox iframe posts with origin "null".
+export const EXPECTED_ORIGIN = SINGLE_FRONTEND ? "null" : RUNTIME_ORIGIN
+export const SANDBOX = SINGLE_FRONTEND ? "allow-scripts" : "allow-scripts allow-same-origin"
+
+
+let runtimePrefetched = false
+
+/**
+ * Warm the browser + service-worker cache for the mini-app runtime once per
+ * session, on idle. The runtime is a single ~5 MB document shared by every
+ * mini-app (theme flows via postMessage; the SW keys it ignoring the query, so
+ * one warmed entry serves every theme). Called when a board's first mini-app
+ * node view mounts, so the first actual open isn't a cold 5 MB fetch. Uses a
+ * low-priority `<link rel="prefetch">` so it never competes with visible work.
+ */
+export function prefetchMiniAppRuntime(): void {
+  if (runtimePrefetched || typeof document === "undefined") return
+  runtimePrefetched = true
+  const warm = (): void => {
+    const link = document.createElement("link")
+    link.rel = "prefetch"
+    link.href = RUNTIME_PATH
+    document.head.appendChild(link)
+  }
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(warm)
+  } else {
+    setTimeout(warm, 1000)
+  }
+}

--- a/webui/src/features/mini-app/runtime-target.ts
+++ b/webui/src/features/mini-app/runtime-target.ts
@@ -36,23 +36,31 @@ let runtimePrefetched = false
 
 /**
  * Warm the browser + service-worker cache for the mini-app runtime once per
- * session, on idle. The runtime is a single ~5 MB document shared by every
- * mini-app (theme flows via postMessage; the SW keys it ignoring the query, so
- * one warmed entry serves every theme). Called when a board's first mini-app
- * node view mounts, so the first actual open isn't a cold 5 MB fetch. Uses a
- * low-priority `<link rel="prefetch">` so it never competes with visible work.
+ * session, on idle, so the first open isn't a cold ~5 MB fetch. The runtime is a
+ * single document shared by every mini-app (theme flows via postMessage; the SW
+ * keys it ignoring the query, so one warmed entry serves every theme).
+ *
+ * Uses `fetch()` — NOT `<link rel="prefetch">`, which WebKit/WKWebView ignore, so
+ * a prefetch link would be a no-op on the desktop build. A real fetch goes
+ * through the service worker and populates the shared runtime cache on every
+ * engine. Only the same-origin single-frontend runtime is SW-cached under
+ * `/mini-app/`; cross-origin mode is served/cached elsewhere, so skip it there.
  */
 export function prefetchMiniAppRuntime(): void {
-  if (runtimePrefetched || typeof document === "undefined") return
+  if (runtimePrefetched || !SINGLE_FRONTEND || typeof window === "undefined") return
   runtimePrefetched = true
   const warm = (): void => {
-    const link = document.createElement("link")
-    link.rel = "prefetch"
-    link.href = RUNTIME_PATH
-    document.head.appendChild(link)
+    // Consume the body so the SW's cache.put clone isn't backpressured by an
+    // unread tee branch; the transient blob is discarded. Offline → non-fatal.
+    void fetch(RUNTIME_PATH)
+      .then((r) => r.blob())
+      .catch(() => {})
   }
-  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(warm)
+  // Pass a `timeout` so it still fires in a backgrounded tab — a plain idle
+  // callback can be deferred indefinitely, which would burn the once-per-session
+  // guard without ever warming.
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(warm, { timeout: 3000 })
   } else {
     setTimeout(warm, 1000)
   }


### PR DESCRIPTION
## Problem
The first time a user opens a mini-app, the ~5 MB runtime is a cold fetch. Everything after is cached (one shared entry, #214), but the first open pays full latency.

## Change
When a board's **first mini-app node view mounts**, warm the browser + service-worker cache once per session, on idle, via a low-priority `<link rel="prefetch">`. So by the time the user actually opens/scrolls to a mini-app, it serves from cache instead of a cold 5 MB download — including for nodes still below the fold.

- Fires on idle (`requestIdleCallback`, `setTimeout` fallback) so it never competes with visible work.
- Once per session (`runtimePrefetched` guard).
- Prefetches the query-less runtime URL; the SW keys `/mini-app/` ignoring the query (#214), so the one warmed entry serves every theme/mode.

## Refactor
Extracted the runtime-target resolution (`RUNTIME_ORIGIN` / `RUNTIME_PATH` / `POST_TARGET` / `EXPECTED_ORIGIN` / `SANDBOX`) from `mount.tsx` into a new non-component module `runtime-target.ts`, so the prefetch helper reuses the same resolution and `mount.tsx` stays component-only (satisfies `react-refresh/only-export-components`). Behavior of those consts is unchanged.

## Verification
- `npm run check-all` clean (type-check + eslint).