### PR TITLE
perf(webui): stagger heavy-node mounts via a per-board scheduler

### DIFF
--- a/webui/src/features/board/harness/canvas/board-camera-motion.ts
+++ b/webui/src/features/board/harness/canvas/board-camera-motion.ts
@@ -58,6 +58,12 @@ export function useTrackBoardCameraMotion(store: CanvasStore): void {
 }
 
 
+/** Non-reactive read of camera-at-rest for THIS board (for the mount scheduler). */
+export function isBoardCameraAtRest(store: CanvasStore): boolean {
+  return getEntry(store).atRest
+}
+
+
 /**
  * Whether the given board's camera has been at rest for QUIET_MS. Pass
  * `waiting = false` for views that don't currently need to react (already mounted,
@@ -65,12 +71,6 @@ export function useTrackBoardCameraMotion(store: CanvasStore): void {
  * dense board doesn't re-render them — only in-view, not-yet-mounted views
  * re-render on the atRest transition that actually boots them.
  */
-/** Non-reactive read of camera-at-rest for THIS board (for the mount scheduler). */
-export function isBoardCameraAtRest(store: CanvasStore): boolean {
-  return getEntry(store).atRest
-}
-
-
 export function useBoardCameraAtRest(store: CanvasStore, waiting: boolean): boolean {
   const subscribe = useCallback(
     (cb: () => void) => {

--- a/webui/src/features/board/harness/canvas/board-camera-motion.ts
+++ b/webui/src/features/board/harness/canvas/board-camera-motion.ts
@@ -65,6 +65,12 @@ export function useTrackBoardCameraMotion(store: CanvasStore): void {
  * dense board doesn't re-render them — only in-view, not-yet-mounted views
  * re-render on the atRest transition that actually boots them.
  */
+/** Non-reactive read of camera-at-rest for THIS board (for the mount scheduler). */
+export function isBoardCameraAtRest(store: CanvasStore): boolean {
+  return getEntry(store).atRest
+}
+
+
 export function useBoardCameraAtRest(store: CanvasStore, waiting: boolean): boolean {
   const subscribe = useCallback(
     (cb: () => void) => {

--- a/webui/src/features/board/harness/shared-views/create-deferred-mount.ts
+++ b/webui/src/features/board/harness/shared-views/create-deferred-mount.ts
@@ -9,6 +9,7 @@ import {
 import { useCanvasStore } from "@canvas-harness/react"
 import type { CanvasStore } from "@canvas-harness/core"
 import { useBoardCameraAtRest } from "../canvas/board-camera-motion"
+import { requestMountSlot } from "./mount-scheduler"
 import { useIsInView } from "./use-is-in-view"
 
 
@@ -20,19 +21,33 @@ export type DeferredMount = {
 }
 
 
+/** Distance from the element's center to the viewport center — mount-order priority. */
+function viewportCenterDistance(ref: RefObject<HTMLElement | null>): number {
+  const el = ref.current
+  if (!el || typeof window === "undefined") return Infinity
+  const r = el.getBoundingClientRect()
+  const dx = r.left + r.width / 2 - window.innerWidth / 2
+  const dy = r.top + r.height / 2 - window.innerHeight / 2
+  return Math.hypot(dx, dy)
+}
+
+
 /**
  * Factory for the "defer heavy on-canvas node mounting until the pan settles"
  * behavior shared by heavy node views (mini-app iframes, sheet editors). Each
- * call creates an INDEPENDENT retention pool (per node type), and the pool is
- * further scoped per board (per CanvasStore) so two boards overlapping during a
- * route transition never evict each other's retained nodes. The returned hook:
- *   - mounts a node only when it's in view AND the board camera is at rest — so
- *     panning/scrolling at any speed boots nothing new — or immediately if it's
- *     kept alive from a recent visit;
- *   - keeps a mounted node while it's in view OR retained, so a genuinely visible
+ * call creates an INDEPENDENT retention pool (per node type), scoped per board
+ * (per CanvasStore) so two boards overlapping during a route transition never
+ * evict each other's retained nodes. The returned hook:
+ *   - a FRESH node mounts only after the camera settles, and then only when the
+ *     shared per-board scheduler grants it a slot (~one per frame, nearest
+ *     viewport center first) — so a settle into a region full of heavy nodes
+ *     trickles in instead of freezing the main thread, and a new pan drops the
+ *     un-granted requests instead of fighting them;
+ *   - a RETAINED node (kept alive from a recent visit) mounts instantly, bypassing
+ *     the scheduler;
+ *   - a mounted node stays while it's in view OR retained, so a genuinely visible
  *     node is never torn down; it unmounts only once off-screen AND evicted;
- *   - retains the most-recently-active `cap` off-screen nodes (bounded LRU) so
- *     panning back re-uses the live instance instead of remounting.
+ *   - retains the most-recently-active `cap` off-screen nodes (bounded LRU).
  */
 export function createDeferredMount({
   cap,
@@ -90,32 +105,42 @@ export function createDeferredMount({
     )
     const isLive = useSyncExternalStore(subscribe, () => getPool(store).live.includes(id))
 
-    // `everMounted` remembers that the node has been mounted so `shouldMount` can
-    // be derived SYNCHRONOUSLY (no one-frame placeholder flash for already-live /
-    // already-mounted nodes) while still keeping a visible node mounted after
-    // eviction. State (not a ref) so `waiting` stays a pure render value.
+    // `everMounted` latches on the scheduler grant so a visible node stays mounted
+    // after eviction. Only a FRESH candidate — in view, not retained, not yet
+    // mounted — waits on the camera + scheduler; everyone else reads constants, so
+    // camera motion doesn't re-render the whole board's heavy views.
     const [everMounted, setEverMounted] = useState(false)
-    // A node only needs to react to camera motion while it's waiting to boot:
-    // in view, not yet live, not yet mounted. Everyone else reads a constant, so
-    // a pan doesn't re-render the whole board's heavy views.
-    const waiting = isInView && !isLive && !everMounted
-    const cameraAtRest = useBoardCameraAtRest(store, waiting)
-    const mountReady = isInView && cameraAtRest
-    const shouldMount = mountReady || isLive || (isInView && everMounted)
+    const wantsMount = isInView && !isLive && !everMounted
+    const cameraAtRest = useBoardCameraAtRest(store, wantsMount)
+    const requesting = wantsMount && cameraAtRest
 
+    // Request a mount slot while waiting-at-rest; withdraw on camera move / leaving
+    // view / unmount. Every visible candidate withdrawing on move is exactly how
+    // "drop all waiting jobs" happens — the scheduler queue drains itself.
+    useEffect(() => {
+      if (!requesting) return
+      return requestMountSlot(store, id, viewportCenterDistance(ref), () =>
+        setEverMounted(true),
+      )
+    }, [requesting, store, id, ref])
+
+    const active = isInView && everMounted
+    const shouldMount = isLive || active
+
+    // Retain most-recently-active nodes: touch on active-enter and active-exit
+    // (keyed on `active`, not pool membership, so eviction can't re-add).
     const wasActive = useRef(false)
     useEffect(() => {
-      if (mountReady) wasActive.current = true
-      // Retain the most-recently-active nodes: touch on active-enter and on
-      // active-exit (was active, just left); never a node that was never active.
-      if (mountReady || wasActive.current) touch(store, id)
-    }, [mountReady, store, id])
+      if (active) wasActive.current = true
+      if (active || wasActive.current) touch(store, id)
+    }, [active, store, id])
     useEffect(() => () => release(store, id), [store, id])
 
+    // Fully gone (off-screen AND evicted) → forget it was mounted, so a later
+    // re-entry goes back through the scheduler.
     useEffect(() => {
-      if (shouldMount) setEverMounted(true)
-      else if (!isInView && !isLive) setEverMounted(false)
-    }, [shouldMount, isInView, isLive])
+      if (!isInView && !isLive) setEverMounted(false)
+    }, [isInView, isLive])
 
     return { shouldMount, isInView }
   }

--- a/webui/src/features/board/harness/shared-views/mount-scheduler.ts
+++ b/webui/src/features/board/harness/shared-views/mount-scheduler.ts
@@ -33,14 +33,21 @@ function tick(store: CanvasStore): void {
   if (s.pending.size === 0) return
   // Only admit while the camera is at rest. On motion the requesters withdraw
   // themselves (their `requesting` flips false), draining `pending` — this guard
-  // also covers the sub-frame gap before their effect cleanup runs.
-  if (isBoardCameraAtRest(store) && ++s.frame >= FRAMES_PER_GRANT) {
+  // also covers the sub-frame gap before their effect cleanup runs. Reset the
+  // frame counter while moving so the cascade restarts cleanly on the next settle
+  // (otherwise, with FRAMES_PER_GRANT > 1, the first post-pan grant fires early).
+  if (!isBoardCameraAtRest(store)) {
+    s.frame = 0
+  } else if (++s.frame >= FRAMES_PER_GRANT) {
     s.frame = 0
     // Grant the nearest-to-viewport-center pending request first (center-out).
+    // `bestId === null ||` guarantees a pick even if every priority is Infinity
+    // (null ref) — otherwise that request would never be granted or deleted and
+    // this rAF loop would spin forever, pinning the store.
     let bestId: string | null = null
     let best = Infinity
     for (const [id, r] of s.pending) {
-      if (r.priority < best) {
+      if (bestId === null || r.priority < best) {
         best = r.priority
         bestId = id
       }
@@ -75,5 +82,11 @@ export function requestMountSlot(
   if (s.raf === null) s.raf = requestAnimationFrame(() => tick(store))
   return () => {
     s.pending.delete(id)
+    // Last one out cancels the loop so a drained queue doesn't leave a scheduled
+    // no-op tick (and its store-capturing closure) hanging.
+    if (s.pending.size === 0 && s.raf !== null) {
+      cancelAnimationFrame(s.raf)
+      s.raf = null
+    }
   }
 }

--- a/webui/src/features/board/harness/shared-views/mount-scheduler.ts
+++ b/webui/src/features/board/harness/shared-views/mount-scheduler.ts
@@ -4,8 +4,11 @@ import { isBoardCameraAtRest } from "../canvas/board-camera-motion"
 
 // Grant at most one mount per this many animation frames. Spreads N settle-time
 // mounts into a cascade so no single frame boots them all — the fix for the
-// "settle → freeze → jank if you move again" burst. Higher = gentler/slower.
-const FRAMES_PER_GRANT = 1
+// "settle → freeze → jank if you move again" burst. ~4 frames (~15 mounts/s at
+// 60Hz) leaves idle frames between mounts for smoothness — worth most on the
+// in-process desktop (WKWebView) webview, where a mount runs on the host thread.
+// Higher = gentler/slower.
+const FRAMES_PER_GRANT = 4
 
 
 type Request = { priority: number; grant: () => void }

--- a/webui/src/features/board/harness/shared-views/mount-scheduler.ts
+++ b/webui/src/features/board/harness/shared-views/mount-scheduler.ts
@@ -1,0 +1,79 @@
+import type { CanvasStore } from "@canvas-harness/core"
+import { isBoardCameraAtRest } from "../canvas/board-camera-motion"
+
+
+// Grant at most one mount per this many animation frames. Spreads N settle-time
+// mounts into a cascade so no single frame boots them all — the fix for the
+// "settle → freeze → jank if you move again" burst. Higher = gentler/slower.
+const FRAMES_PER_GRANT = 1
+
+
+type Request = { priority: number; grant: () => void }
+type Scheduler = { pending: Map<string, Request>; raf: number | null; frame: number }
+
+// One scheduler per board (per CanvasStore), SHARED across node types (mini-apps
+// + sheets) so the admission rate is global, not per-type. WeakMap drops with the
+// store.
+const schedulers = new WeakMap<CanvasStore, Scheduler>()
+
+
+function getScheduler(store: CanvasStore): Scheduler {
+  let s = schedulers.get(store)
+  if (!s) {
+    s = { pending: new Map(), raf: null, frame: 0 }
+    schedulers.set(store, s)
+  }
+  return s
+}
+
+
+function tick(store: CanvasStore): void {
+  const s = getScheduler(store)
+  s.raf = null
+  if (s.pending.size === 0) return
+  // Only admit while the camera is at rest. On motion the requesters withdraw
+  // themselves (their `requesting` flips false), draining `pending` — this guard
+  // also covers the sub-frame gap before their effect cleanup runs.
+  if (isBoardCameraAtRest(store) && ++s.frame >= FRAMES_PER_GRANT) {
+    s.frame = 0
+    // Grant the nearest-to-viewport-center pending request first (center-out).
+    let bestId: string | null = null
+    let best = Infinity
+    for (const [id, r] of s.pending) {
+      if (r.priority < best) {
+        best = r.priority
+        bestId = id
+      }
+    }
+    if (bestId !== null) {
+      const r = s.pending.get(bestId)
+      s.pending.delete(bestId)
+      r?.grant()
+    }
+  }
+  if (s.pending.size > 0) s.raf = requestAnimationFrame(() => tick(store))
+}
+
+
+/**
+ * Ask to mount `id` on this board. The scheduler grants ~one request per frame
+ * (nearest viewport center first) while the camera is at rest, so a settle into a
+ * region full of heavy nodes trickles in instead of freezing the main thread.
+ * Returns a withdraw fn — call it when the node no longer wants to mount (camera
+ * moved, node left view, or it unmounted); withdrawing drops the request from the
+ * queue WITHOUT granting it, which is how "drop all waiting jobs on move" works
+ * (every visible candidate withdraws when the camera moves).
+ */
+export function requestMountSlot(
+  store: CanvasStore,
+  id: string,
+  priority: number,
+  grant: () => void,
+): () => void {
+  const s = getScheduler(store)
+  s.pending.set(id, { priority, grant })
+  if (s.raf === null) s.raf = requestAnimationFrame(() => tick(store))
+  return () => {
+    s.pending.delete(id)
+  }
+}


### PR DESCRIPTION
## Problem
The camera-at-rest gate (#219) mounted **every** in-view heavy node the *same tick* the camera settled — a synchronized burst that froze the main thread. And since it all fired at once, **panning again mid-burst** was the reported lag: the pan fought a thread mid-boot, with nothing to cancel.

## Change
A **per-board mount scheduler**, shared across mini-apps + sheets, that:
- admits ~**one mount per animation frame** (`FRAMES_PER_GRANT`), **nearest viewport center first**, **only while the camera is at rest** — so settling into a region full of heavy nodes **trickles in** instead of freezing;
- has each fresh candidate **request a slot** when it settles in view and **withdraw** on camera move / leaving view / unmount. Every visible candidate withdrawing on move is exactly how **"drop all waiting jobs"** works — the queue drains itself; at most the 1–2 already-granted mounts finish, so a new pan never fights a backlog;
- lets **retained (kept-alive) nodes mount instantly**, bypassing the scheduler — revisits aren't cascaded.

`createDeferredMount` is rewired so a fresh mount latches `everMounted` on the **grant** (not immediately on camera-at-rest); retention `touch` is keyed on view-presence so eviction can't re-add. The scheduler is per-`CanvasStore` (WeakMap), matching the camera + pool scoping.

## Behavior
- Settle into N heavy nodes → they cascade in (~1/frame, center-out) instead of one freeze.
- Pan again mid-cascade → all un-granted requests dropped instantly; pan stays smooth.
- Stop again → remaining unmounted nodes re-queue and resume the trickle (already-mounted ones stay).
- Rapid jitter → mounts progress a few per settle; never bursts.

## Tuning
`FRAMES_PER_GRANT` (default 1) is the one knob — raise for a gentler/slower cascade.

## Verification
- `npm run check-all` clean (type-check + eslint).
- Manual: settle onto a many-mini-app region and immediately pan — should no longer freeze; mini-apps cascade in when you hold still.