### PR TITLE
perf(webui): drop mini-app Tailwind JIT for a build-time safelist

### DIFF
--- a/webui/mini-app-runtime/main.tsx
+++ b/webui/mini-app-runtime/main.tsx
@@ -24,13 +24,12 @@ import "./runtime.css"
 // live in src/fonts.ts. Import them here too or the mini-app falls back to
 // system fonts. viteSingleFile inlines the woff2 into the one-file bundle.
 import "../src/fonts"
-// Tailwind v4's browser build JIT-compiles utility classes at runtime
-// by scanning the live DOM. Critical for mini-apps: the agent's JSX is
-// a string at compile time, so the static @tailwindcss/vite plugin
-// can't see classes like `fill-amber-200` or `bg-sky-50` and they
-// never make it into the compiled CSS. The browser build picks them
-// up the moment React mounts the elements. Side-effect-only import.
-import "@tailwindcss/browser"
+// NOTE: the `@tailwindcss/browser` runtime JIT used to live here — it scanned
+// each iframe's DOM continuously (a per-mini-app CPU cost + WASM in the bundle)
+// solely because the agent's JSX is a runtime string the static build can't see.
+// It's replaced by the build-time safelist in runtime.css (`@source inline(...)`),
+// which force-emits the standard utility surface at compile time. Off-safelist /
+// arbitrary-value classes therefore no longer resolve — see the safelist comment.
 
 
 // Host origin resolution priority:

--- a/webui/mini-app-runtime/runtime.css
+++ b/webui/mini-app-runtime/runtime.css
@@ -40,6 +40,114 @@
 @source inline("font-{handwriting,mono,sans,serif,informal}");
 
 
+/*
+ * Build-time safelist for the STANDARD utility surface the agent may type on raw
+ * elements. Force-emitting these statically is what lets us DROP the
+ * `@tailwindcss/browser` runtime JIT (which scanned every iframe's DOM
+ * continuously — a per-mini-app CPU cost + WASM in the bundle). Tailwind ignores
+ * `@source inline` candidates that aren't real utilities, so over-generating
+ * (incl. v3/v4 name variants) is safe — invalid ones emit nothing. Colors are
+ * intentionally NOT expanded to the full palette: the prompt routes off-palette
+ * color to inline `style`, and semantic tokens + the chart ramp are safelisted
+ * above — keeping this bounded.
+ */
+/* Display / box / position / visibility */
+@source inline("{block,inline-block,inline,flex,inline-flex,grid,inline-grid,table,table-cell,table-row,flow-root,contents,hidden}");
+@source inline("box-{border,content}");
+@source inline("{visible,invisible,collapse}");
+@source inline("{static,relative,absolute,fixed,sticky}");
+@source inline("{isolate,isolation-auto,sr-only,not-sr-only}");
+/* Flexbox + grid */
+@source inline("flex-{row,row-reverse,col,col-reverse,wrap,wrap-reverse,nowrap,1,auto,initial,none}");
+@source inline("{grow,shrink}{,-0}");
+@source inline("order-{1,2,3,4,5,6,7,8,9,10,11,12,first,last,none}");
+@source inline("{items,self}-{start,center,end,baseline,stretch}");
+@source inline("{justify,justify-items,justify-self}-{start,center,end,between,around,evenly,stretch,auto}");
+@source inline("{content,place-content,place-items,place-self}-{start,center,end,between,around,evenly,stretch,baseline}");
+@source inline("grid-cols-{1,2,3,4,5,6,7,8,9,10,11,12,none}");
+@source inline("grid-rows-{1,2,3,4,5,6,none}");
+@source inline("{col,row}-span-{1,2,3,4,5,6,7,8,9,10,11,12,full,auto}");
+@source inline("{col,row}-{start,end}-{1,2,3,4,5,6,7,8,9,10,11,12,13,auto}");
+@source inline("grid-flow-{row,col,dense,row-dense,col-dense}");
+@source inline("columns-{1,2,3,4,5,auto}");
+/* Spacing: gap / padding / margin / space-between */
+@source inline("{gap,gap-x,gap-y}-{0,0.5,1,1.5,2,2.5,3,3.5,4,5,6,7,8,10,12,16,20,24}");
+@source inline("{p,px,py,pt,pb,pl,pr,ps,pe}-{0,0.5,1,1.5,2,2.5,3,3.5,4,5,6,7,8,9,10,11,12,14,16,20,24,28,32}");
+@source inline("{m,mx,my,mt,mb,ml,mr,ms,me}-{0,0.5,1,1.5,2,2.5,3,3.5,4,5,6,7,8,10,12,16,20,24,auto}");
+@source inline("-{m,mx,my,mt,mb,ml,mr}-{0.5,1,1.5,2,3,4,6,8}");
+@source inline("{space-x,space-y}-{0,0.5,1,1.5,2,2.5,3,4,5,6,8}");
+/* Sizing */
+@source inline("{w,h}-{0,px,0.5,1,1.5,2,2.5,3,3.5,4,5,6,7,8,9,10,11,12,14,16,20,24,28,32,36,40,44,48,52,56,60,64,72,80,96,auto,full,screen,svh,dvh,min,max,fit}");
+@source inline("w-{1/2,1/3,2/3,1/4,2/4,3/4,1/5,2/5,3/5,4/5,1/6,5/6,1/12,11/12}");
+@source inline("{min-w,min-h}-{0,full,min,max,fit,screen}");
+@source inline("max-w-{0,none,px,xs,sm,md,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl,full,min,max,fit,prose}");
+@source inline("max-h-{0,px,full,screen,svh,dvh,min,max,fit,32,40,48,56,64,80,96}");
+@source inline("size-{0,1,2,3,4,5,6,7,8,9,10,11,12,14,16,20,24,32,full,min,max,fit}");
+@source inline("aspect-{auto,square,video}");
+/* Typography */
+@source inline("text-{xs,sm,base,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl,8xl,9xl}");
+@source inline("font-{thin,extralight,light,normal,medium,semibold,bold,extrabold,black}");
+@source inline("leading-{none,tight,snug,normal,relaxed,loose,3,4,5,6,7,8,9,10}");
+@source inline("tracking-{tighter,tight,normal,wide,wider,widest}");
+@source inline("text-{left,center,right,justify,start,end}");
+@source inline("{italic,not-italic,underline,overline,line-through,no-underline,uppercase,lowercase,capitalize,normal-case,truncate,text-ellipsis,text-clip,antialiased,subpixel-antialiased}");
+@source inline("align-{baseline,top,middle,bottom,text-top,text-bottom,sub,super}");
+@source inline("whitespace-{normal,nowrap,pre,pre-line,pre-wrap,break-spaces}");
+@source inline("{break-normal,break-words,break-all,break-keep,text-wrap,text-nowrap,text-balance,text-pretty}");
+@source inline("{list-none,list-disc,list-decimal,list-inside,list-outside}");
+@source inline("line-clamp-{1,2,3,4,5,6,none}");
+@source inline("indent-{0,1,2,3,4,8}");
+@source inline("underline-offset-{auto,0,1,2,4,8}");
+@source inline("decoration-{solid,dashed,dotted,double,wavy,none}");
+/* Borders / radius / ring / outline / divide */
+@source inline("rounded{,-none,-xs,-sm,-md,-lg,-xl,-2xl,-3xl,-full}");
+@source inline("rounded-{t,r,b,l,tl,tr,br,bl,s,e,ss,se,es,ee}{,-none,-xs,-sm,-md,-lg,-xl,-2xl,-3xl,-full}");
+@source inline("border{,-0,-2,-4,-8}");
+@source inline("border-{t,r,b,l,x,y,s,e}{,-0,-2,-4,-8}");
+@source inline("border-{solid,dashed,dotted,double,hidden,none}");
+@source inline("{divide-x,divide-y}{,-0,-2,-4,-8}");
+@source inline("divide-{solid,dashed,dotted,none}");
+@source inline("ring{,-0,-1,-2,-4,-8,-inset}");
+@source inline("ring-offset-{0,1,2,4,8}");
+@source inline("outline{,-0,-1,-2,-4}");
+@source inline("outline-{none,dashed,dotted,double,solid}");
+@source inline("outline-offset-{0,1,2,4,8}");
+/* Backgrounds (non-color) / object */
+@source inline("bg-{fixed,local,scroll,clip-border,clip-padding,clip-content,clip-text,cover,contain,center,top,bottom,left,right,repeat,no-repeat,repeat-x,repeat-y}");
+@source inline("{bg-gradient-to,bg-linear-to}-{t,tr,r,br,b,bl,l,tl}");
+@source inline("object-{contain,cover,fill,none,scale-down,center,top,bottom,left,right}");
+/* Overflow / position insets / z */
+@source inline("overflow{,-x,-y}-{auto,hidden,visible,scroll,clip}");
+@source inline("overscroll{,-x,-y}-{auto,contain,none}");
+@source inline("{inset,inset-x,inset-y,top,right,bottom,left,start,end}-{0,0.5,1,2,3,4,6,8,10,12,16,auto,px,full,1/2,1/3,2/3}");
+@source inline("-{top,right,bottom,left}-{1,2,4,8}");
+@source inline("z-{0,10,20,30,40,50,auto}");
+/* Effects: shadow / opacity / blur / blend */
+@source inline("shadow{,-2xs,-xs,-sm,-md,-lg,-xl,-2xl,-inner,-none}");
+@source inline("{,hover:,focus:,group-hover:}opacity-{0,5,10,20,25,30,40,50,60,70,75,80,90,95,100}");
+@source inline("blur{,-none,-xs,-sm,-md,-lg,-xl,-2xl,-3xl}");
+@source inline("backdrop-blur{,-none,-xs,-sm,-md,-lg,-xl}");
+@source inline("mix-blend-{normal,multiply,screen,overlay,darken,lighten}");
+/* Transitions / animation / transforms */
+@source inline("transition{,-none,-all,-colors,-opacity,-shadow,-transform}");
+@source inline("duration-{0,75,100,150,200,300,500,700,1000}");
+@source inline("delay-{0,75,100,150,200,300,500,700,1000}");
+@source inline("ease-{linear,in,out,in-out}");
+@source inline("{animate-none,animate-spin,animate-ping,animate-pulse,animate-bounce}");
+@source inline("transform{,-gpu,-none}");
+@source inline("origin-{center,top,top-right,right,bottom-right,bottom,bottom-left,left,top-left}");
+@source inline("{,hover:,group-hover:}scale{,-x,-y}-{0,50,75,90,95,100,105,110,125,150}");
+@source inline("{,-}rotate-{0,1,2,3,6,12,45,90,180}");
+@source inline("{,-}{translate-x,translate-y}-{0,0.5,1,2,3,4,6,8,px,full,1/2}");
+/* Interactivity / misc */
+@source inline("cursor-{auto,default,pointer,wait,text,move,help,not-allowed,none,progress,grab,grabbing}");
+@source inline("{select-none,select-text,select-all,select-auto}");
+@source inline("pointer-events-{none,auto}");
+@source inline("{resize,resize-none,resize-x,resize-y,appearance-none}");
+@source inline("scroll-{auto,smooth}");
+@source inline("will-change-{auto,scroll,contents,transform}");
+
+
 /* The runtime root element fills the iframe so the host can
    measure its scroll height for auto-resize. */
 html, body {

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "0.3.59",
+  "version": "0.3.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.3.59",
+      "version": "0.3.84",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@canvas-harness/core": "^0.1.27",
@@ -48,7 +48,6 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@streamdown/code": "^1.0.1",
-        "@tailwindcss/browser": "^4.3.0",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.131.27",
@@ -7095,12 +7094,6 @@
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
-    },
-    "node_modules/@tailwindcss/browser": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/browser/-/browser-4.3.0.tgz",
-      "integrity": "sha512-izCuCS1V4c18DH47BbJuAPoCi7LP9gSSanr4k42cL+GN3Km/H3QO3fpMVVPXUBpAatHYgfmQWOmrNJqq+bzAAQ==",
-      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.17",

--- a/webui/package.json
+++ b/webui/package.json
@@ -61,7 +61,6 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@streamdown/code": "^1.0.1",
-    "@tailwindcss/browser": "^4.3.0",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.131.27",


### PR DESCRIPTION
## Problem
Every mini-app iframe imports `@tailwindcss/browser` — Tailwind v4's **runtime JIT**, which MutationObserver-watches the DOM and regenerates CSS on every mount. Profiles pinned it as the dominant **per-iframe CPU** on many-apps-in-view boards, and it ships a WASM engine inside the 5 MB bundle. Its only job: cover utility classes that appear only inside the agent's runtime JSX *string*, which the static build can't see.

## Change
Replace the runtime JIT with a **build-time safelist**. Extended `runtime.css`'s `@source inline(...)` to force-emit the standard utility surface (display, flex/grid, spacing, sizing, typography, borders/radius, effects, transforms, overflow, position, interactivity), so `@tailwindcss/vite` compiles it statically — no runtime engine. Removed the `@tailwindcss/browser` import + dependency.

- **Colors stay bounded** — semantic tokens + chart ramp were already safelisted, and the prompt routes off-palette color to inline `style`; the full palette is deliberately *not* expanded, keeping CSS size in check.
- Tailwind ignores `@source inline` candidates that aren't real utilities, so over-generating (incl. v3/v4 name variants) is safe — invalid ones emit nothing.

## Result (verified against the built `public/mini-app/index.html`)
- **Bundle shrinks** ~5431 KB → ~5235 KB (the WASM engine outweighed the added CSS).
- **No `tailwindcss/browser`** remains (the only `MutationObserver` left is Vite's modulepreload polyfill).
- Safelisted utilities are emitted — spot-checked the example vocabulary (`mb-3`, `max-w-2xl`, `text-3xl`, `rounded-md`, `line-through`, …) and broader ones (`grid-cols-3`, `shadow-lg`, `italic`, `flex-col`, `justify-between`, `overflow-y-auto`).
- No more per-iframe JIT / DOM-scan CPU.

## Residual risk (please test before merge)
There's **no class enforcement** today, so an agent *could* emit an off-safelist or arbitrary-value class (`w-[137px]`) that the JIT used to cover — it now renders unstyled. The prompt already discourages these (bans raw hex/rgb, no arbitrary values in any example), but recommended follow-ups: **tighten the prompt to a closed class list** and add **write-time class validation**. Worth **rendering a few real widgets** (and the prompt's worked examples) in a built mini-app before merging.

## Verification
- `npm run check-all` clean; `npm run build:mini-app` clean.