### PR TITLE
fix(webui): scope deferred-mount pool per board + purer, flash-free mount latch

### DIFF
--- a/webui/src/features/board/harness/node-types/mini-app/view.tsx
+++ b/webui/src/features/board/harness/node-types/mini-app/view.tsx
@@ -4,9 +4,10 @@
 // state hydration, and RPC routing) with the standard canvas chrome:
 // traffic lights for delete/expand, a label caption below the card.
 // Iframe lifecycle: the iframe boots only when the node is in view AND the board
-// camera is at rest (useBoardCameraAtRest) — panning/scrolling at any speed mounts
-// nothing new, so nodes crossed mid-scroll aren't booted — or immediately if it's
-// kept alive from a recent visit (bounded LRU, useKeepAlive). Once mounted it stays
+// camera is at rest — panning/scrolling at any speed mounts nothing new, so nodes
+// crossed mid-scroll aren't booted — or immediately if it's kept alive from a
+// recent visit (bounded LRU). Both come from useMiniAppMount (createDeferredMount).
+// Once mounted it stays
 // while in view OR retained, so a visible node is never torn down; nodes not yet
 // mounted / beyond the LRU show a placeholder.
 //

--- a/webui/src/features/board/harness/node-types/sheet/view.tsx
+++ b/webui/src/features/board/harness/node-types/sheet/view.tsx
@@ -191,7 +191,8 @@ export function SheetView({ id }: SheetViewProps) {
           ...(honoredBg ? { backgroundColor: honoredBg } : null),
           // Retained but off-screen: skip rendering the (heavy TipTap) subtree so
           // the browser stops its layout/paint work while the editor stays mounted.
-          contentVisibility: shouldMount && !isInView ? "hidden" : undefined,
+          // Never while editing — don't stop rendering the editor being typed in.
+          contentVisibility: shouldMount && !isInView && !editing ? "hidden" : undefined,
         }}
         title={!editing && canEdit ? "Double-click to edit" : undefined}
       >

--- a/webui/src/features/board/harness/shared-views/create-deferred-mount.ts
+++ b/webui/src/features/board/harness/shared-views/create-deferred-mount.ts
@@ -1,6 +1,13 @@
-import { useEffect, useRef, useState, type RefObject } from "react"
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type RefObject,
+} from "react"
 import { useCanvasStore } from "@canvas-harness/react"
-import { create } from "zustand"
+import type { CanvasStore } from "@canvas-harness/core"
 import { useBoardCameraAtRest } from "../canvas/board-camera-motion"
 import { useIsInView } from "./use-is-in-view"
 
@@ -16,12 +23,12 @@ export type DeferredMount = {
 /**
  * Factory for the "defer heavy on-canvas node mounting until the pan settles"
  * behavior shared by heavy node views (mini-app iframes, sheet editors). Each
- * call creates an INDEPENDENT bounded-LRU retention pool, so different node types
- * never evict each other (an iframe shouldn't push out a sheet, and their caps
- * differ). The returned hook:
+ * call creates an INDEPENDENT retention pool (per node type), and the pool is
+ * further scoped per board (per CanvasStore) so two boards overlapping during a
+ * route transition never evict each other's retained nodes. The returned hook:
  *   - mounts a node only when it's in view AND the board camera is at rest — so
- *     panning/scrolling at any speed boots nothing new (the measured jank) — or
- *     immediately if it's kept alive from a recent visit;
+ *     panning/scrolling at any speed boots nothing new — or immediately if it's
+ *     kept alive from a recent visit;
  *   - keeps a mounted node while it's in view OR retained, so a genuinely visible
  *     node is never torn down; it unmounts only once off-screen AND evicted;
  *   - retains the most-recently-active `cap` off-screen nodes (bounded LRU) so
@@ -34,20 +41,33 @@ export function createDeferredMount({
   cap: number
   rootMargin?: string
 }) {
-  type Pool = {
-    live: string[]
-    touch: (id: string) => void
-    release: (id: string) => void
+  // Per-board (per CanvasStore) bounded-LRU pool. `live` is MRU-first; listeners
+  // drive useSyncExternalStore. WeakMap so entries drop with their store.
+  type Pool = { live: string[]; listeners: Set<() => void> }
+  const pools = new WeakMap<CanvasStore, Pool>()
+
+  const getPool = (store: CanvasStore): Pool => {
+    let p = pools.get(store)
+    if (!p) {
+      p = { live: [], listeners: new Set() }
+      pools.set(store, p)
+    }
+    return p
   }
-  const usePool = create<Pool>((set) => ({
-    live: [],
-    touch: (id) =>
-      set((s) => {
-        const next = [id, ...s.live.filter((x) => x !== id)]
-        return { live: next.length > cap ? next.slice(0, cap) : next }
-      }),
-    release: (id) => set((s) => ({ live: s.live.filter((x) => x !== id) })),
-  }))
+
+  const touch = (store: CanvasStore, id: string): void => {
+    const p = getPool(store)
+    const next = [id, ...p.live.filter((x) => x !== id)]
+    p.live = next.length > cap ? next.slice(0, cap) : next
+    for (const l of p.listeners) l()
+  }
+
+  const release = (store: CanvasStore, id: string): void => {
+    const p = getPool(store)
+    if (!p.live.includes(id)) return
+    p.live = p.live.filter((x) => x !== id)
+    for (const l of p.listeners) l()
+  }
 
   return function useDeferredMount(
     id: string,
@@ -58,36 +78,44 @@ export function createDeferredMount({
     // observer reports which are actually visible (and don't seed the LRU).
     const isInView = useIsInView(ref, rootMargin, false)
 
-    const isLive = usePool((s) => s.live.includes(id))
-    const touch = usePool((s) => s.touch)
-    const release = usePool((s) => s.release)
+    const subscribe = useCallback(
+      (cb: () => void) => {
+        const p = getPool(store)
+        p.listeners.add(cb)
+        return () => {
+          p.listeners.delete(cb)
+        }
+      },
+      [store],
+    )
+    const isLive = useSyncExternalStore(subscribe, () => getPool(store).live.includes(id))
 
-    // Only an in-view, not-yet-mounted node needs to react to camera motion — a
-    // mounted or off-screen node ignores it, so a pan doesn't re-render every
-    // heavy view on the board (see useBoardCameraAtRest's `waiting`).
-    const mountedRef = useRef(false)
-    const cameraAtRest = useBoardCameraAtRest(store, isInView && !mountedRef.current)
+    // `everMounted` remembers that the node has been mounted so `shouldMount` can
+    // be derived SYNCHRONOUSLY (no one-frame placeholder flash for already-live /
+    // already-mounted nodes) while still keeping a visible node mounted after
+    // eviction. State (not a ref) so `waiting` stays a pure render value.
+    const [everMounted, setEverMounted] = useState(false)
+    // A node only needs to react to camera motion while it's waiting to boot:
+    // in view, not yet live, not yet mounted. Everyone else reads a constant, so
+    // a pan doesn't re-render the whole board's heavy views.
+    const waiting = isInView && !isLive && !everMounted
+    const cameraAtRest = useBoardCameraAtRest(store, waiting)
     const mountReady = isInView && cameraAtRest
+    const shouldMount = mountReady || isLive || (isInView && everMounted)
 
     const wasActive = useRef(false)
     useEffect(() => {
       if (mountReady) wasActive.current = true
       // Retain the most-recently-active nodes: touch on active-enter and on
       // active-exit (was active, just left); never a node that was never active.
-      if (mountReady || wasActive.current) touch(id)
-    }, [mountReady, id, touch])
-    useEffect(() => () => release(id), [id, release])
+      if (mountReady || wasActive.current) touch(store, id)
+    }, [mountReady, store, id])
+    useEffect(() => () => release(store, id), [store, id])
 
-    const [shouldMount, setShouldMount] = useState(false)
     useEffect(() => {
-      if (mountReady || isLive) {
-        mountedRef.current = true
-        setShouldMount(true)
-      } else if (!isInView && !isLive) {
-        mountedRef.current = false
-        setShouldMount(false)
-      }
-    }, [mountReady, isLive, isInView])
+      if (shouldMount) setEverMounted(true)
+      else if (!isInView && !isLive) setEverMounted(false)
+    }, [shouldMount, isInView, isLive])
 
     return { shouldMount, isInView }
   }


### PR DESCRIPTION
Follow-up to the high-effort review of #219 (findings landed on already-merged code).

## Changes
- **Per-board retention pool (finding 1).** The LRU pool in `createDeferredMount` was a module singleton shared across all boards, unlike the camera-at-rest state which #219 scoped per `CanvasStore`. Two boards overlapping during a route transition could evict each other's retained iframes → re-parse on pan-back. Now the pool is a `WeakMap<CanvasStore, …>`, matching the camera scoping. (Also drops `zustand` here for `useSyncExternalStore`, consistent with `board-camera-motion`.)
- **Pure, synchronous mount decision (findings 2 + 3).** `shouldMount` is now derived during render — `mountReady || isLive || (isInView && everMounted)` — with `everMounted` as real state, replacing the render-read `mountedRef`. This removes an impure ref feeding `useSyncExternalStore`'s `getSnapshot`, and removes the one-frame placeholder flash for already-live / already-mounted nodes (which the old useState+effect latch introduced).
- **Sheet: no content-visibility while editing (finding 4).** `contentVisibility: hidden` no longer applies to an off-screen-but-retained sheet that's actively being edited.
- **Comment fix (finding 5).** Mini-app view header no longer references the removed `useKeepAlive`.

## Verified (from the review, preserved)
The never-unmount-a-visible-node guarantee still holds (`shouldMount` includes `isInView && everMounted`); listeners fire twice per pan, not per frame; `release` prevents pool leaks.

## Verification
- `npm run check-all` clean (type-check + eslint).