### PR TITLE
docs(agent): memory and context design and research studies

### DIFF
--- a/docs/plans/agent-context-architecture.md
+++ b/docs/plans/agent-context-architecture.md
@@ -172,7 +172,7 @@ export type BoardSnapshot = {
   truncatedNote?: string                   // "showing 20 of 200 …"
 }
 
-// Pure, no LLM, memoized per (boardId, sceneRevision).
+// Pure, no LLM. Rebuilt per turn (memoization deferred; see open questions).
 export const buildBoardSnapshot = (store: CanvasStore, rootId: string | null, oplogTail): BoardSnapshot
 ```
 
@@ -397,8 +397,8 @@ Deterministic, budget-driven, top-down; stop adding titles when the budget is hi
    entirely if nothing changed.** On a board with no prior session, phrase as `+N this session`.
 6. **Empty board:** a single line — `Empty board — no nodes yet.`
 
-The renderer is a pure function of `(BoardSnapshot, lastSeenSeq)`; it makes **no LLM call** and is
-memoized by scene revision (Part 3 trigger). Titles are truncated per-title to ~40 chars.
+The renderer is a pure function of the `BoardSnapshot`; it makes **no LLM call** and is rebuilt per
+turn (memoization deferred, see Part 3). Titles are truncated per-title to ~40 chars.
 
 ### `buildBoardSnapshot` — the builder (Phase 1 spec, real APIs)
 
@@ -423,41 +423,48 @@ export const readRecentOps = (
   })
 ```
 
-**Field derivation (exact calls / data paths):**
+**Field derivation (exact calls / data paths)** — matches the shipped `board-snapshot.ts`:
 
 - **Scene read:** `store.getAllNodes(): Node[]` — one call. Per node the Dim0 fields live in
   `node.data` (a `NoteNodeData`), *not* the harness built-ins:
-  - **type** = `node.data.noteType ?? "note"` (values: `note` / `folder` / `sheet` / `mini-app` /
-    `code-sandbox` / `widget` / `document` / shape types). Not `node.type` (that's the canvas
-    built-in like `rect`; use `canvasTypeToDim0` only as a fallback).
-  - **title** = `node.data.label` → fallback `firstLine(node.content)` → `"(untitled)"`.
-  - **layer** = `node.data.parentId ?? null` (null = root). A **folder** is a node with
-    `noteType === "folder"`; its `id` is the layer key for its children (children carry
-    `parentId === folder.id`), its `label` is the layer title.
-  - **updatedAt** = `node.data.updatedAt` (tiebreak only; oplog is authoritative for "recent").
-- **counts** = `groupBy(nodes, n => n.data.noteType)` → `Record<type, number>`; total = `nodes.length`.
-- **layers** = group nodes by `parentId`; for each group resolve the folder node's `label` (or
-  `"root"` for `null`), count, and per-layer sampled titles. Sort desc by count; mark
-  `parentId === rootId` as current. (Root always present.)
-- **selection** = `store.getSelection(): NodeId[]` → map each to `store.getNode(id)?.data.label`.
-- **recentChanges** = collapse `recentOps` per node id to a net effect:
-  - `op.type === "node.add"` → `add`, title from `op.node.data.label`.
-  - `op.type === "node.update"` → `edit`, title from the live `store.getNode(id)?.data.label`.
-  - `op.type === "node.delete"` → `delete`, title from the op payload (node is gone from the store).
-  - Edge ops (`edge.*`) are ignored for the snapshot. Net-per-node: an add+edit in the window reads
-    as one `add`; an add+delete cancels out.
-- **empty** = `nodes.length === 0` → `{ counts: {}, … }` → renders the one-line empty form.
+  - **kind** — `node.data.noteType` only distinguishes `"note" | "document"`; the *structural* type
+    (folder / sheet / mini-app / code-sandbox / widget) lives in **`node.data.styleType`** (a
+    `Dim0NodeType`). So: `document` if `noteType === "document"`, else `styleType` when it is one of
+    folder/sheet/mini-app/code-sandbox/widget, else `"note"` (rectangle/ellipse/… all count as
+    notes). **Not `node.type`** (that's the canvas built-in like `rect`).
+  - **title** = `node.data.label?.markdown` (`label` is `RichText`, not a bare string) → fallback
+    `firstLine(node.content)` → `"(untitled)"`, per-title truncated ~40 chars.
+  - **layer** = `node.data.parentId ?? null` (null = root). A **folder** is a node whose
+    `styleType === "folder"`; its `id` is the layer key for its children (children carry
+    `parentId === folder.id`), its `label.markdown` is the layer title.
+- **counts** = group by the derived kind → `Record<kind, number>`; total = `nodes.length`.
+- **layers** = group nodes by `parentId`; resolve each folder's `label.markdown` (or `"root"` for
+  `null`), count, and per-layer sampled titles (selected/recent first). Sort desc by count; mark
+  `parentId === rootId` as current. Orphans (a `parentId` pointing at no existing folder) land at
+  root, not a phantom layer. (Root always present when nodes exist.)
+- **selection** = `store.getSelection(): (NodeId | EdgeId)[]` → filter to node ids (an edge id won't
+  match any node, so it drops out) → each node's title.
+- **recentChanges** = collapse `recentOps` per node id to a net effect. Op types are `node.add` /
+  `node.update` / `node.remove` (**not** `node.delete`):
+  - `node.add` → `add`, title from `op.node.data.label?.markdown`.
+  - `node.update` → `edit`, title from the live `store.getNode(id)?.data.label?.markdown`.
+  - `node.remove` → `delete`, title from `op.node.data.label?.markdown` (the op carries the full
+    node, so the deleted title *is* available).
+  - Edge/group/frame ops are ignored. Net-per-node: add+edit reads as one `add`; add+remove cancels.
+- **empty** = `nodes.length === 0` → the one-line empty form.
 
-**The session cursor (`lastSeenSeq`).** "Since last session" needs a per-board mark. v1: at session
-open, read the board's current max oplog seq (last `oplog` key for `boardId`, or the snapshot/outbox
-`syncedSeq`) and stash it (e.g. `BoardMeta.snapshotSeenSeq` or a tiny per-board record); next open,
-`readRecentOps(…, previousMark)` yields everything since. Fallback when no mark exists: last
-`RECENT_OPS_WINDOW` records (≈50) → phrased `+N this session`.
+**The session cursor.** "Recent changes since you last checked" needs a per-device per-board mark.
+Shipped as a dedicated device-local `snapshot_meta` store (`{ boardId, seenSeq }`) — **not**
+`BoardMeta` (server-authoritative on synced boards) and **not** `sync_meta` (a full-put that would
+clobber a piggybacked field). On each build, recent = ops with `seq > seenSeq`; then `seenSeq`
+advances to the current max. First time on a device: recent = `[]` (adopt the baseline).
 
 **Wiring/perf:** called in `use-local-submit-prompt.ts` at turn start; `getAllNodes()`/`getSelection()`
-are in-memory reads, `readRecentOps` is one indexed IndexedDB range query. Memoize the built snapshot
-by a cheap scene revision (node count + a max-updatedAt, or a store revision counter if the harness
-exposes one) so it recomputes only when the scene actually changed (`SNAPSHOT_DIRTY_DELTA`).
+are in-memory reads, `readRecentOps` is one indexed range query. **Rebuilt once per turn (sub-ms);
+memoization is deliberately *not* implemented** — at once-per-turn frequency a scene-revision memo is
+dead weight (see open questions). (If a memo is ever added for a more frequent in-session refresh,
+note `node.data.updatedAt` is an **ISO string**, so a `max-updatedAt` revision key must not treat it
+as a number.)
 
 ---
 
@@ -473,7 +480,7 @@ Summary (three production modes → three trigger shapes):
 
 | Pillar | Mode | Fires on | Gate (cheap check) | LLM cost |
 |---|---|---|---|---|
-| Board snapshot | compute | turn start (read) | scene changed ≥ `SNAPSHOT_DIRTY_DELTA` since memo | 0 |
+| Board snapshot | compute | turn start (read) | none (rebuilt per turn; memo deferred) | 0 |
 | Board purpose | derive | turn **end** | drift signal true **and** context was read | 1, rare |
 | Conversation context | derive | turn **end** | `turnsSinceRefresh ≥ CONV_CTX_TURNS` OR `tokenGrowth ≥ CONV_CTX_TOKENS` | 1 / N turns |
 | Board / global memory | inline write | **during the turn** | the model's own judgment (WHEN/SKIP prompt) | 0 extra |
@@ -498,9 +505,10 @@ model via `/ai/llm`.
 ## Board snapshot — *compute, on read*
 
 - **Fires on:** every turn, at **turn start**, when the snapshot is assembled into the system prompt.
-- **Gate:** memoized by a cheap scene revision (node count + max `updatedAt`). Recompute only if it
-  moved by ≥ `SNAPSHOT_DIRTY_DELTA` since the last build; otherwise reuse the memo. On session open,
-  always build once.
+- **Gate:** none in v1 — **rebuilt once per turn** (the build is sub-ms). A scene-revision memo
+  (recompute only on a ≥ `SNAPSHOT_DIRTY_DELTA` change; `node.data.updatedAt` is an ISO string, so a
+  `max-updatedAt` key must not be treated as a number) is the *designed* optimization, **deferred**
+  until a more frequent in-session refresh makes it worthwhile (see open questions).
 - **Runs:** `buildBoardSnapshot(store, rootId, recentOps)` + `renderBoardSnapshot` (Part 2 spec).
 - **Cost:** **0 LLM.** In-memory reads + one indexed oplog range query.
 - **Wired at:** `use-local-submit-prompt.ts` turn-start assembly (the `systemWithDocs` seam).
@@ -532,7 +540,7 @@ model via `/ai/llm`.
       nodesTouched.add(nodeIdOf(op))
       if (op.type === "node.add")         charsChanged += sizeOf(op.node)      // label + content
       else if (op.type === "node.update") charsChanged += patchSize(op.patch)  // changed field(s), approx
-      // node.delete: no content in the op payload → counted via nodesTouched only
+      // node.remove: counted as structural churn via nodesTouched (its content mass is not added)
     }
 
   const shouldDerive =
@@ -546,9 +554,9 @@ model via `/ai/llm`.
   covering the slow semantic drift the magnitude heuristics can't see. **Agent mid-turn writes are
   real oplog ops and count** — so set the thresholds above a typical build turn, *or* subtract the
   ops the agent wrote this turn (defers a big build's re-derive to the next turn — cleaner batching;
-  recommended). Notes on the two `node.update` / `node.delete` wrinkles: an update's `patchSize` is
-  an approximation of the true edit delta (over-counts slightly — harmless for a magnitude gate); a
-  delete carries no content, so it only bumps `nodesTouched` — which is exactly why the node-count OR
+  recommended). Notes on the op wrinkles: an update's `patchSize` is an approximation of the true
+  edit delta (over-counts slightly, harmless for a magnitude gate); a `node.remove` carries the full
+  node, but we count it as structural churn (bumps `nodesTouched` only), which is why the node-count OR
   is kept.
 - **Runs:** the extended `describe-board.ts` pass — a single small-model call over the board's
   *current* structure + a content sample (it re-summarizes from state, it does **not** need the
@@ -745,7 +753,7 @@ from the oplog tail; labeled point-in-time. Also exposed as a `get_board_overvie
 + `prompts/index.ts` (new `## BOARD` placeholder); `local/use-local-submit-prompt.ts` (assemble +
 inject at the `systemWithDocs` seam); `engine/tools.ts` + `engine/types.ts` (`get_board_overview`).
 **LoC:** ~250–350. **Risk/notes:** the only subtlety is reading counts/oplog from the canvas-harness
-store API and sampling/capping for large boards; memoize by scene revision. No persistence, no new
+store API and sampling/capping for large boards; rebuilt per turn (memoization deferred). No persistence, no new
 store — lowest-risk first ship.
 
 ## Phase 2 — Reasoning wiring *(Med)*
@@ -835,8 +843,8 @@ drift.
 
 ### Phase 1 — board snapshot
 
-- **`buildBoardSnapshot`:** empty → empty snapshot; flat board → no layers; type breakdown correct;
-  title = `data.label` → first line of `content` → `"(untitled)"`; layer grouping by `parentId`
+- **`buildBoardSnapshot`:** empty → empty snapshot; flat board → no layers; type breakdown by
+  `styleType` correct; title = `data.label?.markdown` → first line of `content` → `"(untitled)"`; layer grouping by `parentId`
   (folder label resolved; `null` = root); current-layer from `rootId`; nested folders; selection
   resolved / empty.
 - **`renderBoardSnapshot`:** budget cap → `(showing X of Y)`; layer cap → `+J more folders …`;
@@ -850,9 +858,8 @@ drift.
 - **Edge cases that bite:** orphan node (dangling `parentId`); stale `rootId`; stale selection id;
   empty folder; titles with newlines/markdown/emoji + multibyte truncation; 1000-node board (budget
   holds, not O(n²)); deleted-node-in-recentChanges.
-- **Memoization/wiring:** identical scene → memo reused; changed ≥ `SNAPSHOT_DIRTY_DELTA` → recompute;
-  `## BOARD` injected at turn start; degenerate omissions (no purpose → snapshot only); the
-  `get_board_overview` tool returns the same text.
+- **Wiring:** `## BOARD` injected at turn start; degenerate omissions (no purpose → snapshot only);
+  the `get_board_overview` tool returns the same text. (Memoization is deferred in v1, so no memo test.)
 
 ### Later phases — highest-value tests (build test-first)
 

--- a/docs/plans/agent-context-architecture.md
+++ b/docs/plans/agent-context-architecture.md
@@ -359,14 +359,14 @@ outline (capped), budgeted title samples, changes summarized by *where*:
 Board snapshot (point-in-time — re-check with tools before acting on it):
 - Title: Acme Analytics — Product Hub
 - 284 nodes: 180 notes, 32 sheets, 18 mini-apps, 40 documents, 14 folders
-- Layers (14 folders; showing 6 by size):
+- Layers (15 total, top 6 by size):
   - / (root, current): 24 nodes — "North star", "Q3 roadmap", "Open questions", …
   - /Research: 68 nodes — "Persona: analyst", [mini-app] "Survey results", …
   - /Specs: 52 nodes — "Dashboards spec", "Alerting spec", "Export v2", …
   - /Design: 41 nodes — "Design system", flow diagrams, …
   - /Meetings: 38 nodes — [sheet] "2026-08 planning", weekly notes, …
   - /Data-model: 22 nodes — schema diagrams, "Events table", …
-  - + 8 more folders (Archive, Legal, GTM, …) — 39 nodes total
+  - + 9 more (Archive, Legal, GTM, …) — 39 nodes total
 - Selection: 1 sheet — "Alerting spec"
 - Recent changes since last session: +5 added (in /Specs, /Meetings), ~3 edited, -1 deleted
 ```
@@ -379,18 +379,22 @@ Deterministic, budget-driven, top-down; stop adding titles when the budget is hi
 
 1. **Header (always):** `Title` line + `N nodes: <breakdown by type, desc>`. If there are no
    folders, append `— all at root (flat)`.
-2. **Structure:**
-   - *Flat board* → skip "Layers"; render a single `Nodes:` line with budgeted titles.
-   - *Foldered board* → `Layers (K folders; showing M by size):` — folders sorted by node count desc,
-     top `MAX_LAYERS` shown; each line `path (count[, current]): sampled titles`; the remainder
-     collapses to `+ J more folders (names…) — P nodes total`. **The current layer is always
-     included**, even if it wouldn't make the top-K.
+2. **Structure:** ("layer" = root or a folder; root is a *layer*, not a folder, so the wording says
+   "layers" to avoid miscounting root as a folder).
+   - *Flat board* → skip "Layers"; render a single `Nodes:` line with budgeted titles. Flat means
+     the sole layer is root **and** we're viewing root; **inside a folder (rootId set) it is not
+     flat** — even an empty folder gets a `count 0` current layer so the outline shows where you are.
+   - *Foldered board* → `Layers (N total[, top M by size]):` — layers sorted by node count desc, top
+     `MAX_LAYERS` shown; each line `path (count[, current]): sampled titles`; the remainder collapses
+     to `+ J more (names…) — P nodes total`. **The current layer is always included**, even if it
+     wouldn't make the top-K (compute the collapsed remainder as *everything not shown* so the
+     displaced top-K layer isn't dropped and the swapped-in current layer isn't double-counted).
 3. **Title sampling & priority:** one global `MAX_TITLES` budget, filled in order —
    (a) current-layer titles → (b) selected titles → (c) recently-changed titles → (d) largest-layer
-   fill — with a `PER_LAYER_TITLES` cap so one folder can't eat the budget. Non-note types carry a
+   fill — with a `PER_LAYER_TITLES` cap so one layer can't eat the budget. Non-note types carry a
    tag (`[sheet]`, `[mini-app]`, `[document]`, `[code]`); notes render bare.
-4. **Selection (always, if any):** `Selection: <k> <type(s)> — "titles"`. The agent's immediate
-   focus, so never dropped for budget.
+4. **Selection (always, if any):** `Selection: <k> selected — "titles"`, **capped at
+   `MAX_SELECTION_TITLES` (+N more)** — a select-all on a big board must not blow the snapshot budget.
 5. **Recent changes:** from the oplog tail since the device's last-seen seq (`snapshot_meta`).
    `+A added (titles/where), ~E edited (titles), -D deleted`; list up to `RECENT_TITLES` titles, else
    summarize by folder (`in /Specs, /Meetings`). **Omit the line entirely if nothing changed.**
@@ -461,6 +465,12 @@ clobber a piggybacked field). At **turn start** the build reads recent = ops wit
 (read-only); the cursor **advances at turn END** (after the agent's writes land), so the agent's own
 edits this turn are *not* reported back next turn as user changes — recent shows only what the USER
 touched between turns. First time on a device: recent = `[]` (the turn-end advance sets the baseline).
+The turn-end advance **must `flush()` the board's debounced writes first** — otherwise the agent's
+creates/arranges (buffered ~50ms) aren't in the oplog yet, the cursor lands below them, and they
+resurface next turn as user changes. **Known limitation:** a compaction folding the oplog between
+turns can drop those folded ops from the *recent-changes delta* (the scene inventory itself is still
+correct); acceptable because between-turn compaction is rare and only the delta, not the state, is
+affected.
 
 **Wiring/perf:** called in `use-local-submit-prompt.ts` at turn start; `getAllNodes()`/`getSelection()`
 are in-memory reads, `readRecentOps` is one indexed range query. **Rebuilt once per turn (sub-ms);

--- a/docs/plans/agent-context-architecture.md
+++ b/docs/plans/agent-context-architecture.md
@@ -1,0 +1,893 @@
+# Dim0 agent context & memory — proposed architecture
+
+The concrete design, synthesizing the research (`inspiration-*`, `synthesis-agent-memory.md`,
+`claude-code-message-representation.md`, `context-update-mechanisms.md`) and the code review
+(`dim0-agent-context-review.md`). Front-end-first, offline-first, fits the existing browser-engine
+seams. Schemas are illustrative TypeScript in the webui house style (no semicolons, named types).
+
+## Goals & principles
+
+1. **Give the agent standing awareness of its board and conversation**, plus durable memory —
+   without a scheduler and without per-turn LLM cost.
+2. **Recompute what's free; gate what costs an LLM call; never run on a wall clock.**
+3. **Represent a turn as an ordered reasoning+tool step list** (Task 2), and re-feed it with real
+   (not lossy) fidelity, bounded by previews.
+4. **Front-end-first:** every store is a repo over the `StorageEngine` port (IndexedDB / rusqlite);
+   the server is an opaque backup target only (per ADR-AGENT-001), never the source of truth.
+5. **Cache-stable injection:** standing context in the system prompt; per-turn recall fenced on the
+   user message; the live snapshot labeled point-in-time.
+
+## Architecture overview
+
+```
+                          ┌───────────────────────── one request ─────────────────────────┐
+ SCOPES        STORES                        ASSEMBLY (per turn)              ENGINE
+ ───────       ──────                        ─────────────────                ──────
+ user   ─────► MemoryRepo (global) ─┐
+                                     ├─► memory INDEX (+ recalled) ─┐
+ board  ─────► MemoryRepo (board) ──┘                              │
+          ┌──► BoardMeta.context (purpose, derived) ──► BOARD ─────┤
+          └──► buildBoardSnapshot(store) [computed] ──► section    ├─► system prompt ─┐
+                                                                   │                  │
+ convo  ─────► LocalChat.context (rolling summary) ──► CONVO ──────┘                  ├─► runAgent
+          └──► transcript (ChatMessage[]) ──► toLlmHistory (Task 2 fidelity) ─────────┤   loop
+                                                                                      │
+ turn   ─────► user prompt + <MessageContext> (selection) ────────────────────────────┘
+```
+
+Read path assembles the four standing pieces + history + the turn's prompt. Write/update path (next
+section) keeps the stores current off natural boundaries.
+
+## The scope / pillar model
+
+Six pillars across three scopes. The load-bearing distinction — the one that decides *how each
+updates* — is **how the pillar is produced**, which comes in three flavors:
+
+- **compute** — deterministic, recomputed from the live scene, **no LLM at all** (snapshot).
+- **derive** — a **dedicated background LLM pass**: a *separate, metered* summarization call, run
+  rarely behind a gate (board purpose, conversation context).
+- **inline write** — the **main agent** writes it via a tool *during its normal turn* — **no extra
+  LLM call of its own**, folded into the answer the model is already producing (board & global
+  memory facts).
+
+So your read is right that **only the snapshot is LLM-free** — but the other four are *not* the same
+kind of LLM work. Two are **background derives** (each spends its own summarization call); two are
+**inline agent writes** (no call of their own — the model just decides to save mid-turn). That split
+is exactly why their triggers differ, and why "all the others are LLM-based" hides the important
+distinction.
+
+| Pillar | Scope | Produced by | LLM call? | Store | Update trigger |
+|---|---|---|---|---|---|
+| **Board snapshot** | board | **compute** | none | — (pure fn over `store`) | recompute on read |
+| **Board purpose** | board | **derive** (bg pass) | 1, rare | `BoardMeta.context` | lazy, drift-gated |
+| **Conversation context** | conversation | **derive** (bg pass) | 1 / N turns | `LocalChat.context` | turn-boundary gate (= compaction ckpt) |
+| **Board memory** | board | **inline write** (agent tool) | none extra | `MemoryRepo` (board) | model judgment mid-turn + overflow prune |
+| **Global memory** | user | **inline write** (agent tool) | none extra | `MemoryRepo` (global) | model judgment mid-turn + overflow prune |
+| **Transcript** | conversation | **capture** (structural) | none | `ChatMessage[]` | every turn (Task 2) |
+
+Compaction (transcript compression) is a seventh update path — it isn't a pillar the agent reads, but
+it rewrites the transcript pillar; it's a **derive** triggered by a token threshold. Covered in Part 3.
+
+---
+
+# Part 1 — Schemas
+
+## 1.1 MemoryRepo (new) — board + global facts
+
+A new repo over the `StorageEngine` port, composed in `local-stores.ts` beside `ChatRepo`/`DocRepo`.
+One object store `memories`.
+
+```ts
+export type MemoryScope = "board" | "global"
+
+// Closed taxonomy (from CC/Hermes). "project" ≈ "what this board is about" at board scope.
+export type MemoryKind = "user" | "feedback" | "project" | "reference"
+
+export type MemoryRecord = {
+  id: string                    // uuid, key path
+  scope: MemoryScope
+  boardId: string | null        // set iff scope === "board"; null for global
+  kind: MemoryKind
+  title: string                 // short slug, unique-ish within (scope, boardId)
+  summary: string               // ONE line — the retrieval key (matches CC frontmatter `description`)
+  body: string                  // the fact; feedback/project carry **Why:** / **How to apply:**
+  hash: string                  // sha/md5 of normalized body — deterministic dedup (mem0)
+  createdAt: number
+  updatedAt: number
+  deleted?: boolean             // soft-delete tombstone — propagates a delete under per-record LWW
+  // sync bookkeeping (see § Sync & persistence in Part 3)
+  dirty: boolean                // local edits not yet pushed
+  serverRev: number | null      // last synced revision (null = never)
+}
+```
+
+Indexes (StorageEngine compound-key ranges, like `DocRepo`'s `by-board`):
+- `by-scope-board` = `[scope, boardId]` → "all board memories for board X" / "all global memories".
+- `by-hash` (optional) → O(1) dedup check.
+
+Caps (Hermes-style, char-based, model-independent), enforced at write:
+- `GLOBAL_MEM_CHARS = 4000`, `BOARD_MEM_CHARS = 4000` (per scope, tune later). Overflow → reject +
+  return current entries → model consolidates & retries (option E).
+
+`MemoryRepo` methods:
+```ts
+class MemoryRepo {
+  add(rec: MemoryRecord): Promise<{ ok: true } | { ok: false; reason: "over_cap"; entries: MemoryRecord[] }>
+  update(id: string, patch: Partial<MemoryRecord>): Promise<void>
+  remove(id: string): Promise<void>
+  list(scope: MemoryScope, boardId: string | null): Promise<MemoryRecord[]>   // for index + recall
+  findByHash(scope, boardId, hash): Promise<MemoryRecord | undefined>          // dedup
+  charCount(scope, boardId): Promise<number>                                   // capacity display
+}
+```
+
+## 1.2 BoardMeta — add board purpose + drift fingerprint
+
+Extend the existing `BoardMeta` (`board/model/index.ts:154`):
+
+```ts
+export type BoardMeta = {
+  // …existing: id, title, kind, syncEngine?, ownerId?, acl?, visibility, thumbnail?, timestamps…
+  context?: string              // NEW — the derived board PURPOSE/summary (semantic)
+  contextDerivedAt?: number     // NEW — wall-clock of the last derive (time-floor drift)
+  contextDeriveSeq?: number     // NEW — the board's local oplog seq at the last derive (change-count drift)
+}
+```
+
+Persisted/read via `BoardRegistry` (add `setBoardContext(id, context, fingerprint)`; reuse the put
+pattern at `board-registry.ts:86`). Note: for **synced** boards `BoardMeta` is server-authoritative
+and not CRDT-synced, so `context` there rides the opaque-backup path or stays device-local.
+
+## 1.3 LocalChat — add conversation context
+
+Extend `LocalChat` (`types/chat.ts:51`):
+
+```ts
+export type LocalChat = {
+  id: string
+  boardId: string
+  label?: string
+  context?: string              // NEW — rolling thread summary (= compaction checkpoint)
+  contextTurnAt?: number        // NEW — turn index at last refresh (gate)
+  contextTokenAt?: number       // NEW — approx token count at last refresh (gate)
+  createdAt: number
+  updatedAt: number
+  deletedAt?: number
+}
+```
+
+Persisted through `ChatRepo.saveTranscript` (`chat-repo.ts:54-76`, add to the `LocalChat` put),
+loaded via `useLocalMessagesStore`.
+
+## 1.4 Board snapshot — a computed value (no schema, no storage)
+
+```ts
+export type BoardSnapshot = {
+  counts: Record<string, number>           // notes, folders, sheets, mini-apps, …
+  layers: { rootId: string | null; title: string; count: number }[]  // folder outline
+  sampledTitles: string[]                  // capped, grouped
+  currentLayer: string | null              // rootId in view
+  selection: string[]                      // selected node ids/titles
+  recentChanges: { id: string; label: string; op: "add" | "edit" | "delete" }[]  // from oplog tail
+  truncatedNote?: string                   // "showing 20 of 200 …"
+}
+
+// Pure, no LLM, memoized per (boardId, sceneRevision).
+export const buildBoardSnapshot = (store: CanvasStore, rootId: string | null, oplogTail): BoardSnapshot
+```
+
+This is the `gitStatus` analogue: recomputed from the live scene, never stored, never "consolidated".
+
+## 1.5 Task 2 — reasoning + higher-fidelity steps
+
+**What already exists (do not rebuild):** the reasoning *model, normalization, and UI are already
+in place* — from the legacy/backend runtime. `ReasoningTextStep { reasoning, message, isSynthesis }`
+(`types/stream.ts:61`) is a first-class step; the backend streams reasoning as a `raw_message` /
+`synthesizer` tool whose content splits across two channels (`build.ts:276`: `stream_reasoning_message`
+chunks → `reasoningBuf`, normal chunks → `messageBuf`); `extractReasoning`/`extractFinalSegment`
+(`utils/stream/text.ts`) parse a `<|F…|>` marker convention; `normalizeReasoningSteps` +
+`reasoning-step-row.tsx`/`tool-step-row.tsx` render it. The **browser engine** (`runAgent` →
+`agent-event-to-step.ts`) reuses this same model + UI but **never fills `reasoning`/`thought` and
+never emits `stream_reasoning_message`** — so for browser turns the slots are empty. Task 2's
+reasoning work is therefore **wiring the browser engine's provider reasoning channel into the
+existing `ReasoningTextStep.reasoning` slot**, not building new infrastructure. Minimal type
+changes to carry it through the engine boundary:
+
+The **only new code** below is the two `reasoning` event variants (the *transport*). The storage
+model (`ReasoningTextStep.reasoning` / `ToolCallStep.thought`, `types/stream.ts`) and the UI already
+exist and are unchanged — these events just carry data into those existing slots:
+
+```ts
+// engine/types.ts — add ONE variant to each existing union (transport only).
+export type LlmStreamEvent =
+  | { kind: "delta"; text: string }
+  | { kind: "reasoning"; text: string }        // +new event → feeds the EXISTING ReasoningTextStep.reasoning
+  | { kind: "tool_start"; name: string; id?: string }
+  | { kind: "final"; turn: LlmTurn }
+
+export type AgentEvent =
+  | { type: "reasoning"; text: string }          // +new event (same destination; objects/UI untouched)
+  | { type: "tool_start"; toolName: string; args: unknown }
+  | { type: "tool_result"; toolName: string; result: unknown }
+  | { type: "assistant_text"; text: string }
+  | { type: "done" }
+```
+
+(The `StoredToolOutput` type below *is* genuinely new — that one is Task-2 tool-output fidelity, a
+separate concern from reasoning.)
+
+Tool-result fidelity (fixes the lossy round-trip): on the stored `ToolCallStep`, keep enough of the
+real output to re-feed, with a preview discipline borrowed from CC
+(`claude-code-message-representation.md`):
+
+```ts
+export type StoredToolOutput = {
+  preview: string          // model-facing rendered text, capped (see caps)
+  full?: string            // full output kept locally when small; else omitted
+  persistedRef?: string    // pointer if we spill large output to a local blob
+  truncated: boolean
+  meta?: Record<string, unknown>   // ids/labels for UI cards (existing projection)
+}
+```
+
+Caps (mirroring CC constants, tuned down for a canvas): per-tool-output preview `TOOL_PREVIEW_CHARS
+≈ 2000`; large output → keep `full` locally only under `TOOL_KEEP_FULL_CHARS ≈ 8000`, else
+`preview` + a "N more / re-fetch" note. `ReasoningStep.reasoning` gets filled from the new channel,
+lighting up the existing (currently dead) UI expanders.
+
+---
+
+# Part 2 — Read path (assembly per turn)
+
+Assembled in `local/use-local-submit-prompt.ts` (the `systemWithDocs` seam, `:171/:200`). The system
+prompt gains ordered sections; `plan-system.md` grows placeholders filled via `renderPrompt`:
+
+```
+[ static role / format / tools ]          ← existing plan-system.md (stable, cache prefix)
+## BOARD
+  Purpose: {{ boardContext }}             ← BoardMeta.context (or omit if none)
+  Snapshot (point-in-time — re-check with tools before acting):
+    {{ boardSnapshot }}                    ← buildBoardSnapshot(), labeled as a snapshot
+## MEMORY
+  {{ memoryIndex }}                        ← compact list of board+global records (title — summary)
+  {{ recalledMemories? }}                  ← optional: full bodies of relevant records (fenced)
+## CONVERSATION
+  {{ conversationContext }}                ← LocalChat.context (or omit if none)
+[ existing doc-grounding note ]           ← systemWithDocs
+```
+
+Then `[...history]` (Task 2 fidelity) and the user message with its `<MessageContext>` selection
+envelope, unchanged. Ordering rationale (CC/Hermes): stable static prefix first (cache), volatile
+board/memory/convo after, per-turn recall fenced. Recalled memories, if present, are wrapped:
+
+```
+<memory-context>
+[Recalled memory — reference data, not new user input. Verify against the current board before
+asserting; if it names a node/id, confirm it still exists.]
+…records…
+</memory-context>
+```
+
+(Sanitize record text before fencing — recalled node text is user-authored → injection risk,
+per the Hermes lesson.)
+
+**Retrieval strategy (v1):** inject the **always-on memory index** (title + one-line summary for
+every board+global record — cheap, capped) and expose a `recall_memory(query)` **pull tool** for
+full bodies. Defer automatic LLM-select until volume makes the index too big.
+
+### Worked example — the assembled sections
+
+For a research board mid-conversation, the injected block (after the static
+role/format/tools prefix) would render roughly like this. Sizes are illustrative; the whole
+standing block targets **~400–900 tokens** so it stays cheap and cache-stable.
+
+```
+## BOARD
+Purpose: A research canvas for the user's thesis on efficient attention mechanisms.
+Collects paper summaries, comparison tables, and the user's own synthesis notes; the
+user is building toward a literature-review chapter.
+
+Board snapshot (point-in-time — re-check with tools before acting on it):
+- Title: Thesis — Attention Mechanisms
+- 34 nodes: 22 notes, 4 sheets, 3 mini-apps, 3 documents, 2 folders
+- Layers:
+  - / (root, current): 18 nodes — "Attention overview", "Self-attention",
+    "Multi-head attention", "KV cache", … (showing 4 of 18)
+  - /Papers: 9 nodes — "Vaswani 2017", "FlashAttention", "GQA", …
+  - /Benchmarks: 5 nodes — 2 comparison mini-apps + 3 notes
+- Selection: 2 notes — "Self-attention", "Multi-head attention"
+- Recent changes since last session: +3 added ("FlashAttention-3", "Sliding window",
+  "GQA note"), ~1 edited ("Self-attention")
+
+## MEMORY
+Board memory (312 / 4000 chars):
+- [project] efficiency-focus — the lit-review chapter prioritizes the efficiency angle
+  over raw accuracy.
+- [feedback] dense-tables — user prefers dense comparison tables over prose for anything
+  comparative.
+User memory (188 / 4000 chars):
+- [user] ml-grad-student — ML grad student, comfortable with transformer internals; pitch
+  explanations at that level.
+- [feedback] no-auto-summaries — don't auto-create summary notes unless asked. Why: user
+  found them redundant.
+
+## CONVERSATION
+Comparing efficient-attention variants (FlashAttention, GQA, sliding-window) for the
+"efficiency" section. Built a comparison mini-app table of 4 variants (memory / speed /
+quality tradeoffs); user then asked to add MQA. Decided to sort the table by memory
+footprint. Open: user wants a short synthesis of when to use each — not yet written.
+```
+
+Notes on the shape:
+- **Board purpose** is one derived paragraph (`BoardMeta.context`) — stable across the session.
+- **Snapshot** is deterministic (`BoardSnapshot` rendered): counts, the folder-layer outline with
+  sampled + capped titles, selection, and the high-signal **recent-changes** line from the oplog —
+  all recomputed, no LLM. The "(showing 4 of 18)" is the `truncatedNote` in action.
+- **Memory** is the always-on index — one line per record (`[kind] title — summary`) with the
+  capacity readout (Hermes-style); full bodies come via `recall_memory`. If retrieval surfaced
+  relevant bodies, they'd appear below, fenced in `<memory-context>`.
+- **Conversation context** is the rolling thread summary (`LocalChat.context`) — the same artifact
+  that becomes the compaction checkpoint. Note it captures *decisions* ("sort by memory footprint")
+  and the *open thread* ("not yet written"), not a transcript.
+
+A brand-new board/thread simply omits the sections it has nothing for: no purpose yet (only the
+snapshot), empty memory (section dropped), no conversation context on turn 1.
+
+### More snapshot archetypes
+
+The snapshot must read well from a 6-node scratch board to a 300-node multi-folder project. Two more
+`## BOARD` renders (purpose/memory/conversation omitted for focus):
+
+**Sparse brainstorm — small, flat, early.** Everything fits, so list it all; no "Layers" heading:
+
+```
+## BOARD
+Board snapshot (point-in-time — re-check with tools before acting on it):
+- Title: Untitled board
+- 7 nodes: 6 notes, 1 mini-app — all at root (flat)
+- Nodes: "App idea: plant tracker", "Who's it for?", "MVP features",
+  "Watering reminders", "Monetization?", [mini-app] "Feature priority chart"
+- Selection: none
+- Recent changes: +2 this session ("Monetization?", "Feature priority chart")
+```
+
+**Large multi-folder project — hundreds of nodes, deep structure.** Counts + a size-ranked folder
+outline (capped), budgeted title samples, changes summarized by *where*:
+
+```
+## BOARD
+Board snapshot (point-in-time — re-check with tools before acting on it):
+- Title: Acme Analytics — Product Hub
+- 284 nodes: 180 notes, 32 sheets, 18 mini-apps, 40 documents, 14 folders
+- Layers (14 folders; showing 6 by size):
+  - / (root, current): 24 nodes — "North star", "Q3 roadmap", "Open questions", …
+  - /Research: 68 nodes — "Persona: analyst", [mini-app] "Survey results", …
+  - /Specs: 52 nodes — "Dashboards spec", "Alerting spec", "Export v2", …
+  - /Design: 41 nodes — "Design system", flow diagrams, …
+  - /Meetings: 38 nodes — [sheet] "2026-08 planning", weekly notes, …
+  - /Data-model: 22 nodes — schema diagrams, "Events table", …
+  - + 8 more folders (Archive, Legal, GTM, …) — 39 nodes total
+- Selection: 1 sheet — "Alerting spec"
+- Recent changes since last session: +5 added (in /Specs, /Meetings), ~3 edited, -1 deleted
+```
+
+### `BoardSnapshot` → text: rendering rules (Phase 1 spec)
+
+Deterministic, budget-driven, top-down; stop adding titles when the budget is hit and emit
+`(showing X of Y)`. Proposed constants (tune with telemetry): `SNAPSHOT_MAX_TOKENS ≈ 350`,
+`MAX_LAYERS ≈ 6`, `MAX_TITLES ≈ 16` (global), `PER_LAYER_TITLES ≈ 4`, `RECENT_TITLES ≈ 5`.
+
+1. **Header (always):** `Title` line + `N nodes: <breakdown by type, desc>`. If there are no
+   folders, append `— all at root (flat)`.
+2. **Structure:**
+   - *Flat board* → skip "Layers"; render a single `Nodes:` line with budgeted titles.
+   - *Foldered board* → `Layers (K folders; showing M by size):` — folders sorted by node count desc,
+     top `MAX_LAYERS` shown; each line `path (count[, current]): sampled titles`; the remainder
+     collapses to `+ J more folders (names…) — P nodes total`. **The current layer is always
+     included**, even if it wouldn't make the top-K.
+3. **Title sampling & priority:** one global `MAX_TITLES` budget, filled in order —
+   (a) current-layer titles → (b) selected titles → (c) recently-changed titles → (d) largest-layer
+   fill — with a `PER_LAYER_TITLES` cap so one folder can't eat the budget. Non-note types carry a
+   tag (`[sheet]`, `[mini-app]`, `[document]`, `[code]`); notes render bare.
+4. **Selection (always, if any):** `Selection: <k> <type(s)> — "titles"`. The agent's immediate
+   focus, so never dropped for budget.
+5. **Recent changes:** from the oplog tail since the last session's last-seen seq (fallback: last
+   `RECENT_OPS_WINDOW` ops). `+A added (titles/where), ~E edited (titles), -D deleted`; list up to
+   `RECENT_TITLES` titles, else summarize by folder (`in /Specs, /Meetings`). **Omit the line
+   entirely if nothing changed.** On a board with no prior session, phrase as `+N this session`.
+6. **Empty board:** a single line — `Empty board — no nodes yet.`
+
+The renderer is a pure function of `(BoardSnapshot, lastSeenSeq)`; it makes **no LLM call** and is
+memoized by scene revision (Part 3 trigger). Titles are truncated per-title to ~40 chars.
+
+### `buildBoardSnapshot` — the builder (Phase 1 spec, real APIs)
+
+Verified against the actual `@canvas-harness/core` store surface and the local oplog. Split into a
+pure builder over the live scene + an async oplog read for recent-changes, so the builder stays
+sync/testable:
+
+```ts
+// pure — reads the live scene synchronously from the store
+export const buildBoardSnapshot = (
+  store: CanvasStore,
+  rootId: string | null,        // ctx.rootId — the projected folder layer
+  recentOps: OplogRecord[],     // pre-read tail (see readRecentOps)
+): BoardSnapshot => { … }
+
+// async — reads the local oplog tail past the session's cursor
+export const readRecentOps = (
+  engine: StorageEngine, boardId: string, lastSeenSeq: number,
+): Promise<OplogRecord[]> =>
+  engine.list<OplogRecord>("oplog", {
+    range: { lower: [boardId, lastSeenSeq], upper: [boardId, Number.MAX_SAFE_INTEGER], lowerOpen: true },
+  })
+```
+
+**Field derivation (exact calls / data paths):**
+
+- **Scene read:** `store.getAllNodes(): Node[]` — one call. Per node the Dim0 fields live in
+  `node.data` (a `NoteNodeData`), *not* the harness built-ins:
+  - **type** = `node.data.noteType ?? "note"` (values: `note` / `folder` / `sheet` / `mini-app` /
+    `code-sandbox` / `widget` / `document` / shape types). Not `node.type` (that's the canvas
+    built-in like `rect`; use `canvasTypeToDim0` only as a fallback).
+  - **title** = `node.data.label` → fallback `firstLine(node.content)` → `"(untitled)"`.
+  - **layer** = `node.data.parentId ?? null` (null = root). A **folder** is a node with
+    `noteType === "folder"`; its `id` is the layer key for its children (children carry
+    `parentId === folder.id`), its `label` is the layer title.
+  - **updatedAt** = `node.data.updatedAt` (tiebreak only; oplog is authoritative for "recent").
+- **counts** = `groupBy(nodes, n => n.data.noteType)` → `Record<type, number>`; total = `nodes.length`.
+- **layers** = group nodes by `parentId`; for each group resolve the folder node's `label` (or
+  `"root"` for `null`), count, and per-layer sampled titles. Sort desc by count; mark
+  `parentId === rootId` as current. (Root always present.)
+- **selection** = `store.getSelection(): NodeId[]` → map each to `store.getNode(id)?.data.label`.
+- **recentChanges** = collapse `recentOps` per node id to a net effect:
+  - `op.type === "node.add"` → `add`, title from `op.node.data.label`.
+  - `op.type === "node.update"` → `edit`, title from the live `store.getNode(id)?.data.label`.
+  - `op.type === "node.delete"` → `delete`, title from the op payload (node is gone from the store).
+  - Edge ops (`edge.*`) are ignored for the snapshot. Net-per-node: an add+edit in the window reads
+    as one `add`; an add+delete cancels out.
+- **empty** = `nodes.length === 0` → `{ counts: {}, … }` → renders the one-line empty form.
+
+**The session cursor (`lastSeenSeq`).** "Since last session" needs a per-board mark. v1: at session
+open, read the board's current max oplog seq (last `oplog` key for `boardId`, or the snapshot/outbox
+`syncedSeq`) and stash it (e.g. `BoardMeta.snapshotSeenSeq` or a tiny per-board record); next open,
+`readRecentOps(…, previousMark)` yields everything since. Fallback when no mark exists: last
+`RECENT_OPS_WINDOW` records (≈50) → phrased `+N this session`.
+
+**Wiring/perf:** called in `use-local-submit-prompt.ts` at turn start; `getAllNodes()`/`getSelection()`
+are in-memory reads, `readRecentOps` is one indexed IndexedDB range query. Memoize the built snapshot
+by a cheap scene revision (node count + a max-updatedAt, or a store revision counter if the harness
+exposes one) so it recomputes only when the scene actually changed (`SNAPSHOT_DIRTY_DELTA`).
+
+---
+
+# Part 3 — Write / update path (triggers)
+
+Per `context-update-mechanisms.md` — **no scheduler**; every update hangs off a natural boundary
+(turn start, turn end, read) or a token threshold. Two things happen on the one submit path
+(`use-local-submit-prompt.ts`): **turn start** = read + inject the pillars; **turn end** (after the
+`done` event) = fire the gated background work. Below, each pillar's trigger is spelled out as
+*Fires on → Gate → Runs → Cost → Wired at*.
+
+Summary (three production modes → three trigger shapes):
+
+| Pillar | Mode | Fires on | Gate (cheap check) | LLM cost |
+|---|---|---|---|---|
+| Board snapshot | compute | turn start (read) | scene changed ≥ `SNAPSHOT_DIRTY_DELTA` since memo | 0 |
+| Board purpose | derive | turn **end** | drift signal true **and** context was read | 1, rare |
+| Conversation context | derive | turn **end** | `turnsSinceRefresh ≥ CONV_CTX_TURNS` OR `tokenGrowth ≥ CONV_CTX_TOKENS` | 1 / N turns |
+| Board / global memory | inline write | **during the turn** | the model's own judgment (WHEN/SKIP prompt) | 0 extra |
+| Compaction | derive | turn start (read) | est. prompt tokens ≥ `COMPACT_PCT × window` | rare |
+
+**Blocking vs async (verified against the CC leak).** In CC every LLM derive/extraction is
+**fire-and-forget** — `void executePostSamplingHooks` (session memory), `void executeExtractMemories`,
+`void executeAutoDream` — while compaction is `await`ed in the turn loop (`await deps.autocompact`).
+We follow the same split: **the two turn-end derives (board purpose, conversation context) run
+async/fire-and-forget after `done`** — the user never waits on them, and if a refresh is mid-flight or
+fails, the next turn simply uses the last value. **Only compaction sits on the blocking turn-start
+path** — and even it avoids the inline summarize in the common case (see below). (JS is
+single-threaded, so "blocking" = *`await`ed in the turn loop* → user waits, vs *`void`ed* → runs
+concurrently on the event loop.)
+
+Starting constants (tune with telemetry): `SNAPSHOT_DIRTY_DELTA=3`, `BOARD_DRIFT_CHARS≈4000`
+(≈1k tokens, primary), `BOARD_DRIFT_NODES=15` (OR fallback), `BOARD_DRIFT_DAYS=7`, `CONV_CTX_TURNS=4`,
+`CONV_CTX_TOKENS≈4000`, `COMPACT_PCT≈0.75`, `CTX_WAIT_MS≈5000` (bounded compaction wait for an
+in-flight refresh), memory overflow retries ≤3/turn. Every **derive** call uses the **cheap/fast**
+model via `/ai/llm`.
+
+## Board snapshot — *compute, on read*
+
+- **Fires on:** every turn, at **turn start**, when the snapshot is assembled into the system prompt.
+- **Gate:** memoized by a cheap scene revision (node count + max `updatedAt`). Recompute only if it
+  moved by ≥ `SNAPSHOT_DIRTY_DELTA` since the last build; otherwise reuse the memo. On session open,
+  always build once.
+- **Runs:** `buildBoardSnapshot(store, rootId, recentOps)` + `renderBoardSnapshot` (Part 2 spec).
+- **Cost:** **0 LLM.** In-memory reads + one indexed oplog range query.
+- **Wired at:** `use-local-submit-prompt.ts` turn-start assembly (the `systemWithDocs` seam).
+- **Why no "update" trigger:** it's recomputed, never stored — node adds are self-healing (there is
+  nothing to invalidate). This is the whole reason the snapshot dodges the trigger problem.
+
+## Board purpose — *derive, lazy on drift + read*
+
+- **Fires on:** **turn end** (fire-and-forget after `done`), *only if the purpose was actually
+  needed this turn* (i.e. the board is being used) — so an untouched board never re-derives.
+- **Gate — the drift signal (deterministic, no LLM):** a **magnitude-of-change heuristic**, not a
+  semantic detector — the LLM does the semantics; the gate only decides *when it's worth re-looking*.
+  It reuses the snapshot's oplog reader (`readRecentOps`) to count *real* changes since the last
+  derive:
+
+  Primary metric is **content mass (chars)** — a better proxy than node cardinality for a *content*
+  summary (a 10k-word sheet shifts the board's substance far more than a one-word note, yet
+  node-count scores them equally). It also **unifies with the conversation-context gate**, which is
+  already token-growth-based. Node-count is kept as an **OR fallback** because it cleanly covers
+  deletes + structural churn that char-counting can't see. One pass over the ops computes both:
+
+  ```ts
+  const recentOps = await readRecentOps(engine, boardId, meta.contextDeriveSeq ?? 0)
+  let charsChanged = 0                          // content mass added/edited (primary)
+  const nodesTouched = new Set<string>()        // distinct nodes touched (fallback; covers deletes)
+  for (const rec of recentOps)
+    for (const op of rec.batch.ops) {
+      if (!op.type.startsWith("node.")) continue
+      nodesTouched.add(nodeIdOf(op))
+      if (op.type === "node.add")         charsChanged += sizeOf(op.node)      // label + content
+      else if (op.type === "node.update") charsChanged += patchSize(op.patch)  // changed field(s), approx
+      // node.delete: no content in the op payload → counted via nodesTouched only
+    }
+
+  const shouldDerive =
+       !meta.context                                                   // never derived / empty
+    || charsChanged      >= BOARD_DRIFT_CHARS                          // enough content mass changed (≈ /4 tokens)
+    || nodesTouched.size >= BOARD_DRIFT_NODES                          // OR structural churn / deletes
+    || (Date.now() - (meta.contextDerivedAt ?? 0)) >= BOARD_DRIFT_DAYS // OR stale by time
+  ```
+
+  The **time floor** (`BOARD_DRIFT_DAYS`) guarantees an eventual refresh even under both thresholds,
+  covering the slow semantic drift the magnitude heuristics can't see. **Agent mid-turn writes are
+  real oplog ops and count** — so set the thresholds above a typical build turn, *or* subtract the
+  ops the agent wrote this turn (defers a big build's re-derive to the next turn — cleaner batching;
+  recommended). Notes on the two `node.update` / `node.delete` wrinkles: an update's `patchSize` is
+  an approximation of the true edit delta (over-counts slightly — harmless for a magnitude gate); a
+  delete carries no content, so it only bumps `nodesTouched` — which is exactly why the node-count OR
+  is kept.
+- **Runs:** the extended `describe-board.ts` pass — a single small-model call over the board's
+  *current* structure + a content sample (it re-summarizes from state, it does **not** need the
+  diff) → a 1–2 sentence purpose. On success: write `BoardMeta.context`, stamp `contextDerivedAt =
+  now` and `contextDeriveSeq = current max oplog seq` (resets the drift baseline).
+- **Caveats:** (1) the oplog seq is **per-device** — fine for device-local board context (open Q#4);
+  a synced/cross-device purpose would need a `serverSeq`-based mark or a per-device recompute.
+  (2) magnitude ≠ semantics: the gate may re-derive when the purpose text barely changes (false
+  positive — cheap, harmless) or miss a tiny semantic pivot (false negative — caught by the time
+  floor). Acceptable because the derive is cheap and rare.
+- **Cost:** 1 cheap call, **rarely** (batches many sessions of drift into one derive).
+- **Wired at:** `use-local-submit-prompt.ts` turn-end (beside the existing `maybeAutoLabelBoard`).
+
+## Conversation context — *derive, turn-boundary gated*
+
+- **Fires on:** **turn end** (fire-and-forget after `done`).
+- **Gate:** run iff since the last refresh **`turnsSinceRefresh ≥ CONV_CTX_TURNS`** OR
+  **`tokenGrowth ≥ CONV_CTX_TOKENS`** (the token gate is the CC session-memory rule — token growth is
+  always sufficient; the turn count is a secondary floor). Stamped by `LocalChat.contextTurnAt` /
+  `contextTokenAt`.
+- **Runs:** **async, fire-and-forget after `done`** (never blocks the reply) — a small-model call
+  that folds the recent turns into the running `LocalChat.context` summary (rolling, not
+  from-scratch each time). `LocalChat.context` is a **persistent, progressively-updated artifact**:
+  a failed or mid-flight refresh leaves the *last good* value in place (never an empty checkpoint).
+  **Its output doubles as the compaction checkpoint** (see below), so it is never computed twice.
+- **Cost:** ~1 cheap call per `CONV_CTX_TURNS` turns.
+- **Wired at:** `use-local-submit-prompt.ts` turn-end.
+
+## Board memory & global memory — *inline write, model judgment*
+
+- **Fires on:** **during the turn** — the model calls `save_memory` / `update_memory` /
+  `delete_memory` as ordinary tool calls in its normal loop; **or** the user explicitly says
+  "remember …" (honored immediately). There is **no separate pass and no schedule.**
+- **Gate:** the model's own judgment, shaped by the **WHEN/SKIP** guidance in the system prompt (save
+  durable preferences/decisions/board-facts; skip anything derivable from the board, trivial,
+  ephemeral, or its own mid-turn work). *(Optional later: a turn-end extraction backstop, N≈5–10
+  turns, that stands down if the agent already wrote this turn — Phase 7.)*
+- **Runs:** `MemoryRepo.add` — **additive + `hash` dedup** (no LLM mutation loop). Over the char cap →
+  the write is **rejected with current entries returned**; the model consolidates (`update`/`remove`)
+  and retries **in the same turn** (≤3 retries, then a terminal "answer anyway"). No background prune.
+- **Cost:** **0 extra LLM calls** — folded into the turn the model is already doing.
+- **Wired at:** tools in `engine/tools.ts`, `memory: MemoryRepo` on `ToolContext`; the tool **binds
+  `boardId`/scope from context** (the model passes only `scope` + `kind` + content, never an id — it
+  can't cross-contaminate scopes). Writes are silent-but-inspectable (a subtle "saved to memory"
+  indicator + a user-editable panel); **no confirm gate** (local data, not off-board egress).
+
+## Sync & persistence — *board memory is shared, global is per-user*
+
+The front-end `MemoryRepo` (IndexedDB/rusqlite) is always the **local replica and the read source**;
+the server (Qdrant now → blob later) is a **sync target**, never on the read path. Two scopes, two
+shapes, both **eventually-consistent** (no live relay — a sidecar like the transcript backup,
+ADR-AGENT-001; collab invariants untouched):
+
+- **Board memory = shared across collaborators.** It's *about the board*, so all members converge on
+  the same set. Synced **per record**, keyed by `boardId`, merged **per-record LWW by `updatedAt`**.
+  Per-record (not one opaque blob) because a board has **many writers** — a blob would clobber a
+  collaborator's write; at record granularity, two people saving *different* facts both survive and
+  LWW only bites on the *same* record. Deletes are **tombstones** (`deleted: true` + `updatedAt`) so
+  a removal propagates instead of resurrecting on the next pull.
+- **Global memory = per-user.** Same per-record sync, keyed by `userId` — spans *your* devices, never
+  reaches collaborators. Anonymous (no account) → device-local, no sync.
+- **Conversation context** rides the existing **transcript blob** (single writer per conversation →
+  blob-LWW is fine). **Board purpose** v1: recompute per device; later: ride the board-memory channel.
+- **Local (unsynced) boards:** IndexedDB only. No server, no collaborators, no tombstones needed.
+
+**Cadence:** **push on write, debounced (~2s)** and **delta-only** (dirty records, not the whole
+store); **pull on board open + on reconnect** (+ optionally a lightweight "memory changed" nudge over
+the existing relay so a collaborator refreshes sooner). Writes are *rare* (a few durable facts per
+session), so this is never a stream.
+
+**Performance guarantees (the hard requirement) — the sync is structurally off every hot path:**
+1. **Never on the turn/UI path.** The agent always reads the **local** replica (no network wait); the
+   pull only *reconciles* in the background. Board render and the first turn never block on it.
+2. **Push is fire-and-forget + debounced** (`void`, ~2s coalesce) — a burst of saves in one turn
+   becomes **one** delta push; it never blocks the `save_memory` tool or the reply.
+3. **Tiny payloads** — records are ≤4KB/scope, and pushes are **deltas** (only `dirty` records), so
+   there is no large transfer.
+4. **Bounded background executor + timeout** (Hermes' lesson) — a slow/wedged server can't stall a
+   turn; the push runs on a single-worker queue with a timeout, off the critical path.
+5. **Failure backoff, no retry storms** — a permanent failure (no auth / 4xx) **suppresses** further
+   pushes until recovery (Hermes once emitted 167K push events from a no-auth device — we won't).
+6. **Reuses the offline-first plumbing** (debounced flush + pull-on-open), so it adds a light channel,
+   not new heavy infra.
+
+Net: reads are local and instant; the only network work is a rare, tiny, debounced, backgrounded
+delta push + a once-per-open pull — no measurable impact on the turn or the canvas.
+
+## Compaction — *derive, token-threshold*
+
+- **Fires on:** **turn start**, before building the request, when the transcript is near the window.
+- **Gate:** estimated prompt tokens ≥ `COMPACT_PCT × effectiveWindow`. **Anti-thrash:** skip if the
+  last compaction saved < ~10% (CC/Hermes circuit-breaker). This is the *only* token-length trigger
+  in the system — memory saving is decoupled from it (per the CC re-analysis).
+- **Runs (blocking, but the expensive work is already async) — a graceful hierarchy, mirroring CC's
+  `waitForSessionMemoryExtraction`:**
+  1. **Fresh checkpoint** → reuse `LocalChat.context` as the summary: a cheap **splice**
+     (`summary + verbatim recent tail`), **no LLM.**
+  2. **Refresh actively in-flight** → **bounded wait** (`CTX_WAIT_MS`, CC uses 15s) for it to land,
+     then splice. Still no LLM.
+  3. **Refresh stale/stuck** → don't wait; splice the **last completed** `context` — only slightly
+     behind, and the recent tail is verbatim anyway. Still no LLM.
+  4. **`context` still empty** (thread never summarized) → **blocking full-LLM summarize** — the only
+     expensive case, and a once-per-thread rarity.
+  The persistent-rolling checkpoint (above) is what makes 3 possible: a stuck refresh degrades to the
+  *previous* summary, not to a blocking summarize.
+- **Cost:** usually **0** (splice); a bounded wait in the mid-flight case; one blocking summarize only
+  on a never-summarized thread. So "the user waits on an LLM for compaction" collapses to just that
+  first-ever compaction.
+- **Wired at:** `chat-history.ts` / the turn-start assembly (Phase 6).
+
+---
+
+# Part 4 — Task 2: message representation
+
+Three changes, each independently shippable:
+
+1. **Wire reasoning into the existing model (not build it).** The `ReasoningTextStep.reasoning`
+   slot, normalization, and UI already exist (§1.5) and are populated by the legacy backend path
+   via a two-channel (`stream_reasoning_message`) mechanism — the browser engine just doesn't feed
+   them. Work: `stream-assemble.ts` / `managed-client.ts` / `byok-client.ts` parse the provider
+   reasoning channel (`delta.reasoning` / `reasoning_content`) → emit the new `reasoning` stream
+   event → `stepsFromEvents` fills `ReasoningTextStep.reasoning` / `ToolCallStep.thought`.
+   Instantly lights up the **already-built** (currently empty-for-local) UI expanders
+   (`reasoning-step-row.tsx`, `tool-step-row.tsx`) and enables re-feed. Reuse the legacy
+   `reasoningBuf`/`messageBuf` split concept from `build.ts:276` rather than inventing a new shape.
+   **Caveat:** provider reasoning blocks carry **signatures** with re-send constraints — decide per
+   provider: re-feed (with signature) or display-only.
+
+2. **Higher-fidelity history round-trip.** In `chat-history.ts`, either (a) emit **native**
+   `assistant{toolCalls}` + `tool` messages instead of `<Reasoning>` XML, or (b) keep the XML but
+   store the **real** tool output (`StoredToolOutput.preview`, not just ids) so the next turn can
+   re-read what tools returned. Replace the blunt 10k `slice` with the preview discipline (cap +
+   "re-fetch" affordance), and freeze the truncation per call id for byte-stable re-sends.
+
+3. **Bound intra-run + age old outputs.** Cap `fetch`/`web_search`/`get_note` outputs (they're
+   uncapped today), and add a microcompaction-style clear of old tool-result content before any
+   full compaction (`[old tool output cleared]`), cheapest-first.
+
+Backup compatibility: any `ReasoningStep` schema change must stay backward-compatible on load
+(`chat-persist.ts:20-27` already normalizes) since the opaque transcript backup carries this shape.
+
+---
+
+# Part 5 — Module map (where each piece lives)
+
+| Piece | New / changed | Location |
+|---|---|---|
+| `MemoryRepo` + `memories` store | new | `board/persist/local/memory-repo.ts` + schema in `idb.ts`/`sqlite-schema.ts`; composed in `features/local-stores.ts` |
+| Memory tools (`save/update/delete/recall_memory`) | new | `agent/engine/tools.ts`; `memory` added to `ToolContext` (`engine/types.ts`) |
+| Memory index + fencing | new | assembly in `local/use-local-submit-prompt.ts` |
+| Board snapshot | new | `agent/local/board-snapshot.ts` (pure fn over `ctx.store` + oplog) |
+| Board purpose derive | extend | `agent/local/describe-board.ts` (add context derive beside title) |
+| `BoardMeta.context` | change | `board/model/index.ts` + `board/persist/local/board-registry.ts` |
+| `LocalChat.context` | change | `agent/types/chat.ts` + `store/chat-repo.ts` + `store/local-messages-store.ts` |
+| Conversation-context refresh | new | fire-and-forget after `done` in `local/use-local-submit-prompt.ts` |
+| System-prompt sections | change | `agent/prompts/plan-system.md` + `prompts/index.ts` (`renderPrompt` placeholders) |
+| Reasoning capture | change | `engine/stream-assemble.ts`, `managed-client.ts`, `byok-client.ts`, `engine/types.ts` |
+| History fidelity + tool-output preview | change | `local/chat-history.ts`, `local/agent-event-to-step.ts`, `engine/tool-result.ts` |
+| Intra-run caps + microcompact | change | `engine/agent-loop.ts`, `engine/tools.ts` |
+| Compaction (reuse convo context) | new | `local/chat-history.ts` (threshold + summary) |
+
+All read/write hangs off the one submit path `local/use-local-submit-prompt.ts` (turn start = read +
+inject; turn end = fire gated background work), extending the `DescribeBoard` precedent already there.
+
+---
+
+# Part 6 — Implementation plan
+
+Seven phases, each independently shippable and valuable. LoC = rough *implementation* lines in the
+webui house style; the repo tests heavily, so budget **~0.8–1.2× more for tests** on logic/store
+phases (less on prompt/UI-wiring phases). Complexity reflects blast radius + correctness risk, not
+line count.
+
+## Summary
+
+| # | Phase | Impl LoC | +Tests | Complexity | Depends on | Ships |
+|---|---|---|---|---|---|---|
+| 1 | Board snapshot | ~250–350 | ~150 | Low–Med | — | agent sees the board; fixes "can't enumerate" |
+| 2 | Reasoning wiring | ~200–280 | ~120 | Med | — | visible chain-of-thought (lights up dead UI) |
+| 3 | Memory store + tools | ~500–700 | ~350 | Med–High | — | durable board + global facts, inline writes |
+| 4 | Board purpose + conversation context | ~400–550 | ~200 | Med | 3 (repo pattern) | standing board/thread context |
+| 5 | History fidelity + tool caps | ~450–650 | ~250 | Med–High | 2 (adjacent) | model re-reads real tool output; bounded growth |
+| 6 | Compaction | ~300–400 | ~150 | Med | 4 (convo ctx) | long chats don't overflow |
+| 7 | (later) LLM-select / extraction backstop / sync backup | — | — | Med | 3,4 | scale + cross-device |
+
+**Rough total for v1 (Phases 1–6): ~2,100–2,900 impl LoC + ~1,200 test LoC.**
+
+## Phase 1 — Board snapshot *(Low–Med)*
+
+**Does:** a pure, LLM-free "state of the board now" block injected into the system prompt — counts
+by node type, folder-layer outline, sampled titles, current selection/layer, and **recent changes**
+from the oplog tail; labeled point-in-time. Also exposed as a `get_board_overview` pull tool.
+**Files:** `agent/local/board-snapshot.ts` (new, pure fn + text renderer); `prompts/plan-system.md`
++ `prompts/index.ts` (new `## BOARD` placeholder); `local/use-local-submit-prompt.ts` (assemble +
+inject at the `systemWithDocs` seam); `engine/tools.ts` + `engine/types.ts` (`get_board_overview`).
+**LoC:** ~250–350. **Risk/notes:** the only subtlety is reading counts/oplog from the canvas-harness
+store API and sampling/capping for large boards; memoize by scene revision. No persistence, no new
+store — lowest-risk first ship.
+
+## Phase 2 — Reasoning wiring *(Med)*
+
+**Does:** feed the browser engine's provider reasoning channel into the **existing**
+`ReasoningTextStep.reasoning` / `ToolCallStep.thought` slots (model + UI already built, §1.5) —
+lighting up the currently-empty expanders and enabling re-feed. **Files:** `engine/types.ts` (new
+`reasoning` variant on `LlmStreamEvent` + `AgentEvent`); `engine/stream-assemble.ts`,
+`engine/managed-client.ts`, `engine/byok-client.ts` (parse `delta.reasoning`/`reasoning_content`);
+`engine/agent-loop.ts` (yield it); `local/agent-event-to-step.ts` (accumulate into the reasoning
+slot); `local/use-local-submit-prompt.ts` (consume the event). **LoC:** ~200–280. **Risk/notes:**
+the real work is **per-provider format variance** (Claude thinking vs OpenAI `reasoning_content` vs
+OpenRouter) — 3 client parsers. Reuse the `reasoningBuf`/`messageBuf` split from `build.ts:276`. Ship
+**display-only first**; re-feed (signature handling) is a follow-up flag.
+
+## Phase 3 — Memory store + tools *(Med–High)*
+
+**Does:** the `MemoryRepo` (board + global scope) with additive writes + hash dedup + overflow-
+reject; the `save/update/delete/recall_memory` tools; the always-on memory index injection + fencing;
+WHEN/SKIP prompt guidance. **Files:** `board/persist/local/memory-repo.ts` (new); `idb.ts` +
+`sqlite-schema.ts` (new `memories` store + **DB version bump**); `features/local-stores.ts` (compose);
+`engine/tools.ts` + `engine/types.ts` (tools + `ToolContext.memory`); `local/use-local-submit-prompt.ts`
+(index assembly + fence); `prompts/plan-system.md` (`## MEMORY` + guidance); a small UI affordance
+(indicator + minimal viewer). **LoC:** ~500–700 (+~150–250 if we build the full editable panel now —
+recommend a *minimal* viewer v1, full panel later). **Risk/notes:** the **DB version bump +
+migration** and the dedup/overflow semantics are the correctness-sensitive parts; run the
+`engine-contract` behavioral tests against the new store. Inline writes only — no background pass.
+
+## Phase 4 — Board purpose + conversation context *(Med)*
+
+**Does:** two derived-context fields with their gated refresh passes. **Files:** `board/model/index.ts`
++ `board/persist/local/board-registry.ts` (`BoardMeta.context` + fingerprint + setter);
+`agent/types/chat.ts` + `store/chat-repo.ts` + `store/local-messages-store.ts` (`LocalChat.context`
++ gate fields); `agent/local/describe-board.ts` (extend: derive purpose beside title + drift check);
+`local/use-local-submit-prompt.ts` (conversation-context refresh fire-and-forget after `done`;
+inject both into the system seam); prompt sections. **LoC:** ~400–550. **Risk/notes:** schema
+changes are additive/simple; the care is in the **gates** (drift fingerprint, N-turn/token
+thresholds) and the derive prompts. Reuses Phase 3's repo/persistence patterns.
+
+## Phase 5 — History fidelity + tool-output preview + intra-run caps *(Med–High)*
+
+**Does:** stop the lossy inter-turn round-trip — store real tool output (`StoredToolOutput` preview,
+not just ids), re-feed with a preview/truncation discipline (or native `assistant{toolCalls}` + `tool`
+messages), replace the blunt 10k `slice`; cap uncapped intra-run outputs (`fetch`/`web_search`/
+`get_note`); microcompact old tool outputs. **Files:** `engine/tool-result.ts` +
+`local/agent-event-to-step.ts` (`StoredToolOutput` + preview); `local/chat-history.ts` (round-trip);
+`engine/tools.ts` (intra-run caps); `engine/agent-loop.ts` (aging). **LoC:** ~450–650. **Risk/notes:**
+**highest correctness risk** — this changes what the model re-reads, so mind tool-pairing and
+byte-stable re-sends; the native-tool-message path needs the clients to accept `tool` role messages
+in history (agent-loop already builds them intra-run, so support exists). Keep
+`chat-persist.ts` backward-compatible on load (opaque backup carries this shape). Sits adjacent to
+Phase 2 (both touch `agent-event-to-step`/`chat-history`) — do them near each other to avoid churn.
+
+## Phase 6 — Compaction *(Med)*
+
+**Does:** token-threshold conversation compaction that **reuses `LocalChat.context` as the summary**
+(no extra call when context is fresh; one summarize call otherwise), preserving a verbatim recent
+tail, with an anti-thrash guard. **Files:** `local/chat-history.ts` / `local/use-local-submit-prompt.ts`
+(threshold check + splice); a small summarize helper. **LoC:** ~300–400. **Risk/notes:** mostly
+reuses Phase 4's conversation context; the fiddly bits are the token estimate and the
+splice-keeping-recent-turns. Depends on Phase 4.
+
+## Phase 7 — Later *(deferred)*
+
+Automatic LLM-select retrieval (when the index outgrows always-on); the turn-boundary extraction
+backstop (N≈5–10 turns, only if telemetry shows the inline tool under-saves); and **memory sync**
+(Part 3 § Sync & persistence) — **shared board memory** (per-record, per-record LWW by `boardId`,
+tombstoned deletes) + **per-user global memory** (`userId`), both eventually-consistent
+(pull-on-open + debounced delta push) on a bounded background queue with failure backoff, so it stays
+off every hot path. Not estimated until 1–6 land and we have usage signal.
+
+## Sequencing notes
+
+- **Independent, ship-anytime:** Phases 1, 2, 3 have no hard dependencies — 1 is the safest first
+  ship, 2 is the highest visible-value-per-LoC.
+- **Chained:** 4 reuses 3's repo pattern; 6 needs 4's conversation context; 5 is best done adjacent
+  to 2.
+- **Recommended order:** 1 → 2 → 3 → 4 → 5 → 6 (value-forward, dependency-safe).
+
+## Test plan
+
+Philosophy: Phase 1's core is **pure functions** → fixture-based unit tests, no mocks. `readRecentOps`
+runs against the in-memory `StorageEngine` (the `engine-contract` trick), not IndexedDB. For
+rendering, assert **structural properties** (contains/capped/present) *plus* one **golden test** per
+archetype (empty / sparse / large) to lock the format — properties survive tweaks, the golden catches
+drift.
+
+### Phase 1 — board snapshot
+
+- **`buildBoardSnapshot`:** empty → empty snapshot; flat board → no layers; type breakdown correct;
+  title = `data.label` → first line of `content` → `"(untitled)"`; layer grouping by `parentId`
+  (folder label resolved; `null` = root); current-layer from `rootId`; nested folders; selection
+  resolved / empty.
+- **`renderBoardSnapshot`:** budget cap → `(showing X of Y)`; layer cap → `+J more folders …`;
+  **current layer always included even if not top-K** *(silent-regression guard)*; title priority
+  (current → selection → recent → largest) + per-layer cap; flat → `Nodes:` line, no `Layers`; empty
+  → one-line form; recent changes `+/~/-`, list vs by-folder summary, **omitted when nothing changed**,
+  `+N this session` with no prior session; non-note type tags; per-title ~40-char truncation;
+  **golden tests for the three archetypes**.
+- **`readRecentOps` + collapse:** range `seq > lastSeenSeq`; per-node collapse (add+edit→add,
+  add+delete→cancel, multi-edit→edit); delete title from op payload; `edge.*` ignored; no-change → [].
+- **Edge cases that bite:** orphan node (dangling `parentId`); stale `rootId`; stale selection id;
+  empty folder; titles with newlines/markdown/emoji + multibyte truncation; 1000-node board (budget
+  holds, not O(n²)); deleted-node-in-recentChanges.
+- **Memoization/wiring:** identical scene → memo reused; changed ≥ `SNAPSHOT_DIRTY_DELTA` → recompute;
+  `## BOARD` injected at turn start; degenerate omissions (no purpose → snapshot only); the
+  `get_board_overview` tool returns the same text.
+
+### Later phases — highest-value tests (build test-first)
+
+- **P2 reasoning:** per-provider parser fixtures (Claude thinking / OpenAI `reasoning_content` /
+  OpenRouter) fill the slot; a no-reasoning stream still works (regression).
+- **P3 memory:** run `engine-contract` on the store; dedup by `hash`; overflow→reject→consolidate→
+  retry; **scope isolation** (board write never leaks to global / another board) — a silent-correctness
+  guard.
+- **P5 fidelity:** round-trip **byte-stability** (same turn → identical re-sent history); tool_use/
+  tool_result pairing integrity; large output → preview not full.
+- **P6 compaction:** the graceful hierarchy (fresh→splice / in-flight→bounded-wait→splice / stale→
+  last-good splice / empty→blocking summarize); recent tail stays verbatim.
+
+The two never-ship-without tests: **"current layer always included"** (P1) and **"scope isolation"**
+(P3) — both silent bugs that code review misses.
+
+---
+
+# Open questions
+
+1. **Taxonomy:** keep CC's 4 `MemoryKind`s or collapse to fewer for v1? (Lean: keep 4 — cheap, and
+   the per-kind save/why guidance is valuable.)
+2. **Memory index always-on vs LLM-select from day one?** (Lean: index + `recall` tool; LLM-select
+   later.)
+3. **Reasoning re-feed vs display-only** per provider (signature constraints).
+4. **Synced-board sync** — *resolved:* **board memory is shared** (per-record, per-record LWW, keyed
+   by `boardId`); **global memory is per-user** (keyed by `userId`); both eventually-consistent
+   (pull-on-open + debounced delta push, off every hot path). **v1 is device-local**; the shared/sync
+   layer is **Phase 7** — it slots on top of the same `MemoryRepo` without changing it. See
+   Part 3 § Sync & persistence.
+5. **Snapshot freshness** — *shipped:* rebuilt **once per turn** (at submit), which is between
+   session-open and per-render. The "seen" cursor is persisted per device in a dedicated
+   `snapshot_meta` store (not `BoardMeta` — it's device-local, and `sync_meta` is a full-put that
+   would clobber), so recent-changes span sessions ("since you last checked"). **Memoization
+   (`SNAPSHOT_DIRTY_DELTA`) deliberately skipped**: at once-per-turn frequency the build is sub-ms
+   (one `getAllNodes` + one indexed oplog read), so a scene-revision memo is dead weight — revisit
+   only if we add a more frequent in-session refresh.
+6. **Extraction backstop N** if/when added: start ~5–10 turns (metered cost), not CC's per-turn.

--- a/docs/plans/agent-context-architecture.md
+++ b/docs/plans/agent-context-architecture.md
@@ -391,10 +391,11 @@ Deterministic, budget-driven, top-down; stop adding titles when the budget is hi
    tag (`[sheet]`, `[mini-app]`, `[document]`, `[code]`); notes render bare.
 4. **Selection (always, if any):** `Selection: <k> <type(s)> — "titles"`. The agent's immediate
    focus, so never dropped for budget.
-5. **Recent changes:** from the oplog tail since the last session's last-seen seq (fallback: last
-   `RECENT_OPS_WINDOW` ops). `+A added (titles/where), ~E edited (titles), -D deleted`; list up to
-   `RECENT_TITLES` titles, else summarize by folder (`in /Specs, /Meetings`). **Omit the line
-   entirely if nothing changed.** On a board with no prior session, phrase as `+N this session`.
+5. **Recent changes:** from the oplog tail since the device's last-seen seq (`snapshot_meta`).
+   `+A added (titles/where), ~E edited (titles), -D deleted`; list up to `RECENT_TITLES` titles, else
+   summarize by folder (`in /Specs, /Meetings`). **Omit the line entirely if nothing changed.**
+   Phrased uniformly as "Recent changes since you last checked" (the away-open and a mid-session turn
+   share the same cursor semantics). Still shown on a now-empty board (a full clear is the signal).
 6. **Empty board:** a single line — `Empty board — no nodes yet.`
 
 The renderer is a pure function of the `BoardSnapshot`; it makes **no LLM call** and is rebuilt per
@@ -456,8 +457,10 @@ export const readRecentOps = (
 **The session cursor.** "Recent changes since you last checked" needs a per-device per-board mark.
 Shipped as a dedicated device-local `snapshot_meta` store (`{ boardId, seenSeq }`) — **not**
 `BoardMeta` (server-authoritative on synced boards) and **not** `sync_meta` (a full-put that would
-clobber a piggybacked field). On each build, recent = ops with `seq > seenSeq`; then `seenSeq`
-advances to the current max. First time on a device: recent = `[]` (adopt the baseline).
+clobber a piggybacked field). At **turn start** the build reads recent = ops with `seq > seenSeq`
+(read-only); the cursor **advances at turn END** (after the agent's writes land), so the agent's own
+edits this turn are *not* reported back next turn as user changes — recent shows only what the USER
+touched between turns. First time on a device: recent = `[]` (the turn-end advance sets the baseline).
 
 **Wiring/perf:** called in `use-local-submit-prompt.ts` at turn start; `getAllNodes()`/`getSelection()`
 are in-memory reads, `readRecentOps` is one indexed range query. **Rebuilt once per turn (sub-ms);
@@ -854,7 +857,8 @@ drift.
   `+N this session` with no prior session; non-note type tags; per-title ~40-char truncation;
   **golden tests for the three archetypes**.
 - **`readRecentOps` + collapse:** range `seq > lastSeenSeq`; per-node collapse (add+edit→add,
-  add+delete→cancel, multi-edit→edit); delete title from op payload; `edge.*` ignored; no-change → [].
+  add+remove→cancel, remove+update stays delete, multi-edit→edit); delete title from the `node.remove`
+  op's node; `edge.*` ignored; no-change → []. Recent changes still shown on a now-empty board.
 - **Edge cases that bite:** orphan node (dangling `parentId`); stale `rootId`; stale selection id;
   empty folder; titles with newlines/markdown/emoji + multibyte truncation; 1000-node board (budget
   holds, not O(n²)); deleted-node-in-recentChanges.

--- a/docs/plans/agent-context-memory.md
+++ b/docs/plans/agent-context-memory.md
@@ -1,0 +1,198 @@
+# Agent context & memory — design (discussion draft)
+
+Status: **draft, for discussion.** Nothing here is committed. `DECISION?` marks an
+open fork we need to resolve together; `LEAN:` is my current recommendation.
+
+## Goal (one line)
+
+Give the board agent a **layered, curated, read+write memory** plus a cheap
+**auto-built board snapshot**, so every run starts already knowing (a) the state
+of the board now, (b) durable facts about this board, and (c) durable facts about
+the user across all boards — the way Claude Code assembles `gitStatus` + `CLAUDE.md`
++ a relevance-retrieved memory dir.
+
+Runtime is the **browser engine** (`webui/src/features/agent/engine/`), the north-star
+runtime. Persistence is **front-end-first**: the same local DB the runtime lives on
+(IndexedDB on web, rusqlite on desktop) via the existing `StorageEngine` port. The
+server (Qdrant today, a blob layer later) is only a **sync/backup target** for synced
+boards and cross-device — never the primary store.
+
+## Prior art: how Claude Code's memory works (what we're stealing)
+
+Five transferable ideas (from the leaked `memdir/` + `services/extractMemories/`):
+
+1. **Two-tier storage: always-loaded index + on-demand fact files.** `MEMORY.md` is a
+   capped index (200 lines / 25KB, hard-truncated) that's *always* in the prompt; each
+   fact is a separate file (`name`, `description`, `type` frontmatter). The index keeps
+   the always-on cost flat while the memory grows unbounded.
+2. **Closed 4-type taxonomy** — `user` / `feedback` / `project` / `reference` — governed
+   by one rule that does most of the work: **never save what's derivable from current
+   state** (for us: derivable from reading the board — that's the snapshot's job).
+3. **Relevance retrieval is a cheap LLM side-query, not embeddings.** Scan headers
+   (name + description) → hand the manifest to a small fast model → "pick ≤5 you're
+   *certain* are useful" → inject only those full files.
+4. **Write-back is prompted, two-step, dedup-first** (write fact file, then index
+   pointer; update-before-create), plus a passive `extractMemories` pass over the
+   transcript.
+5. **Drift discipline on recall**: memory is "true as of when written" — verify against
+   current state before acting, trust what you observe now, update/remove stale entries.
+
+## The three layers
+
+| Layer | CC analogue | Nature | Persistence |
+|---|---|---|---|
+| **L0 — Board snapshot** | `gitStatus` | Auto, ephemeral, frozen per run | none (computed from live scene) |
+| **L1 — Board memory** | project/feedback memories + `CLAUDE.md` | Curated read+write, board-scoped | local DB, synced per-board |
+| **L2 — Global memory** | user-level memory | Curated read+write, account-wide | local DB, backed up per-user |
+
+### L0 — Board snapshot (build first; almost free)
+
+Computed from the live harness store at run start, frozen for the run (memoized like
+`getSystemContext`), injected as a labeled block: *"snapshot in time, will not update
+during this run."* Contents (budgeted, ~1–2k tokens):
+
+- Node inventory by type + counts (notes, folders, sheets, code-sandboxes, mini-apps, docs).
+- Titles / short captions of nodes (truncated list; the whole board if small).
+- Current selection + which folder layer (`rootId`) is projected.
+- Optionally: recently-changed nodes (from the oplog tail).
+
+`DECISION?` How big is the snapshot allowed to get on a large board — hard node cap +
+"N more not shown", or a summarize-the-board pass for big boards? `LEAN:` hard cap first
+(cheap, deterministic); a summarizer is a later enhancement.
+
+### L1 — Board memory (curated, board-scoped)
+
+Durable facts about *this board*: its purpose, the user's intent for it, conventions
+("keep research notes in the left cluster"), decisions, references. Excludes anything
+readable from the board itself.
+
+### L2 — Global memory (curated, account-wide)
+
+Durable facts about the *user* that should travel across every board: role, expertise,
+collaboration preferences, feedback ("don't auto-create summary notes"), cross-board
+references. This is the `user`/`feedback` taxonomy.
+
+`DECISION?` Do we keep CC's exact 4 types (`user`/`feedback`/`project`/`reference`), or
+add a board-native one (e.g. `board` for "what this canvas is")? `LEAN:` reuse the 4;
+map "what this board is" to `project` scoped to the board. Fewer concepts.
+
+## Storage model (front-end-first)
+
+### The record
+
+One store, `memories`, over the `StorageEngine` port — a new `MemoryRepo` composed in
+`local-stores.ts` beside `ChatRepo`/`DocRepo`. Record shape:
+
+```ts
+type MemoryRecord = {
+  id: string                 // uuid, key path
+  scope: "global" | "board"
+  boardId: string | null     // set iff scope === "board"; null for global
+  type: "user" | "feedback" | "project" | "reference"
+  name: string               // short slug/title
+  description: string        // one-line — THE retrieval key (matches CC frontmatter)
+  body: string               // the fact; feedback/project carry Why: / How to apply:
+  createdAt: number
+  updatedAt: number
+  // sync bookkeeping (see below)
+  dirty: boolean             // has local edits not yet backed up
+  serverRev: number | null   // last synced revision, null = never synced
+}
+```
+
+Indexes: `by-scope-board` (`[scope, boardId]`) for "all memories for this board" and
+"all global memories"; `by-type` optional. Mirrors `DocRepo`'s `by-board` pattern; the
+engine already supports compound-key ranges (see `engine-contract.ts`).
+
+There is **no separate `MEMORY.md` file** as in CC — the "always-loaded index" is
+*derived* at assembly time by listing records and rendering their `name`+`description`
++`type`. Same effect, no second artifact to keep in sync. The 200-line/25KB cap becomes
+a budget on how many index lines we render (oldest/least-relevant dropped, with a
+"N more not shown" note).
+
+### Sync / backup
+
+Retrieval and index-building are **entirely front-end** — the server never needs to
+understand memory semantics, only store and return opaque bytes. So model both layers
+on the **opaque-blob backup** pattern already used for browser-agent transcripts
+(ADR-AGENT-001), not on the collab oplog:
+
+- **L2 global:** one per-user memory blob (all global records), backed up to the server
+  keyed by `userId`. Pulled on login/first-open, pushed (debounced) when `dirty`. Merge
+  is last-writer-wins per record (`updatedAt`), same discipline as the sync spine.
+  Anonymous users: local-only, no backup (no identity — acceptable, matches CC's
+  "no account, no cross-device").
+- **L1 board:** one per-board memory blob keyed by `boardId`, backed up alongside the
+  board. Local boards: local-only. Synced boards: backed up so the same user's other
+  devices get it.
+
+`DECISION?` For a **synced/shared** board, should board memory be **collaborative**
+(every member sees the same memory, live) or **per-user-per-board** (my notes on this
+board are mine)? Collaborative ⇒ it must ride the board relay/oplog as a new op type
+(touches ADR-SYNC-001 invariants). Per-user ⇒ the opaque-blob backup above, keyed by
+`(userId, boardId)`, and collab is untouched. `LEAN:` **per-user-per-board via blob
+backup** for v1 — keeps collab invariants untouched, ships faster; collaborative shared
+memory is a clean follow-up (it's "team memory" — CC gates that behind a flag too).
+
+`DECISION?` Blob backup vs proper per-record server rows. Blob = trivial server, coarse
+merge; rows = finer merge, more backend. `LEAN:` blob for v1 (memory writes are rare and
+small; coarse LWW is fine), revisit if merge conflicts bite.
+
+## Retrieval (front-end)
+
+At run start, for the current user message:
+
+1. **Index (always in prompt):** render every global + this-board record as one line
+   (`- [type] name — description`), budget-capped. This is the `MEMORY.md` equivalent.
+2. **Relevant full memories:** CC's `findRelevantMemories` — build a manifest from the
+   records' `name`+`description`, call a cheap model via the `/ai/llm` proxy with a
+   strict "pick ≤5 certain-useful" prompt, inject those full bodies.
+
+`DECISION?` Do we need the LLM-select at all for v1, or just inject the whole index
+(names+descriptions) and let the main model ask for bodies via a `read_memory` tool?
+`LEAN:` start with **index-always + a `recall_memory` tool** (model pulls bodies on
+demand) — simplest, no extra model call per run. Add the automatic LLM-select later when
+memory volume makes the index too big to always show. (We also already have Orama BM25
+from doc Q&A as a future pre-filter if volume explodes.)
+
+## Write path
+
+New browser-engine tools (fit the ADR-AGENT-002 tool contract — one `ToolFailure` shape):
+
+- `save_memory({ scope, type, name, description, body })` — dedup-first (update existing
+  by name+scope before creating).
+- `update_memory({ id, ... })`, `delete_memory({ id })`, `recall_memory({ query })`.
+
+`DECISION?` Also run a **passive post-run extraction pass** (CC's `extractMemories`) that
+mines the finished turn for durable facts? Pro: catches what the model forgets to save.
+Con: an extra metered `/ai/llm` call per run. `LEAN:` **tools only for v1**; add extraction
+behind a flag once the tool path is proven.
+
+## Assembly / injection
+
+New module `features/agent/engine/context/` mirroring CC's `context.ts`:
+
+- `getBoardSnapshot(store)` → L0, memoized per run.
+- `getMemoryContext(userId, boardId, query)` → L1+L2 index (+ optional relevant bodies).
+- Both assembled into the system prompt at `agent-loop.ts` start, frozen for the run.
+
+Prompt scaffolding (taxonomy text, what-not-to-save, drift caveat, how-to-save) is
+adapted from CC's `memoryTypes.ts` — that text is eval-tuned; we should port it near-verbatim
+and trim the team/scope branches we don't use in v1.
+
+## Phasing
+
+1. **L0 board snapshot** — pure win, no persistence, immediately useful.
+2. **MemoryRepo + `memories` store + schema/migration** — local only, no sync.
+3. **Write tools + index injection + `recall_memory`** — memory usable on local boards.
+4. **Backup/sync** — L2 per-user blob, then L1 per-board blob.
+5. **(later)** automatic LLM-select retrieval; passive extraction; collaborative board memory.
+
+## Open questions (consolidated)
+
+1. Snapshot size strategy on large boards — hard cap vs summarizer.
+2. Taxonomy — CC's 4 types as-is, or add a board-native type.
+3. Shared-board memory — collaborative (relay) vs per-user (blob). *(biggest one)*
+4. Backup granularity — opaque blob vs per-record rows.
+5. Retrieval — index-always + tool vs automatic LLM-select from day one.
+6. Extraction — tools-only vs passive post-run pass.

--- a/docs/plans/agent-context-memory.md
+++ b/docs/plans/agent-context-memory.md
@@ -1,5 +1,13 @@
 # Agent context & memory — design (discussion draft)
 
+> **SUPERSEDED.** This is the earliest discussion draft; the `DECISION?`/`LEAN:` forks below were
+> resolved in **[`agent-context-architecture.md`](./agent-context-architecture.md)**, which is the
+> single source of truth for the design. Where the two disagree, the architecture doc wins — notably
+> the **memory sync model**: this draft leans toward an opaque per-board *blob* backup, but the
+> resolved design is **per-record sync with per-record LWW** (board memory is shared across
+> collaborators, so a blob would clobber concurrent writes). Kept for the reasoning trail; do not
+> implement from it.
+
 Status: **draft, for discussion.** Nothing here is committed. `DECISION?` marks an
 open fork we need to resolve together; `LEAN:` is my current recommendation.
 

--- a/docs/plans/claude-code-compaction-prompt.md
+++ b/docs/plans/claude-code-compaction-prompt.md
@@ -1,0 +1,307 @@
+# Claude Code: the memory/context compression prompt
+
+Focused companion to `inspiration-claude-code-memory.md`. Answers one question precisely:
+**what prompt does Claude Code use to compress context, what goes in, what comes out, and
+does it use any tools?** All citations are `path:line` in `~/workspace/leak-claude-code/`.
+
+## First: "compress memory" is three different things
+
+There are three compression-adjacent mechanisms, and the **tool answer differs for each** —
+so the disambiguation matters:
+
+| Mechanism | Compresses | Uses tools? |
+|---|---|---|
+| **Conversation compaction** (the famous one) | the running message history → a text summary | **No** — text-only, tools denied |
+| **Session-memory self-condense** | `summary.md` when it exceeds its 12K-token budget | **Yes** — the note-taker `Edit`s the file |
+| **Dream prune** | `MEMORY.md` + topic files, nightly | **Yes** — `Read`/`Grep`/`Edit`/`Write` |
+
+This doc details **conversation compaction** (the primary "compression," and the one with
+the notable prompt), then summarizes the other two at the end so the tool question is fully
+answered.
+
+---
+
+## Conversation compaction
+
+Source: `services/compact/prompt.ts` (the prompts) and `services/compact/compact.ts` (the
+input prep + tool config).
+
+### The INPUT (what the summarizer model sees)
+
+The summarizer is a **one-shot model call** whose message list is built at
+`compact.ts:1292-1301`:
+
+```
+normalizeMessagesForAPI(
+  stripImagesFromMessages(
+    stripReinjectedAttachments([
+      ...getMessagesAfterCompactBoundary(messages),   // the conversation to compress
+      summaryRequest,                                  // a user message = getCompactPrompt()
+    ]),
+  ),
+)
+```
+
+So the input is:
+
+1. **The conversation since the last compaction boundary** — `getMessagesAfterCompactBoundary`
+   (not the whole history; earlier already-compacted spans are excluded).
+2. **Two transforms before it's sent:**
+   - `stripReinjectedAttachments` — removes previously re-injected file attachments (avoid
+     double-paying for file bodies).
+   - `stripImagesFromMessages` — strips image blocks (keeps text, tool_use/tool_result, and
+     thinking blocks); images can't be summarized and are expensive.
+3. **A final user message** carrying the compaction prompt (`summaryRequest`).
+
+**System prompt for the call:** minimal — `"You are a helpful AI assistant tasked with
+summarizing conversations."` (`compact.ts:1302-1304`) on the streaming-fallback path. The
+preferred path is a **cache-sharing fork** that inherits the parent's full system prompt +
+message prefix (so it hits the prompt cache), with the compaction instruction appended.
+
+**Call config** (`compact.ts:1305-1321`): `thinkingConfig: disabled`, `querySource:
+'compact'`, `maxOutputTokensOverride = min(COMPACT_MAX_OUTPUT_TOKENS = 20_000, model max)`,
+`maxTurns: 1`.
+
+### The PROMPT (verbatim)
+
+Assembled by `getCompactPrompt(customInstructions?)` as **`NO_TOOLS_PREAMBLE` + `BASE_COMPACT_PROMPT`
++ (optional custom instructions) + `NO_TOOLS_TRAILER`** (`prompt.ts:293-303`).
+
+**① No-tools preamble** (`prompt.ts:19-26`) — placed FIRST because on newer adaptive-thinking
+models the model sometimes tries a tool call despite the trailer, wasting its only turn:
+
+```
+CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
+
+- Do NOT use Read, Bash, Grep, Glob, Edit, Write, or ANY other tool.
+- You already have all the context you need in the conversation above.
+- Tool calls will be REJECTED and will waste your only turn — you will fail the task.
+- Your entire response must be plain text: an <analysis> block followed by a <summary> block.
+```
+
+**② The base compaction prompt** (`prompt.ts:61-143`) — the analysis instruction + the
+9-section spec + a worked example:
+
+```
+Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
+This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context.
+
+Before providing your final summary, wrap your analysis in <analysis> tags to organize your thoughts and ensure you've covered all necessary points. In your analysis process:
+
+1. Chronologically analyze each message and section of the conversation. For each section thoroughly identify:
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions, technical concepts and code patterns
+   - Specific details like:
+     - file names
+     - full code snippets
+     - function signatures
+     - file edits
+   - Errors that you ran into and how you fixed them
+   - Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+2. Double-check for technical accuracy and completeness, addressing each required element thoroughly.
+
+Your summary should include the following sections:
+
+1. Primary Request and Intent: Capture all of the user's explicit requests and intents in detail
+2. Key Technical Concepts: List all important technical concepts, technologies, and frameworks discussed.
+3. Files and Code Sections: Enumerate specific files and code sections examined, modified, or created. Pay special attention to the most recent messages and include full code snippets where applicable and include a summary of why this file read or edit is important.
+4. Errors and fixes: List all errors that you ran into, and how you fixed them. Pay special attention to specific user feedback that you received, especially if the user told you to do something differently.
+5. Problem Solving: Document problems solved and any ongoing troubleshooting efforts.
+6. All user messages: List ALL user messages that are not tool results. These are critical for understanding the users' feedback and changing intent.
+7. Pending Tasks: Outline any pending tasks that you have explicitly been asked to work on.
+8. Current Work: Describe in detail precisely what was being worked on immediately before this summary request, paying special attention to the most recent messages from both user and assistant. Include file names and code snippets where applicable.
+9. Optional Next Step: List the next step that you will take that is related to the most recent work you were doing. IMPORTANT: ensure that this step is DIRECTLY in line with the user's most recent explicit requests, and the task you were working on immediately before this summary request. If your last task was concluded, then only list next steps if they are explicitly in line with the users request. Do not start on tangential requests or really old requests that were already completed without confirming with the user first.
+                       If there is a next step, include direct quotes from the most recent conversation showing exactly what task you were working on and where you left off. This should be verbatim to ensure there's no drift in task interpretation.
+
+Here's an example of how your output should be structured:
+
+<example>
+<analysis>
+[Your thought process, ensuring all points are covered thoroughly and accurately]
+</analysis>
+
+<summary>
+1. Primary Request and Intent:
+   [Detailed description]
+
+2. Key Technical Concepts:
+   - [Concept 1]
+   - [Concept 2]
+   - [...]
+
+3. Files and Code Sections:
+   - [File Name 1]
+      - [Summary of why this file is important]
+      - [Summary of the changes made to this file, if any]
+      - [Important Code Snippet]
+   - [File Name 2]
+      - [Important Code Snippet]
+   - [...]
+
+4. Errors and fixes:
+    - [Detailed description of error 1]:
+      - [How you fixed the error]
+      - [User feedback on the error if any]
+    - [...]
+
+5. Problem Solving:
+   [Description of solved problems and ongoing troubleshooting]
+
+6. All user messages: 
+    - [Detailed non tool use user message]
+    - [...]
+
+7. Pending Tasks:
+   - [Task 1]
+   - [Task 2]
+   - [...]
+
+8. Current Work:
+   [Precise description of current work]
+
+9. Optional Next Step:
+   [Optional Next step to take]
+
+</summary>
+</example>
+
+Please provide your summary based on the conversation so far, following this structure and ensuring precision and thoroughness in your response. 
+
+There may be additional summarization instructions provided in the included context. If so, remember to follow these instructions when creating the above summary. Examples of instructions include:
+<example>
+## Compact Instructions
+When summarizing the conversation focus on typescript code changes and also remember the mistakes you made and how you fixed them.
+</example>
+
+<example>
+# Summary instructions
+When you are using compact - please focus on test output and code changes. Include file reads verbatim.
+</example>
+```
+
+**③ Optional custom instructions** appended as `\n\nAdditional Instructions:\n<text>` — from
+`/compact <text>` or a PreCompact hook.
+
+**④ No-tools trailer** (`prompt.ts:269-272`):
+
+```
+REMINDER: Do NOT call any tools. Respond with plain text only — an <analysis> block followed by a <summary> block. Tool calls will be rejected and you will fail the task.
+```
+
+> **Prompt-design notes worth stealing.** (a) The `<analysis>` block is a **drafting
+> scratchpad** — it improves quality, then gets thrown away (see OUTPUT). (b) Section 6 "All
+> user messages" and Section 9's demand for **verbatim quotes** of the current task exist to
+> prevent "task drift" across the compression boundary. (c) The no-tools framing is doubled
+> (preamble + trailer) and explains the *consequence* ("waste your only turn") — behavioral,
+> not just a rule.
+
+There are two other variants for **partial** compaction (`prompt.ts:145-267`):
+`PARTIAL_COMPACT_PROMPT` (`direction: 'from'` — summarize the recent tail, keep the older
+prefix, preserves prompt cache) and `PARTIAL_COMPACT_UP_TO_PROMPT` (`'up_to'` — summarize the
+prefix, keep the newer tail; its sections 8–9 become **"Work Completed"** and **"Context for
+Continuing Work"** because the summary is prepended before newer messages). Same 9-slot
+shape otherwise.
+
+### The OUTPUT
+
+**Raw model output:** `<analysis>…</analysis>` followed by `<summary>1. … 9. …</summary>`.
+
+**Post-processing** — `formatCompactSummary` (`prompt.ts:311-335`):
+1. **Strips the `<analysis>` block entirely** (`replace(/<analysis>[\s\S]*?<\/analysis>/, '')`)
+   — the scratchpad never reaches context.
+2. Replaces the `<summary>…</summary>` tags with a plain `Summary:\n…` header.
+3. Collapses extra blank lines.
+
+**Final wrapping** — `getCompactUserSummaryMessage` (`prompt.ts:337-374`) turns it into the
+message that actually re-enters the conversation:
+
+```
+This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.
+
+<formatted summary>
+```
+
+plus, conditionally:
+- a transcript pointer: *"If you need specific details from before compaction (like exact
+  code snippets, error messages, or content you generated), read the full transcript at:
+  <path>"* — **the lossless fallback**: the summary is lossy, but the raw transcript survives
+  on disk and the model is told where to read it.
+- `"Recent messages are preserved verbatim."` when a recent tail was kept.
+- when auto-triggered (`suppressFollowUpQuestions`): *"Continue the conversation from where it
+  left off without asking the user any further questions. Resume directly — do not
+  acknowledge the summary, do not recap… Pick up the last task as if the break never
+  happened."*
+
+This becomes a `UserMessage` flagged `isCompactSummary: true`. The new conversation history
+is then assembled in order (`buildPostCompactMessages`): **boundary marker → summary message →
+kept recent messages → re-hydrated attachments → hook output**. "Re-hydrated attachments" =
+the last ≤5 read files (≤5K each / 50K total), the active plan, invoked-skill text, and
+tool/agent/MCP availability — surgically re-injected so the model isn't amnesiac about its
+environment after compression.
+
+### Does compaction use any tool? — **No.**
+
+Compaction is a **text-only summarization turn**. Two layers enforce it:
+
+1. **Prompt level:** the no-tools preamble + trailer above.
+2. **Runtime level:** on the preferred cache-sharing fork path, `canUseTool` is
+   `createCompactCanUseTool()` (`compact.ts:1125-1134`), which **denies every tool call**:
+
+   ```ts
+   return async () => ({
+     behavior: 'deny',
+     message: 'Tool use is not allowed during compaction',
+     decisionReason: { type: 'other', reason: 'compaction agent should only produce text summary' },
+   })
+   ```
+
+   with `maxTurns: 1` — one shot, text only.
+
+   Caveat on the **streaming-fallback path**: its tool *schema* is minimal — `[FileReadTool]`
+   (plus `ToolSearchTool` + MCP tools only when tool-search is enabled) — for API/cache
+   reasons, but the prompt still forbids tool calls. So the fork path *hard-denies* tools; the
+   fallback path *exposes only FileReadTool but instructs against using it*. Net effect:
+   **compression produces a summary from context alone, without gathering new information via
+   tools.** (Contrast the fork's full inherited tool set, which exists purely for prompt-cache
+   key-matching, not for use — `prompt.ts:12-18`.)
+
+---
+
+## The other two "memory compression" mechanisms (tool answers)
+
+### Session-memory self-condense — **uses `Edit`**
+
+When `summary.md` grows past its budget (`MAX_SECTION_LENGTH = 2000` tokens/section,
+`MAX_TOTAL_SESSION_MEMORY_TOKENS = 12000` total), the background note-taker is told to shrink
+it in place. The instruction (session-memory update prompt): *"if a section is approaching
+this limit, condense it by cycling out less important details while preserving the most
+critical information"*, and when over total budget: *"You MUST condense the file… Aggressively
+shorten oversized sections by removing less important details, merging related items, and
+summarizing older entries. Prioritize keeping Current State and Errors & Corrections."* The
+note-taker is a **forked subagent restricted to the `Edit` tool on that one file** — so this
+compression **does** use a tool. Separately, at compaction time
+`truncateSessionMemoryForCompact` does a **hard, non-model** truncation (cut each oversized
+section at a line boundary, append `[... section truncated for length ...]`).
+
+### Dream prune — **uses `Read`/`Grep`/`Edit`/`Write`**
+
+The nightly `autoDream` consolidation's Phase 4 ("Prune and index") rewrites `MEMORY.md` to
+stay *"under 200 lines AND under ~25KB… an index, not a dump,"* removing stale pointers,
+demoting over-long lines, resolving contradictions. This runs as a **forked agent with
+read-only Bash + Read/Grep/Edit/Write scoped to the memory dir** — so it **does** use tools.
+
+---
+
+## One-line answers
+
+- **Prompt to compress context:** `NO_TOOLS_PREAMBLE + BASE_COMPACT_PROMPT (9 sections +
+  worked example) + NO_TOOLS_TRAILER` (`services/compact/prompt.ts`).
+- **Input:** messages since the last compaction boundary (images + re-injected attachments
+  stripped) + the prompt, one shot, thinking disabled, ≤20K output tokens.
+- **Output:** `<analysis>` (discarded) + `<summary>` 9 sections → reformatted → wrapped as a
+  "This session is being continued…" user message + transcript pointer + resume directive,
+  then re-assembled with a boundary marker and re-hydrated file/plan/tool attachments.
+- **Tools:** conversation compaction uses **none** (denied at runtime, forbidden in prompt);
+  the two *memory-file* compressions (session-memory condense, dream prune) **do** use
+  `Edit`/`Write` because they rewrite files.

--- a/docs/plans/claude-code-message-representation.md
+++ b/docs/plans/claude-code-message-representation.md
@@ -1,0 +1,244 @@
+# Claude Code: what the model actually sees in past turns
+
+How Claude Code serializes prior agent turns — reasoning + interleaved tool calls + results —
+into the message history it re-sends on every request. Answers: *a turn is a list of steps
+(reasoning → tool calls → reasoning…); what does that look like in the payload, and how are
+tool inputs/outputs represented and truncated?*
+
+Builds on the existing analyses in the leak's `claude-code-analysis/` (`streaming-events`,
+`tools`, `file-related-tools`). Code cites `~/workspace/leak-claude-code/`.
+
+## TL;DR — the mental model
+
+1. **A turn is one assistant message whose `content` is an ordered list of blocks**:
+   `thinking` / `text` / `tool_use` — in the exact order the model emitted them. "Reasoning →
+   multiple tool calls → reasoning" is just that block list; parallel/interleaved calls are
+   several `tool_use` blocks in the same array.
+2. **The role boundary splits a step from its result.** `tool_use` blocks ride the **assistant**
+   message; the matching `tool_result` blocks ride the **next user** message. So a multi-step
+   trajectory is `assistant[…tool_use×N] → user[tool_result×N] → assistant[…] → …`.
+3. **The model does NOT see the tool's rich output object.** It sees a **rendered, truncated,
+   wrapped string** (`mapToolResultToToolResultBlockParam`), which differs from both the tool's
+   internal `Output` object *and* what the human sees in the UI.
+4. **Prior thinking is preserved** (with its signature) and re-sent — with four narrow exceptions.
+5. Everything runs through `normalizeMessagesForAPI` (`utils/messages.ts:1989`), which
+   **re-merges** the turn that streaming split apart, then a fixed chain of integrity/strip passes.
+
+## A worked example — what one turn looks like on the wire
+
+A turn where the model thinks, calls two tools, then (next request) continues:
+
+```jsonc
+// assistant message (one message.id, blocks in emission order)
+{ "role": "assistant", "content": [
+    { "type": "thinking", "thinking": "I need to check the config and run tests.",
+      "signature": "…" },                         // ← preserved across turns
+    { "type": "text", "text": "Let me check two things." },
+    { "type": "tool_use", "id": "toolu_A", "name": "Read",
+      "input": { "file_path": "/app/config.ts" } },   // ← full input JSON
+    { "type": "tool_use", "id": "toolu_B", "name": "Bash",
+      "input": { "command": "npm test" } }
+] }
+// next user message — results, hoisted to the front, one per tool_use id
+{ "role": "user", "content": [
+    { "type": "tool_result", "tool_use_id": "toolu_A",
+      "content": "     1→export const PORT = 3000\n     2→…" },   // rendered+truncated
+    { "type": "tool_result", "tool_use_id": "toolu_B", "is_error": false,
+      "content": "<persisted-output>\nOutput too large (412.0KB). Full output saved to: …/toolu_B.txt\n\nPreview (first 2.0KB):\n…\n...\n</persisted-output>" }
+] }
+```
+
+Note the two tool_results share **one** user message (parallel batch), results come **before**
+any text sibling, and the big output is a **preview + disk path**, not the full 412KB.
+
+## 1. Why there's a merge step: streaming splits the turn, normalize rejoins it
+
+During streaming (`services/api/claude.ts`; see your `streaming-events` analysis) each content
+block is emitted as a **separate `AssistantMessage` sharing one `message.id`**.
+`normalizeMessages` (`utils/messages.ts:741`) then deliberately **splits** any multi-block
+message into one-block messages. So mid-pipeline a turn is N fragments.
+
+`normalizeMessagesForAPI` (`:1989`) **re-merges** them: for each assistant fragment it walks
+*backwards* and, on finding an assistant with the same `message.id`, concatenates content
+(`mergeAssistantMessages`, `:2389` — pure `[...a.content, ...b.content]`):
+
+```
+2250  for (let i = result.length - 1; i >= 0; i--) {
+        if (msg.type === 'assistant' && msg.message.id === normalizedMessage.message.id) {
+          result[i] = mergeAssistantMessages(msg, normalizedMessage); return }
+        // skip different-id assistants (teammate streams) and interleaved tool_result users
+      }
+```
+
+Because streaming order is preserved, `[thinking, text, tool_use, tool_use]` is reconstructed
+intact — **this is what makes interleaved reasoning-between-tool-calls faithful.** The backward
+walk steps *over* the interleaved `tool_result` user messages and different-id fragments so the
+right id's blocks reunite.
+
+The tail of `normalizeMessagesForAPI` is a fixed pass sequence (`:2295-2369`): relocate tool-ref
+siblings → filter orphaned thinking-only → strip trailing thinking from the last assistant →
+drop whitespace-only assistants → ensure non-empty content → merge adjacent user messages →
+sanitize error tool_results → append snip tags → validate images. Then in `claude.ts`:
+`ensureToolResultPairing` (`:1301`), strip advisor blocks, and drop media beyond
+`API_MAX_MEDIA_PER_REQUEST` (100, oldest-first).
+
+## 2. Tool INPUTS in history — full JSON, minus injected fields
+
+A `tool_use.input` is re-sent as the **full JSON object** — not truncated — but passed through
+`normalizeToolInputForAPI(tool, input)` (`utils/api.ts:685`) which strips *synthetic* fields the
+runtime injected but the API schema doesn't want:
+
+- **ExitPlanMode**: strips `plan` / `planFilePath`.
+- **FileEdit**: strips synthetic `old_string`/`new_string`/`replace_all` from *old resumed
+  transcripts* — *"so old --resume'd transcripts don't send whole-file copies to the API."*
+- When tool-search is off, the block is rebuilt with only `{type,id,name,input}`, dropping a
+  stored `caller` field; tool name is canonicalized to the registered tool's name.
+
+So: inputs are faithful and complete; only runtime-injected metadata is removed.
+
+## 3. Tool OUTPUTS in history — the crux (four size mechanisms)
+
+The model never sees the tool's structured `Output` object (the `{stdout, structuredPatch,
+gitDiff, originalFile, …}` shapes in your `file-related-tools` analysis). It sees a string built
+by **`mapToolResultToToolResultBlockParam(Output)`** (`Tool.ts:557`) — the *model-facing*
+serialization, explicitly distinct from `renderToolResultMessage` (the UI's React render,
+`Tool.ts:566`). Four independent size mechanisms apply, in order:
+
+**(a) Per-tool self-truncation** (before it's even a result).
+- **Bash** truncates to `getMaxOutputLength()` — default **30,000** chars, env-overridable to
+  **150,000** (`shell/outputLimits.ts:3-4`). Marker: `\n\n... [N lines truncated] ...`
+  (`BashTool/utils.ts:158`).
+- **FileRead** caps at `MAX_LINES_TO_READ = 2000` (`FileReadTool/prompt.ts:10`).
+
+**(b) Result construction** — `mapToolResultToToolResultBlockParam`. Bash joins
+`stdout+stderr+backgroundInfo`, sets `is_error: interrupted`, trims blanks. FileRead prepends a
+freshness line, adds line numbers, and appends a `CYBER_RISK_MITIGATION_REMINDER` system-reminder
+— all **model-only** chrome the UI never shows.
+
+**(c) Large output → persist to disk, leave a preview + path** (the big one).
+Threshold = `min(tool.maxResultSizeChars, DEFAULT_MAX_RESULT_SIZE_CHARS)` where
+`DEFAULT_MAX_RESULT_SIZE_CHARS = 50_000` (`constants/toolLimits.ts:13`). Over threshold →
+`persistToolResult` writes the full content to
+`<projectDir>/<sessionId>/tool-results/<tool_use_id>.{txt|json}`, and the model-visible content
+becomes (`toolResultStorage.ts:189`):
+
+```
+<persisted-output>
+Output too large (412.0KB). Full output saved to: /…/toolu_B.txt
+
+Preview (first 2.0KB):
+<first 2000 bytes, cut at a newline>
+...
+</persisted-output>
+```
+
+`PREVIEW_SIZE_BYTES = 2000`. **FileRead opts out** (`maxResultSizeChars: Infinity`) — persisting
+a file it would just Read back is circular. Images and already-compacted content also skip it.
+
+**(d) Per-message aggregate budget.** The **sum** of tool_result sizes in one wire user message
+(a parallel batch) is capped at `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS = 200_000`
+(`toolLimits.ts:49`); the largest fresh results are persisted-to-disk until under budget.
+Decisions are **frozen per `tool_use_id`** so re-sends stay byte-identical (prompt-cache safety).
+
+**Empty output** becomes `(<toolName> completed with no output)` (`toolResultStorage.ts:293`) —
+because an empty tool_result at the prompt tail makes some models emit a stop sequence and end
+the turn.
+
+## 4. Thinking / reasoning across turns
+
+**Prior-turn thinking blocks are preserved and re-sent, with their `signature`, by default.**
+There is no general "strip thinking from history" pass. Removal happens in exactly four cases:
+
+1. **Trailing thinking on the *last* assistant only** — the API forbids an assistant message
+   ending in thinking, so trailing thinking blocks are sliced (`filterTrailingThinkingFromLastAssistant`,
+   `:4781`); an all-thinking message becomes `[{type:'text', text:'[No message content]'}]`.
+2. **Orphaned thinking-only fragments** — dropped only if no same-`message.id` sibling has
+   non-thinking content (else the merge in §1 rejoins them).
+3. **Credential change** (`/login`) — `stripSignatureBlocks` (`:5066`) removes all
+   thinking/redacted_thinking because *"their signatures are bound to the API key that generated
+   them; after a credential change they're invalid and the API rejects them with a 400."*
+4. **Compaction** slicing (which case 2 repairs).
+
+The `signature` rides verbatim inside the thinking block and is never stripped on the normal
+path. Token estimation counts only `block.thinking` text, "not the JSON wrapper or signature."
+Interleaved thinking (before/between tool calls in one turn) is preserved precisely because the
+merge concatenates same-id blocks in emission order (§1).
+
+## 5. Pairing & integrity rules (why trajectories stay valid)
+
+`ensureToolResultPairing` (`:5133`, run after normalize) enforces the API's tool-trajectory
+contract:
+
+- **Every `tool_use` needs a `tool_result`.** Missing → a synthetic error block
+  `[Tool result missing due to internal error]` (`is_error:true`) is inserted.
+- **Orphaned `tool_result`s** (no matching `tool_use`, e.g. resume mid-turn) are stripped.
+- **Dedup by id** — duplicate `tool_use` ids in a later assistant, and duplicate `tool_result`s
+  for one id, are removed ("tool_use ids must be unique").
+- **Ordering/role** — tool_results ride user messages and are **hoisted to the front**
+  (`hoistToolResults`, `:2470`) so they precede text ("tool result must follow tool use");
+  parallel results merge into one user message.
+- **Empty-content placeholders** keep role alternation valid: `[Tool use interrupted]`,
+  `(no content)` (`NO_CONTENT_MESSAGE`).
+
+## 6. How past tool outputs get trimmed *later* (microcompaction)
+
+Independent of compaction, old tool *outputs* are cleared in place as the session ages
+(`services/compact/microCompact.ts`). Only `COMPACTABLE_TOOLS` (Read/shell/Grep/Glob/WebSearch/
+WebFetch/Edit/Write). **Time-based**: when the gap since the last assistant exceeds a threshold
+(server cache already cold), keep the last N compactable results, **replace the rest's content**
+with `[Old tool result content cleared]`. **Cached** (API cache-editing): deletes old results
+server-side without mutating local content, preserving the cached prefix. So a past tool_result's
+content evolves: full → preview+path → `[Old tool result content cleared]`, while its
+`tool_use`/`tool_result` skeleton stays.
+
+## 7. Model-sees ≠ UI-shows (and ≠ the tool's Output object) — the divergences
+
+- **Two render paths**: model = `mapToolResultToToolResultBlockParam` (string, with
+  system-reminders + persisted-output wrappers); UI = `renderToolResultMessage` (React, from the
+  raw `Output`). Explicitly documented as diverging (`Tool.ts:582-588`).
+- **Persisted large outputs**: model gets the `<persisted-output>` preview; UI shows full stdout.
+- **Injected chrome**: FileRead's `CYBER_RISK_MITIGATION_REMINDER` + freshness/line-numbers,
+  `(no output)` placeholders, `[id:xxx]` snip tags, and `Tool loaded.` turn-boundary text are all
+  **model-only**.
+- **"Don't tell the user" meta notes** (`isMeta:true`) — truncation/file-modified notes only the
+  model sees.
+- **Role reassignment**: local-command output is re-injected as a *user* message so the model can
+  reference it.
+
+## Constants quick-reference
+
+| Constant | Value | Location |
+|---|---|---|
+| `DEFAULT_MAX_RESULT_SIZE_CHARS` | `50_000` | constants/toolLimits.ts:13 |
+| `MAX_TOOL_RESULT_TOKENS` / `_BYTES` | `100_000` / `400_000` | toolLimits.ts:22,33 |
+| `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS` | `200_000` | toolLimits.ts:49 |
+| `PREVIEW_SIZE_BYTES` | `2000` | toolResultStorage.ts:109 |
+| `PERSISTED_OUTPUT_TAG` | `<persisted-output>` | toolResultStorage.ts:30 |
+| cleared-result marker | `[Old tool result content cleared]` | microCompact.ts:36 |
+| Bash output cap (default/max) | `30_000` / `150_000` | shell/outputLimits.ts:3-4 |
+| Bash truncation marker | `\n\n... [N lines truncated] ...` | BashTool/utils.ts:158 |
+| `MAX_LINES_TO_READ` (FileRead) | `2000` | FileReadTool/prompt.ts:10 |
+| missing-result placeholder | `[Tool result missing due to internal error]` | messages.ts:246 |
+| empty-result placeholder | `(<toolName> completed with no output)` | toolResultStorage.ts:293 |
+| API media cap / request | `100` (oldest dropped) | claude.ts:1312 |
+
+## Implications for the Dim0 board agent
+
+The board agent runs its own browser tool-loop (`features/agent/engine/`), so it faces the same
+questions. What to copy:
+
+1. **Persist the turn as an ordered block list** (thinking/text/tool_use), with tool_use on the
+   assistant turn and tool_result on the next user turn — don't flatten steps into prose. This is
+   what lets the model reason over its own prior trajectory.
+2. **Render tool outputs for the model separately from the UI**, and **cap + preview large
+   outputs** rather than dumping them — for a canvas agent the analogues are big search results,
+   fetched pages, code-run output, doc chunks. A `[too large — N items, showing first K]` preview
+   with a way to re-fetch beats flooding context.
+3. **Keep tool_use/tool_result pairing strict** — every emitted call needs a result (synthesize
+   an error result if a tool fails) or the provider will reject the trajectory. (We already have
+   the `ToolFailure` contract per ADR-AGENT-002 — this is the same discipline at the history
+   level.)
+4. **Byte-stable re-sends** — freeze truncation/preview decisions per tool-call id so replays
+   don't churn (matters for any prompt caching we use via the `/ai/llm` proxy).
+5. **Trim old tool outputs as the session ages** (the microcompaction pattern) before doing a
+   full transcript compaction — cheapest-first, same as the compaction ladder we documented.

--- a/docs/plans/context-update-mechanisms.md
+++ b/docs/plans/context-update-mechanisms.md
@@ -1,0 +1,147 @@
+# Context & memory update mechanisms — trigger model for Dim0
+
+*When* (not what) the agent's context/memory gets built, refreshed, consolidated, and compacted.
+Companion to `dim0-agent-context-review.md` (which covers the *what*) and
+`synthesis-agent-memory.md`. The thesis: **Dim0 needs no scheduler/cron** — every update hangs off
+a natural boundary or point-of-use, gated so the expensive (LLM) work is rare.
+
+## Principle (read this first)
+
+> **Recompute-on-demand for anything free; turn-boundary-gated for anything that costs an LLM call;
+> lazy-on-overflow / on-read for cleanup. Nothing runs on a wall clock.**
+
+Work only happens when the user is *active* (turn boundary), goes *idle*, or the data is *actually
+needed* (session open / read / window-full). This is strictly cheaper than a cron, needs no
+scheduler infrastructure (a real cron in a browser means a service worker or a tab-only
+`setInterval` — flaky and wasteful), and matches how the reference systems actually work.
+
+## Premise correction: the reference systems are NOT cron-based
+
+A common misread (we made it too): that Claude Code / Hermes run "nightly" consolidation on a
+schedule. They don't. What looks like "nightly" is a **rate-limit gate**, not a scheduler.
+
+| System | Update | Real trigger | Why it's not a cron |
+|---|---|---|---|
+| **Claude Code** | autoDream (distill memory) | **stop hook at end of every turn**, then gated: skip unless ≥24h *and* ≥5 sessions since last, PID lock | piggybacks on turn-end; 24h is a floor, no daemon |
+| CC | extractMemories (write-back) | **end of query loop** (final response), throttled every N turns, stands down if main agent already wrote | turn-boundary hook |
+| CC | session memory (rolling notes) | **post-sampling hook** per turn, gated on token-growth + tool-count | turn-boundary hook |
+| CC | compaction | **inline** at token threshold | event-driven by necessity |
+| **Hermes** | background review (memory + skills) | **post-turn fork**, turn-count nudge (every 10) | turn-boundary hook |
+| Hermes | Curator (skill lifecycle) | **idle-triggered** when idle + interval elapsed — *"no cron daemon"* (stated) | opportunistic on idle |
+| Hermes | compaction | inline at 50% threshold + 85% gateway safety net | event-driven |
+| **mem0** | memory update | **inline, additive, on every `add()`** — one LLM call, deterministic dedup | no separate pass at all |
+
+The invariant across all three: **cheap check at a natural boundary + a gate that makes the
+expensive work rare.** Never a wall clock.
+
+## The trigger design space (our menu)
+
+Cheapest → most machinery. The decisive split is **no-LLM work (just recompute)** vs **LLM work
+(gate it hard)**.
+
+| # | Option | Fires when | Cost | Fits |
+|---|---|---|---|---|
+| A | **On-demand compute** | data is needed (session open) | **0 LLM** — read the scene | live board snapshot |
+| B | **Inline additive** | during the turn, via a tool the agent calls | folds into the turn (0 extra calls) | global memory writes |
+| C | **Turn-boundary hook + gate** | end of turn, if a cheap threshold trips | 1 small-model call, *rarely* | conversation context, extraction |
+| D | **Idle-triggered** | user stops interacting for X | deferred, off critical path | heavy consolidation (if ever) |
+| E | **Lazy-on-overflow** | a store hits its cap | 0 until full | memory pruning |
+| F | **Lazy-on-read** | read + found stale | paid at point of use | board purpose summary |
+| G | **Explicit** | user clicks / slash command | 0 automatic | escape hatch — always offer |
+| H | **Inline threshold compaction** | context window fills | unavoidable | conversation compression |
+
+We already run this pattern in-tree: **`DescribeBoard`** (`local/describe-board.ts`) fires at
+end-of-turn, gated ("only if still untitled"), best-effort — options C/F exactly. We *extend that
+precedent*, we don't add a scheduler.
+
+## Recommendation per update target
+
+### 1. Board snapshot (structure / inventory) → **A. On-demand compute. No consolidation.**
+A pure function over the canvas store (node counts by type, titles, selection, folder layer),
+recomputed each session open (and optionally refreshed within a session on material change).
+**Zero LLM, always fresh.** The key realization: the always-fresh part of board context needs *no
+pass whatsoever* — it's `gitStatus`, not memory. Also exposable as a `get_board_overview` tool for
+the pull path.
+
+### 2. Board purpose / summary → **F + C.**
+Derive once via the DescribeBoard pass (already end-of-turn); re-derive **lazily** only when it's
+read *and* a cheap deterministic drift check says the board changed materially since (gates the 1
+LLM call). Best-effort; never blocks a turn.
+
+### 3. Conversation context (rolling thread state) → **C, fused with H.**
+Refresh on a turn-boundary gate (every N turns or on token growth). Critically — the Hermes
+insight — **make it the SAME artifact as the compaction summary**: the rolling thread summary you
+maintain is exactly what you inject when the window fills. One summary serves both roles, so you
+never pay for two. (This also means: if you build conversation context well, compaction is nearly
+free — you already have the checkpoint.)
+
+### 4. Global memory (durable user facts) → **B + E.**
+Additive writes via an explicit `save_memory`/`update_memory` tool the agent calls during the turn
+(no separate pass, no destructive LLM mutation — the mem0 shift we documented). Prune **only on
+overflow** (reject-and-consolidate: reject the over-cap write, show current entries, let the model
+merge/remove and retry) — never on a schedule. Optional later: a turn-boundary extraction fork
+(option C) that stands down if the main agent already wrote (CC's mutual-exclusion).
+
+### 5. Conversation compaction → **H.**
+Inline at a token threshold, like everyone. Event-driven and unavoidable. Reuses the conversation
+context as the summary (see #3).
+
+## Proposed gate specs (starting points — tune with telemetry)
+
+Concrete cheap checks so "gated" isn't hand-wavy. All numbers are initial guesses to be tuned; the
+*shape* matters more than the values.
+
+- **Board snapshot recompute (A):** on session open, always. Within a session, recompute only if
+  the scene's node/edge count changed by ≥ `SNAPSHOT_DIRTY_DELTA` (e.g. 3) since last compute —
+  otherwise reuse the memoized snapshot (cache-stable, like CC's memoized `getSystemContext`).
+- **Board drift check for purpose re-derive (F):** a deterministic, no-LLM signal — e.g.
+  `nodesChangedSinceDerive ≥ BOARD_DRIFT_NODES` (e.g. 10) **or** `titleStillDefault` **or**
+  `≥ BOARD_DRIFT_DAYS` (e.g. 7) since last derive. Only when this trips *and* the context is being
+  read do we spend the LLM call. Store `lastDerivedAt` + a cheap fingerprint (node count / hash)
+  on `BoardMeta`.
+- **Conversation context refresh (C):** fire the summary pass when, since last refresh, **either**
+  `turnsSinceRefresh ≥ CONV_CTX_TURNS` (e.g. 4) **or** `tokenGrowth ≥ CONV_CTX_TOKENS` (e.g. ~4k)
+  — mirroring CC session memory's "token threshold is always required, tool-count is secondary."
+  Run best-effort in the background after the turn; never block the reply.
+- **Compaction trigger (H):** when estimated prompt tokens ≥ `COMPACT_PCT` of the model's effective
+  window (start ~0.7, per Hermes/CC ballpark), inline before the next call. Circuit-breaker: skip
+  if the last compaction saved < ~10% (CC/Hermes anti-thrash).
+- **Memory overflow (E):** reject an `add` that would exceed the store's char/entry cap; return the
+  current entries; the model consolidates and retries in the same turn (Hermes pattern). Guard:
+  ≤ 3 consolidation retries/turn, then a terminal "answer the user anyway."
+- **Small-model routing:** every gated LLM call (board purpose, conversation context) uses the
+  *cheap/fast* model via `/ai/llm`, not the main model — matches CC/Hermes routing background
+  passes to a small model.
+
+## Cost model (per typical turn under this scheme)
+
+- **Most turns: 0 extra LLM calls.** Board snapshot = recompute (free); global-memory write =
+  the agent's own tool call folded into the turn; conversation context not yet due.
+- **Every ~N turns: 1 small-model call** for conversation context.
+- **Rarely: 1 small-model call** for board purpose (only on drift + read).
+- **At genuine boundaries only:** the compaction call (window full).
+
+Contrast a cron: a scheduled pass burns a call (and wakes infra) *whether or not anything changed*.
+The gated model burns a call only when something changed enough to matter.
+
+## Where this wires in (seams, from the review)
+
+- All triggers hang off the existing submit path `local/use-local-submit-prompt.ts` (turn start =
+  read/inject; turn end = fire gated background work — the DescribeBoard call already lives here at
+  `:~284`, `maybeAutoLabelBoard`).
+- Board snapshot: pure fn over `ctx.store`, assembled at the system seam (`:200-202`).
+- Board purpose + drift fingerprint: `BoardMeta` (`board/model/index.ts`) via `BoardRegistry`.
+- Conversation context: `LocalChat.context` (`types/chat.ts`) via `ChatRepo.saveTranscript`.
+- Global memory + overflow: the new `MemoryRepo` (`agent-context-memory.md`).
+- Compaction: in the loop / history assembly (`chat-history.ts`), reusing conversation context.
+
+## Open questions to settle with the plan
+
+1. Exact gate thresholds (the constants above) — pick starting values, add telemetry, tune.
+2. Idle-trigger (option D): do we want it at all for v1, or is turn-boundary + lazy enough? (Lean:
+   skip D for v1 — turn-boundary + lazy covers everything without needing an idle timer.)
+3. Where "background after the turn" actually runs in the browser — a microtask after the stream
+   completes vs a `requestIdleCallback`. (Lean: fire-and-forget after `done`, like DescribeBoard.)
+4. Cross-device: for synced boards, does a background-derived board context get backed up (opaque
+   blob, per ADR-AGENT-001) or recomputed per device? (Lean: recompute per device for the snapshot;
+   back up the derived purpose/summary.)

--- a/docs/plans/dim0-agent-context-review.md
+++ b/docs/plans/dim0-agent-context-review.md
@@ -1,0 +1,236 @@
+# Dim0 agent context & message-representation — current-state review
+
+A code review of the Dim0 browser agent (`webui/src/features/agent/`) for the two tasks we
+scoped, grounded in the memory/context research (`inspiration-*`, `synthesis-agent-memory.md`).
+For each task: **what exists today → the gaps → the seams to build on.** This is diagnostic; the
+implementation plan is the next step.
+
+## Scope model (the vocabulary these tasks assume)
+
+Three nested scopes (from the earlier discussion), plus the cross-cutting memory:
+
+- **Board** = the workspace / "project" scope — spans all conversations on the board. In Dim0 the
+  board is effectively the *largest* scope for a local/anonymous user (no account = no true
+  cross-board global).
+- **Conversation** (a chat thread on a board) = the "session" — holds one transcript, resumable.
+- **Turn** = one user message → the agent's multi-step reasoning+tool response.
+- **Global memory** = user/account scope, cutting across boards (needs an account; device-local
+  for anonymous).
+
+The two tasks map onto this cleanly:
+- **Task 1** = introduce **board context** (board scope) + **conversation context** (conversation
+  scope) + **global memory** (user scope), and the mechanisms that keep them updated.
+- **Task 2** = fix how a **turn** is represented in history (the chain-of-thought the model
+  re-reads, and what the user sees).
+
+---
+
+# Task 1 — Board context, conversation context, global memory
+
+## Current state
+
+The agent is invoked from `local/use-local-submit-prompt.ts`, which builds the message array
+`[system, ...history, {user}]` (`agent-loop.ts:155-158`). Of the three, only pieces exist:
+
+- **`system`** = `planSystemPrompt(now)` (`use-local-submit-prompt.ts:171`) — the *static*
+  `plan-system.md` (role/format/tools guide), with **only `{{time}}` interpolated**. The one
+  runtime augmentation is `systemWithDocs` (`:200-202`), which appends a doc-grounding note when
+  the board has indexed document chunks. **No board title, node inventory, purpose, or
+  conversation context is injected — ever.**
+- **`history`** = `toLlmHistory(messages, 16)` — last 16 user/assistant turns (see Task 2).
+- **`userMessage`** = `wrapWithMessageContext(prompt, messageContext)` — a `<MessageContext>`
+  envelope carrying the *selected notes / active surface* text (cap 12K chars), only when the user
+  has something selected.
+
+So the agent's *only* board awareness is: (a) the optional per-turn selection envelope, and
+(b) **pull-only** tool access to the live scene (`ctx.store`, `ctx.search`). There is **no tool
+that inventories the board** — it can `search_notes` or `get_note(id)` but cannot enumerate,
+count, or see the board's shape/title. It genuinely does not know what board it's on.
+
+What's latent and reusable:
+- **`DescribeBoard`** (`local/describe-board.ts`) already runs a background LLM pass that derives a
+  board **title** from the first conversation and writes it to `BoardMeta.title`. This is the exact
+  pattern (background derive → persist → inject) that board/conversation context need — it just
+  produces one field today. Its prompt even frames a board as *"a project or workspace label,
+  broader than a single conversation"* — our scope split, already articulated.
+
+Storage homes (both currently thin):
+- **`BoardMeta`** (`board/model/index.ts:154`) = `{id, title, kind, …}` — **only `title`** is
+  descriptive; no `description`/`topic`/`summary`/`context`. (Caveat: for *synced* boards
+  `BoardMeta` is server-authoritative and not CRDT-synced — a synced board-context field needs its
+  own sync story or stays local.)
+- **`LocalChat`** (`types/chat.ts:51`) = `{id, boardId, label?, createdAt, updatedAt, deletedAt?}`
+  — **only `label`**; no summary/context/metadata blob.
+- **Global memory** — **nothing exists.** No store, no scope, no retrieval.
+
+## The gaps
+
+1. **No board context.** The agent can't see the board's purpose, size, structure, or title
+   without spending tool calls, and can't enumerate it at all.
+2. **No conversation context.** Cross-turn continuity relies entirely on replaying raw history
+   (16-turn window); there's no rolling summary/state of the thread.
+3. **No global/user memory.** No durable cross-board facts (preferences, who the user is).
+4. **No update mechanism** for any of the above beyond the one-shot title labeler.
+
+## The three new pieces + their update mechanisms
+
+Mapping to the research (`synthesis-agent-memory.md`): board context ≈ project/workspace context
+(CC's CLAUDE.md + workspace snapshot; Hermes' `MEMORY.md`), conversation context ≈ session memory
+(Hermes' `summary.md`), global memory ≈ user memory (USER.md / mem0 `user_id`).
+
+| Piece | Scope | What it holds | Update mechanism | Storage home |
+|---|---|---|---|---|
+| **Board context** | board | purpose of the board + a curated/live overview of its structure & key content | (a) **derive** via a DescribeBoard-style background pass; (b) **user-editable**; (c) a **live snapshot** part regenerated per session (node inventory/counts/layer) | new `context`/`description` on `BoardMeta` + a computed snapshot |
+| **Conversation context** | conversation | rolling "what this thread is doing / decided / current state" | incremental/background summary (session-memory style), refreshed every N turns | new `context` field on `LocalChat` |
+| **Global memory** | user | durable cross-board facts (preferences, role, corrections) | additive extraction + explicit `save`/`update` tool (mem0-style, per the memory design doc) | **new memory store** (front-end-first, per `agent-context-memory.md`) |
+
+Note the board-context split (per the harnesses): a **static** part (purpose + curated overview,
+stable across the session, cache-friendly) and a **live snapshot** part (current node
+inventory/selection/layer — "point-in-time, re-check before acting"). The snapshot is nearly free
+and also fills the "can't enumerate the board" gap.
+
+## The seams (where each slots in)
+
+- **Injection (all three):** the `systemWithDocs` append in `use-local-submit-prompt.ts:200-202`
+  is the proven pattern — assemble board context + conversation context (+ retrieved global memory)
+  there and append to the system string. Cleaner still: add `{{boardContext}}` /
+  `{{conversationContext}}` placeholders to `plan-system.md` via `renderPrompt`
+  (`prompts/index.ts`) under a new `## BOARD` / `## CONVERSATION` section. Keep these in the
+  *system* message (not the per-turn `<MessageContext>` envelope) so they aren't re-replayed into
+  history compaction.
+- **Board context derive/persist:** extend `describe-board.ts`'s background pass to also emit a
+  board context/summary; persist on `BoardMeta` via `BoardRegistry` (`board-registry.ts`), fetched
+  at submit time with the `getLocalStores().boards.getBoard(boardId)` call the labeler already
+  makes.
+- **Board snapshot (live):** a small pure function over `ctx.store` (node counts by type, titles,
+  selection, `rootId`), assembled at submit time — no persistence. Also worth exposing as a
+  `get_board_overview` tool for the pull path.
+- **Conversation context:** new `context` field on `LocalChat` (`types/chat.ts:51`) →
+  `ChatRepo.saveTranscript` (`chat-repo.ts:54-76`) → loaded via `useLocalMessagesStore`; refreshed
+  by a background summary pass (analogous to DescribeBoard, but per-chat and recurring).
+- **Global memory:** the new store from `agent-context-memory.md` (front-end-first via the
+  `StorageEngine` port, a `MemoryRepo` beside `ChatRepo`/`DocRepo`), retrieved per-turn and
+  injected at the same system-assembly seam.
+
+---
+
+# Task 2 — Chain-of-thought / turn representation
+
+## The core finding: two fidelity levels
+
+There are **two different representations of a turn**, and the gap between them is the whole task:
+
+- **Intra-turn (inside one `runAgent`)** — *high fidelity, verbatim.* The live `LlmMessage[]`
+  carries wire-native structure: `{role:"assistant", toolCalls}` then
+  `{role:"tool", content: JSON.stringify(output)}` with the **full, untruncated** tool output
+  (`agent-loop.ts:195-206`). `get_note`/`fetch`/`web_search` return uncapped
+  (`tools.ts:321`, `fetch-url.ts`, only `search_notes` snippet is capped at 600 chars). This is the
+  real chain-of-thought the model reads *during* a run — and it can grow unbounded.
+- **Inter-turn (next user message)** — *lossy re-projection.* `toLlmHistory`
+  (`chat-history.ts:101-106`) drops the `role:"tool"` messages and `assistant.toolCalls` entirely
+  and re-encodes the trace as **XML text inside the assistant's `content`** — `<Reasoning>` with
+  `<ToolCall name><Input><Output></ToolCall>` (`compactReasoning`, `:79`). Worse, `<Output>` is
+  `JSON.stringify` of the already-lossy UI projection (`ToolOutput`), not the verbatim result — a
+  note write stores only `{noteId, label, noteType}` (`agent-event-to-step.ts:53-71`), so
+  **next turn the model cannot re-read the note body it wrote, the page it fetched, or its full
+  search results.** Truncation is a blunt 10K `slice + "..."` (can corrupt mid-JSON), window is 16
+  messages.
+
+So mid-run the model has rich structured context; on the *next* turn it re-reads a weak XML
+summary. Task 2 is closing that gap.
+
+## The stored model (what backs both the UI and the round-trip)
+
+`ChatMessage.properties.reasoning.reasoning: ReasoningStep[]` (`types/chat.ts`, `types/stream.ts`)
+— an **ordered** step list: `ToolCallStep` (name + args + a *projected* `output` + `state`) and
+`ReasoningTextStep` (`message` = answer text, `reasoning`/`thought` = a "thought" slot).
+`AgentEvent`s are accumulated into this via `stepsFromEvents` (`agent-event-to-step.ts:112-163`),
+preserving order. The whole `ChatMessage[]` (incl. steps) is what's persisted and also PUT
+verbatim as the **opaque transcript backup** (`api/chat-transcript.ts`) on synced boards.
+
+**Good news:** the ordered-step structure already exists and is faithful to intra-turn order — the
+scaffolding for a proper CoT is there.
+
+## The gaps
+
+**Model-facing (what it re-reads next turn):**
+1. **The browser engine doesn't capture reasoning** (but the model + UI already exist — see note).
+   `stream-assemble.ts`/`managed-client.ts`/`byok-client.ts` parse only `content` + `tool_calls`
+   and **drop the provider reasoning channel** (Claude thinking, o-series/OpenRouter
+   `reasoning_content`). `LlmMessage`/`AgentEvent`/`LlmStreamEvent` have no reasoning slot, so
+   `runAgent`'s `ReasoningTextStep.reasoning` / `ToolCallStep.thought` are always `""`.
+   > **Correction / not-from-scratch:** the reasoning *model, normalization, and UI are already
+   > built* — from the legacy/backend runtime. `ReasoningTextStep { reasoning, message, isSynthesis }`
+   > (`types/stream.ts:61`), the two-channel `stream_reasoning_message` split (`build.ts:276`:
+   > `reasoningBuf` vs `messageBuf`), the `<|F…|>` marker parser (`utils/stream/text.ts`), and
+   > `normalizeReasoningSteps` + `reasoning-step-row.tsx`/`tool-step-row.tsx` all exist and are
+   > populated **for backend turns** (`api/send-message.ts`, `api/list-messages.ts`). The browser
+   > engine reuses the same model + UI but never feeds them. So the work is **wiring the browser
+   > engine's provider reasoning into the existing `reasoning` slot**, not building reasoning
+   > capture.
+2. **Inter-turn history is lossy** — full tool outputs are never stored on the step, so the model
+   loses access to what tools actually returned (§ two fidelity levels).
+3. **History flattens wire structure into XML** in one `content` string instead of native
+   `assistant(toolCalls)` + `tool` messages — forfeits provider-native tool linkage and any
+   provider-side reasoning/prompt caching across turns.
+4. **Truncation is blunt** (10K `slice`) and the window (16 msgs) drops older context wholesale;
+   no smart preview/summarization.
+5. **Intra-run tool output is uncapped** → unbounded context growth in long multi-step turns
+   (`agent-loop.ts:206`).
+
+**User-facing (what they see):**
+6. **No visible chain of thought.** The reasoning/thought UI already exists —
+   `ReasoningStepRow`'s "Reasoning" expander, `ToolStepRow`'s "Thought" block
+   (`reasoning-step-row.tsx`, `tool-step-row.tsx`) — but is **dead for local turns** because the
+   slots are never filled.
+7. **Tool results render minimally** — args + a one-line status + ids; note cards show a link but
+   **no content preview**; raw output only for code-interpreter/web sources.
+
+## The seams
+
+- **Capture reasoning:** add a `reasoning` channel through `stream-assemble.ts` (parse
+  `delta.reasoning`/`reasoning_content`) → a new `LlmStreamEvent`/`AgentEvent` reasoning variant →
+  fill `ReasoningStep.reasoning`/`thought`. Lights up the *existing* UI expanders immediately
+  (gap 6) and lets reasoning be re-fed (gap 1). Mind the CC lesson: thinking blocks carry
+  provider **signatures** and have re-send constraints — decide per provider whether to re-feed or
+  display-only.
+- **Structured round-trip:** change `toLlmHistory` (`chat-history.ts`) to emit native
+  `assistant{toolCalls}` + `tool` messages instead of `<Reasoning>` XML — or, keep XML but stop
+  discarding fidelity. Store enough of the real tool output on the step (not just ids) to re-feed,
+  with a **preview + truncation** discipline borrowed from Claude Code (see
+  `claude-code-message-representation.md`): render tool output for the model separately, cap large
+  outputs to a preview + a "N more / re-fetch" affordance, freeze truncation per call id for
+  byte-stable re-sends.
+- **Cap intra-run output + age it:** apply per-tool output caps (esp. `fetch`/`web_search`/
+  `get_note`), and add a microcompaction-style trim of old tool outputs before any full history
+  compaction (the "cheapest-first" ladder).
+- **Backup compatibility:** any step-schema change must stay backward-compatible on load
+  (`chat-persist.ts:20-27` already normalizes old steps) since the opaque transcript backup carries
+  this shape verbatim.
+
+---
+
+# How the two tasks relate
+
+- **Shared seam:** both inject at the system-assembly point in `use-local-submit-prompt.ts`
+  (`systemWithDocs` pattern). Task 1 adds standing context there; Task 2 changes how `history`
+  (also assembled there) is built.
+- **Shared model:** conversation context (Task 1) and the transcript representation (Task 2) both
+  live on the conversation — conversation context is the *summary* of the thread; Task 2 is the
+  *fidelity* of the thread's turns. They're complementary: better per-turn representation reduces
+  how much conversation context has to compensate, and vice-versa.
+- **Shared discipline (from the research):** fence recalled/injected content, keep the system
+  prefix cache-stable (standing context in `system`, per-turn recall separate), and represent a
+  turn as an ordered reasoning+tool step list — all apply to both.
+
+# Suggested sequencing (for the plan doc)
+
+1. **Board snapshot (live)** — pure function over `ctx.store`, injected at the system seam. Pure
+   win, no persistence, fixes the "can't enumerate the board" gap immediately. (Task 1)
+2. **Reasoning capture** — parse the provider reasoning channel; lights up existing UI + enables
+   re-feed. High visible value, contained blast radius. (Task 2)
+3. **Board context + conversation context fields** + the DescribeBoard-style derive passes. (Task 1)
+4. **Structured/higher-fidelity history round-trip** + tool-output preview/caps. (Task 2)
+5. **Global memory store** — per `agent-context-memory.md`. (Task 1)
+
+Each step is independently shippable and independently valuable.

--- a/docs/plans/inspiration-claude-code-memory.md
+++ b/docs/plans/inspiration-claude-code-memory.md
@@ -1,0 +1,324 @@
+# Inspiration: how Claude Code solves memory & context
+
+A study of the leaked Claude Code source (`~/workspace/leak-claude-code/`), written to
+inform our own board-agent memory design (`agent-context-memory.md`). This is a
+*reference* — it explains mechanisms, quotes the load-bearing prompts, and ends with the
+transferable principles. File paths cite the leak; verify before relying on a detail.
+
+## TL;DR — it's not one system, it's five
+
+The single biggest lesson: Claude Code does **not** have "a memory feature." It has five
+distinct subsystems operating at different time horizons and granularities, each with its
+own store, trigger, and prompt. Conflating them is the mistake.
+
+| # | Subsystem | Horizon | Store | Purpose |
+|---|---|---|---|---|
+| 1 | **Persistent memory (memdir)** | across sessions, forever | `~/.claude/projects/<repo>/memory/*.md` | durable facts about the user & project |
+| 2 | **CLAUDE.md tree** | across sessions (human-authored) | files in the repo tree | rules/conventions the human curates |
+| 3 | **Session memory** | one session | `<session>/session-memory/summary.md` | rolling structured notes → cheap compaction |
+| 4 | **Compaction + microcompact** | within a session, on demand | (transforms the message array) | keep the context window from overflowing |
+| 5 | **Dream (assistant mode)** | nightly | daily logs → distilled topic files | turn an append-only log into curated memory |
+
+Two axes separate them: **auto-derived vs curated** (compaction/snapshot are derived and
+lossy; memdir/CLAUDE.md are curated and durable), and **static vs per-turn** (CLAUDE.md is
+assembled once and cached; relevant-memory recall runs every turn).
+
+---
+
+## 1. The assembly model: context is layered, and injected at three sites
+
+Every request is assembled from pieces that land in **three different places** — this
+separation is deliberate and worth copying.
+
+| Payload | Content | Injection site | Cached? |
+|---|---|---|---|
+| Memory **mechanics** | the taxonomy, "how to save", "when to access" — *instructions, no data* | **system prompt** section | session |
+| CLAUDE.md tree + `MEMORY.md` **index** + date | the actual durable content | **first user message**, wrapped in `<system-reminder>` | session |
+| `gitStatus` | branch/status/recent commits snapshot | **system prompt tail** | session |
+| **Relevant memories** (topic files) | retrieved-for-this-query full facts | **mid-turn attachment messages**, `<system-reminder>` wrapped | **per turn** |
+
+Key subtleties:
+
+- **Mechanics are separated from content.** `loadMemoryPrompt()` injects only *how memory
+  works* into the system prompt; the actual `MEMORY.md` bytes ride in the user-context
+  message. This keeps the cacheable system prompt stable while content varies.
+- **The user-context block is fenced and hedged.** It's one `isMeta` user message that ends
+  with: *"IMPORTANT: this context may or may not be relevant to your tasks. You should not
+  respond to this context unless it is highly relevant to your task."*
+- **`gitStatus` is explicitly a snapshot.** *"This is the git status at the start of the
+  conversation. Note that this status is a snapshot in time, and will not update during the
+  conversation."* — it tells the model the freshness contract up front.
+- **Static context is memoized for the whole conversation** (`getSystemContext`,
+  `getUserContext`, `getGitStatus`, `getMemoryFiles` are all `lodash memoize` with a single
+  slot), and explicitly `.cache.clear()`'d on the events that invalidate it (`/compact`,
+  `/clear`, worktree enter/exit, settings sync, the `/memory` editor).
+- **Only recall is per-turn.** `startRelevantMemoryPrefetch` fires *once per user turn*
+  (not per loop iteration — "the prompt is invariant across iterations").
+
+**→ For Dim0:** mirror the split — a small always-on *mechanics* block, an always-on
+*index + board snapshot* block, and *per-turn retrieved* memories as separate attachment
+messages. Memoize the static parts per run; only recall recomputes.
+
+---
+
+## 2. Persistent memory (memdir) — the durable, curated store
+
+This is the closest analogue to what we want for L1/L2. Its design in five parts.
+
+### 2.1 Two-tier storage: an always-loaded index + on-demand fact files
+
+- `MEMORY.md` is an **index**, always in context, hard-capped at **200 lines / 25KB**
+  (truncated with a warning naming which cap fired). Each line is a pointer:
+  `- [Title](file.md) — one-line hook`. *"Never write memory content directly into
+  MEMORY.md."*
+- Each fact is its **own `.md` file** with frontmatter (`name`, `description`, `type`).
+- This is what keeps always-on cost **flat** while the memory grows unbounded. The index is
+  cheap; bodies load only when retrieved.
+
+### 2.2 The closed 4-type taxonomy + the one governing rule
+
+Memories are constrained to four types, and one rule does most of the work:
+
+> **Never save what's derivable from current state.** *"Code patterns, conventions,
+> architecture, file paths, git history, debugging fixes, anything already in CLAUDE.md,
+> ephemeral task state — do NOT save. These can be derived by reading the current project
+> state."*
+
+| Type | Captures | Body structure |
+|---|---|---|
+| `user` | role, expertise, goals, preferences — "who they are, how to be most helpful" | freeform |
+| `feedback` | corrections **and confirmations** of how to work | rule + **Why:** + **How to apply:** |
+| `project` | ongoing work/decisions/incidents not in code or git; convert relative→absolute dates | fact + **Why:** + **How to apply:** |
+| `reference` | pointers to external systems (dashboards, Linear, Slack) | freeform |
+
+Two sharp details in the prompt: save from **success as well as failure** (*"if you only
+save corrections, you will avoid past mistakes but drift away from approaches the user has
+already validated"*), and the explicit-save gate — *"These exclusions apply even when the
+user explicitly asks you to save. If they ask you to save a PR list, ask what was
+*surprising* or *non-obvious* about it — that is the part worth keeping."*
+
+### 2.3 How-to-save, when-to-access, and drift discipline
+
+- **Save is two-step, dedup-first:** write the fact file, then add the index pointer;
+  *"First check if there is an existing memory you can update before writing a new one."*
+- **When to access:** when relevant or asked; and a precise anti-pattern for "ignore
+  memory" — *"proceed as if MEMORY.md were empty. Do not apply remembered facts, cite,
+  compare against, or mention memory content."*
+- **Drift discipline** (eval-tuned into its own section, *"Before recommending from
+  memory"*): a memory naming a file/function/flag is a claim it existed *when written* —
+  *"'The memory says X exists' is not the same as 'X exists now.'"* Verify before
+  recommending; trust what you observe now; update/remove the stale entry.
+
+### 2.4 Retrieval is a cheap LLM side-query — not embeddings
+
+The whole recall path, per turn:
+
+1. `scanMemoryFiles` reads only the **first 30 lines** (frontmatter) of each `.md`, newest
+   first, capped at **200 files**. Builds a manifest: `- [type] filename (ISO-timestamp): description`.
+2. A **Sonnet side-query** (`max_tokens: 256`, JSON-schema output) picks **≤5** files it is
+   *certain* are useful: *"Only include memories that you are certain will be helpful based
+   on their name and description… If you are unsure… do not include it. Be selective."*
+   Nice touch: it de-prioritizes reference docs for tools *already in active use*, but keeps
+   *gotchas/warnings* about them.
+3. Selected files are read (capped 200 lines / 4KB, with a "use Read for the full file"
+   note) and injected as `<system-reminder>` **attachment messages**, each headed with its
+   path + freshness.
+
+**No vector store, no embeddings.** The "index" is literally the markdown pointer list; the
+"retrieval model" is an LLM reading names + descriptions. De-dup and byte-budget
+(`MAX_SESSION_BYTES = 60KB`) are enforced by *scanning prior attachments in the transcript*
+— so compaction naturally resets recall.
+
+### 2.5 Freshness, not decay
+
+Age is computed from file **mtime** and surfaced to the model as **text**, never used to
+expire or down-rank:
+
+> *"This memory is N days old. Memories are point-in-time observations, not live state —
+> claims about code behavior or file:line citations may be outdated. Verify against current
+> code before asserting as fact."* (emitted only for memories > 1 day old)
+
+Rationale in the source: *"Models are poor at date arithmetic — a raw ISO timestamp doesn't
+trigger staleness reasoning the way '47 days ago' does."*
+
+### 2.6 The passive extraction pass
+
+Beyond the model saving memories itself, a **background forked agent** mines each turn:
+
+- **Runs at the end of each query loop** (final response, no tool calls), fire-and-forget.
+- It's a **perfect fork of the main conversation** (same system prompt + prefix → shares the
+  prompt cache), `maxTurns: 5`, tools locked to Read/Grep/Glob + Edit/Write **only inside
+  the memory dir** (read-only Bash, no `rm`, no MCP).
+- **Mutually exclusive with the main agent:** if the main agent already wrote memory this
+  turn, the pass skips. So you get exactly one writer per turn.
+- Efficiency instruction: *"turn 1 — issue all Read calls in parallel; turn 2 — issue all
+  Write/Edit calls in parallel. Do not interleave."* And a hard scope: *"only use content
+  from the last ~N messages… no grepping source files, no git commands."*
+- Dedup/indexing are **prompt-instructed, not code-enforced** (the fork *is* the writer).
+
+### 2.7 Where it lives + team memory
+
+- Path: `~/.claude/projects/<sanitized-canonical-git-root>/memory/`. Keyed on the
+  **canonical git root**, so all worktrees of one repo share one memory dir.
+- **Team memory** = a `team/` subdir, shared across org members on the same GitHub repo,
+  synced over an **HTTP API to Anthropic's backend (not git)**: delta push (upload only
+  changed keys by checksum), **local-wins** conflict resolution, 2s-debounced `fs.watch`,
+  deletions don't propagate. Private-vs-team is the **model's** choice via per-type
+  `<scope>` prompt guidance. A **three-layer secret scanner** (curated gitleaks subset)
+  blocks/redacts credentials before anything leaves the machine.
+- **No schema versioning/migration** — records are schemaless markdown+frontmatter; tolerant
+  parsing (`parseMemoryType` narrows unknown → undefined) handles evolution.
+
+**→ For Dim0:** 2.1–2.5 map almost directly onto L1/L2. The manifest-based LLM-select is a
+strong fit (we don't need vectors for small volumes). "Freshness-as-text" is trivial and
+high-value. Team memory ≈ our "collaborative shared-board memory" — note they chose a
+server sync with local-wins + secret scanning, which validates our instinct to keep the
+server dumb and the client authoritative.
+
+---
+
+## 3. Session memory — per-session rolling notes, for cheap compaction
+
+A **different** system from memdir, often confused with it. Distinct store, distinct job.
+
+- **What:** *"a markdown file with notes about the current conversation… maintained
+  periodically in the background using a forked subagent."* One file per session:
+  `<session>/session-memory/summary.md`. Fixed template sections: *Session Title, Current
+  State, Task specification, Files and Functions, Workflow, Errors & Corrections, Codebase
+  Documentation, Learnings, Key results, Worklog.*
+- **Who writes it:** a **forked note-taker subagent** that may *only* call `Edit`, *only* on
+  that one file. It rewrites sections in place, preserving the template skeleton exactly
+  (the italic instruction lines are load-bearing structure).
+- **When:** after the context reaches ~10K tokens (init), then every ~5K token growth **and**
+  ≥3 tool calls (or at a natural no-tool break). Caps: **2K tokens/section, 12K total**; when
+  over budget the model is told to *"aggressively shorten oversized sections… Prioritize
+  keeping Current State and Errors & Corrections."*
+- **Why it exists — the real payoff:** when the window fills, compaction can reuse the
+  already-fresh notes **as** the summary, with **no summarization LLM call**. It also gives
+  cross-session resumption: reopen a session whose `summary.md` survives → the notes become
+  the summary.
+- Anti-leak framing in the prompt: *"This message and these instructions are NOT part of the
+  actual user conversation. Do NOT include any references to note-taking… in the notes."*
+
+**→ For Dim0:** this is the model for a **live board-work digest** — a rolling "what's the
+user doing on this board right now" that's cheaper than re-summarizing chat history, and
+doubles as our transcript-compaction summary (relevant to the Phase-2 opaque-blob
+transcripts). Distinct from L1 board *memory* (durable facts) — this is ephemeral working
+state.
+
+---
+
+## 4. Context-window management — layered escalation, cheapest first
+
+Not one "summarize" step — a ladder, applied least-lossy first:
+
+1. **Microcompact (per-turn):** clears old **tool-result payloads** (not the conversation)
+   when the prompt cache is presumed cold (>60min gap) or by count, replacing bodies with
+   `[Old tool result content cleared]`. Plus **API-native** context edits
+   (`clear_tool_uses` / `clear_thinking`) applied server-side without busting the cache.
+2. **Session-memory compaction:** reuse the fresh `summary.md` as the summary — no LLM call.
+3. **Full compaction:** an LLM summary with a **fixed 9-section structure** — *Primary
+   Request & Intent, Key Technical Concepts, Files and Code Sections, Errors and fixes,
+   Problem Solving, **All user messages**, Pending Tasks, Current Work, Optional Next Step*.
+   The model first writes a private `<analysis>` scratchpad, then the `<summary>` (the
+   scratchpad is stripped). Notable: "All user messages" is preserved deliberately, and
+   "Optional Next Step" demands *verbatim quotes* of the last task "to ensure there's no
+   drift in task interpretation."
+4. **Selective re-hydration** (the clever part): compaction discards raw history but
+   surgically **re-injects** the last ≤5 read files (≤5K each, 50K total), the active plan,
+   invoked-skill text, and tool/agent/MCP availability — so the model doesn't wake up amnesiac
+   about its environment. Final order: `boundary marker → summary → kept recent messages →
+   re-hydrated attachments → hook output`.
+
+Token gauge: **exact anchor from the last API `usage` response + a rough char-based estimate
+of the un-billed tail** (4 bytes/token, but 2 for JSON; images/docs hardcoded to 2000).
+Auto-compact fires at `effectiveWindow − 13K`; a circuit breaker stops after 3 consecutive
+failed compactions.
+
+**→ For Dim0:** the escalation ladder and especially **selective re-hydration** are the
+lessons. When we compact a long board-chat transcript, don't just summarize — re-attach the
+current board snapshot + recently-touched nodes so the agent stays oriented.
+
+---
+
+## 5. The dream loop (assistant mode) — logs → nightly distillation
+
+For long-lived "assistant" sessions, memdir flips from live-index to **append-only log +
+nightly distill**:
+
+- **Producer:** the agent **appends** timestamped bullets to `logs/YYYY/MM/YYYY-MM-DD.md` —
+  *"Do not rewrite or reorganize the log — it is append-only."* It never touches `MEMORY.md`
+  directly.
+- **Consumer (`autoDream`):** a forked agent, gated to run **≥24h apart** and after **≥5
+  sessions**, behind a PID lock. It runs a 4-phase distillation — *Orient* (read MEMORY.md +
+  existing topic files), *Gather* (daily logs + drifted memories + narrow transcript greps),
+  *Consolidate* (merge into topic files, absolute-ize dates, **delete contradicted facts**),
+  *Prune & index* (rewrite `MEMORY.md` ≤200 lines/25KB of pointers, demote verbose lines,
+  resolve contradictions).
+
+The distillation prompt is a clean template worth copying nearly verbatim if we ever want
+this — its phase structure ("orient → gather → consolidate → prune") is the reusable shape.
+
+**→ For Dim0:** probably **out of scope for v1**, but it's the answer to "how does curated
+memory stay clean over time without the main agent spending turns on housekeeping" — a
+separate, throttled, forked distiller. Worth keeping in the back pocket.
+
+---
+
+## 6. User-facing surfaces
+
+- **`/memory`** is an **editor launcher**, not a viewer — pick a CLAUDE.md-family file, open
+  it in `$EDITOR`. Memory is human-editable by design.
+- **`/context`** is a **visualizer** of what the model actually sees — it applies the same
+  transforms as a real request, then renders a **token breakdown by bucket** (per
+  system-prompt section, per memory file, CLAUDE.md total). Great for "why is my context
+  full."
+
+**→ For Dim0:** a "what does the agent know about this board" panel (the assembled snapshot
++ index + retrieved memories, with token counts) would be both a debugging tool and a trust
+feature.
+
+---
+
+## 7. Transferable principles (the distilled takeaways)
+
+1. **Separate the subsystems by time horizon.** Durable curated memory, ephemeral session
+   digest, and window-compaction are three different problems — don't build one blob.
+2. **Two-tier storage keeps always-on cost flat:** a capped, always-loaded *index* +
+   *on-demand* fact bodies. Grow the store without growing the base prompt.
+3. **The governing rule is "don't store what's derivable."** For us: don't memorize what
+   reading the board would tell you — that's the snapshot's job.
+4. **A closed, small taxonomy with per-type save/access/why guidance** beats freeform notes.
+   Steal `user`/`feedback`/`project`/`reference` and the **Why:/How to apply:** body shape.
+5. **Retrieval can be a cheap LLM side-query over name+description** — no vector store needed
+   at small scale. Be strict ("only if certain", ≤5).
+6. **Inject content at the right site with the right freshness contract.** Mechanics in the
+   system prompt; content fenced in a hedged user message; per-turn recall as separate
+   attachments; snapshots labeled "as of now, won't update."
+7. **Freshness as text, not decay.** Tell the model "N days old, verify before asserting" —
+   don't silently expire.
+8. **One writer per turn.** A passive extraction fork that *stands down* when the main agent
+   already wrote avoids double-writes and keeps the main loop cheap.
+9. **Compaction is lossy summary + selective re-hydration**, not just summary. Re-attach the
+   environment (files, plan, snapshot) so the agent stays oriented.
+10. **Keep the server dumb, the client authoritative** (team memory: delta push, local-wins,
+    secret-scan before egress). Validates our offline-first + opaque-backup instinct.
+11. **Make it inspectable and editable** (`/context`, `/memory`). Memory the user can see and
+    correct is memory the user trusts.
+
+---
+
+## 8. Mapping back to our design (`agent-context-memory.md`)
+
+| Our layer | Closest CC subsystem | What to copy | What to drop for v1 |
+|---|---|---|---|
+| **L0 board snapshot** | `gitStatus` | snapshot + explicit freshness label, memoized per run | summarizer for huge boards (later) |
+| **L1 board memory** | memdir (project scope) + team memory | two-tier index+files, taxonomy, LLM-select recall, freshness-text | team/collab sync (later), autoDream |
+| **L2 global memory** | memdir (user scope) | same, user-scoped | — |
+| **(future) work digest** | session memory | rolling structured notes → cheap transcript compaction | v1: skip |
+| **(future) transcript compaction** | compaction ladder | selective re-hydration of the board snapshot | microcompact/API edits |
+
+The open decisions in `agent-context-memory.md` now have CC precedents to lean on:
+retrieval → **LLM-select over a manifest** (§2.4); write path → **tools + a stood-down
+passive fork** (§2.6); shared-board memory → **server-synced, local-wins, secret-scanned**
+(§2.7); snapshot → **labeled point-in-time, memoized** (§1).

--- a/docs/plans/inspiration-hermes-memory.md
+++ b/docs/plans/inspiration-hermes-memory.md
@@ -1,0 +1,421 @@
+# Inspiration: how Hermes Agent solves memory & context
+
+A study of the NousResearch **Hermes Agent** source (`~/workspace/hermes-agent/`), written
+as a companion to `inspiration-claude-code-memory.md` so the two harnesses can be compared
+directly. Same goal: inform our board-agent memory design. File paths cite the Hermes repo;
+verify before relying on a detail.
+
+## TL;DR — Hermes vs Claude Code, at a glance
+
+Hermes solves the same problem as Claude Code but with **more explicit structure and more
+extension seams**. Where CC has five loosely-coupled subsystems, Hermes has the same shape
+plus two big additions: a **pluggable memory-provider layer** and a **self-improvement loop**
+(the agent rewrites its own skills). The subsystem map:
+
+| Hermes subsystem | CC analogue | One-line role |
+|---|---|---|
+| **Built-in memory** — `MEMORY.md` + `USER.md` | memdir | bounded, char-capped, curated facts (agent notes + user profile) |
+| **Skill memory + self-improvement** | (no direct CC analogue) | successful workflows → reusable `SKILL.md`; agent edits its own skills |
+| **Memory providers** (pluggable) | team memory (barely) | swap in Honcho/Mem0/etc.; external recall as a `<memory-context>` block |
+| **Context engine + 3-tier system prompt** | `context.ts` assembly | prompt-cache-stable assembly; swappable engine |
+| **Session search** (SQLite FTS5) | transcript grep | unlimited, on-demand recall of the full history |
+| **ContextCompressor** | compaction | token-threshold lossy summary of the middle |
+| **Curator** | autoDream (dream) | background skill-lifecycle maintenance (stale/archive/pin) |
+
+The two axes from the CC doc still apply — **auto-derived vs curated**, **static vs
+per-turn** — and Hermes adds a third theme it takes very seriously: **prompt-cache
+stability** as a first-class constraint that shapes *where* everything is injected.
+
+---
+
+## 1. The assembly model: 3-tier system prompt + per-turn user-message sidecar
+
+Hermes' single most pervasive design principle is **keep the cached prefix byte-stable**.
+Everything about placement follows from it.
+
+### 1.1 The three-tier system prompt
+
+Built once per session (`agent/system_prompt.py:338`), rebuilt **only on compaction**, joined
+as `stable\n\n context\n\n volatile`:
+
+- **`stable`** — identity (`SOUL.md` or `DEFAULT_AGENT_IDENTITY`), tool guidance, environment
+  hints, the coding operating brief. Cross-session stable → the cacheable prefix.
+- **`context`** — cwd-dependent: caller `system_message`, the **coding workspace snapshot**
+  (the gitStatus analogue, §6), and **context files** (`AGENTS.md`/`CLAUDE.md`/`.cursorrules`
+  chain).
+- **`volatile`** — kept last so a change re-prefills the least: **skills index → `MEMORY.md`
+  snapshot → `USER.md` profile → external-memory provider block → date-only timestamp.**
+
+Two cache tricks worth stealing: the timestamp is **date-only** (byte-stable for a full day),
+and the skills index is in volatile (not stable) because skills are runtime-mutable.
+
+### 1.2 Per-turn context goes on the USER message, via a sidecar
+
+Anything that changes per turn — external-memory prefetch, plugin context, gateway notes — is
+**never** put in the system prompt. It's appended to an `api_content` **sidecar** copy of the
+user message (`agent/turn_context.py:54-86`), leaving the stored message clean:
+
+```
+api_content = content + "\n\n" + "\n\n".join(injections)
+```
+
+The sidecar is persisted so the next turn replays **byte-identically** — "what turn N sends
+must be what turn N+1 replays" — which is the whole reason the cached prefix survives. This is
+a sharper version of CC's "mechanics in system prompt, content in a fenced user message" split.
+
+**→ For Dim0:** even though we run in the browser (no provider prompt-cache to protect in the
+same way), the *discipline* is worth adopting: assemble the static board context once per run;
+inject per-turn recall as a separate, clearly-fenced block on the user message, not by mutating
+history.
+
+---
+
+## 2. Built-in curated memory: `MEMORY.md` + `USER.md`
+
+The closest analogue to memdir, but **char-capped, split into two stores, and injected as a
+frozen snapshot**. Implementation is entirely in `tools/memory_tool.py` (not `hermes_state*`).
+
+### 2.1 Two bounded stores (chars, not tokens)
+
+| Store | Holds | Cap | Path |
+|---|---|---|---|
+| `MEMORY.md` | agent's notes: env facts, conventions, tool quirks, lessons | **2,200 chars** (~800 tok) | `~/.hermes/memories/MEMORY.md` |
+| `USER.md` | user profile: role, style, pet peeves, skill level | **1,375 chars** (~500 tok) | `~/.hermes/memories/USER.md` |
+
+Char caps because they're "model-independent." Entries are delimited by `\n§\n`. The rendered
+block even **shows remaining capacity**: `MEMORY (your personal notes) [67% — 1,474/2,200 chars]`.
+
+### 2.2 Overflow is a hard error, not eviction
+
+Unlike CC's 200-line truncation, an `add` past the cap is **rejected**, returning the current
+entries so the model can decide what to cut, then retry — ideally as one atomic `batch` that
+removes/shortens and adds together. Guards: 3-consolidation-failures-per-turn limit, then a
+**terminal** "stop retrying, answer the user" result (a failed memory side-effect must never
+block the reply). Dedup on add + on load; `replace`/`remove` match by short unique substring.
+
+### 2.3 Two write paths
+
+- **Foreground tool** (`memory` with `add`/`replace`/`remove`/`operations`). The behavioral
+  guidance lives in the tool schema — notably the **WHEN/SKIP** rule:
+  > WHEN: "save proactively when the user states a preference, correction, or personal
+  > detail… Priority: user preferences & corrections > environment facts > procedures. The
+  > best memory stops the user repeating themselves."
+  > SKIP: "trivial/obvious info, easily re-discovered facts, raw data dumps, task progress,
+  > completed-work logs, temporary TODO state… Reusable procedures belong in a skill, not
+  > memory."
+- **Passive background review** (§3.2) — a post-turn fork that saves what the model forgot to.
+
+### 2.4 Frozen-snapshot injection + security
+
+Memory is captured **once at session start** and injected as a frozen snapshot; mid-session
+writes persist to disk (durable, and tool responses show live state) but **don't change the
+system prompt until next session** — again for prefix-cache stability. And content is
+**security-scanned on both write and load**: a poisoned-on-disk entry is replaced *in the
+injected snapshot* with a `[BLOCKED: … threat pattern …]` marker (live text kept so the user
+can remove it). Plus per-file locks, atomic writes, external-drift detection with `.bak`.
+
+**→ For Dim0:** the `MEMORY.md`/`USER.md` **split maps cleanly to our L1 (board memory) / L2
+(user/global memory)**. The "show remaining capacity + consolidate-on-overflow" pattern is a
+nice alternative to silent truncation and keeps the model honest about the budget.
+
+---
+
+## 3. Skill memory + self-improvement — Hermes' biggest differentiator
+
+This is the part with **no real Claude Code analogue** (CC's autoDream distills memory, but
+doesn't author reusable *procedures*). Hermes treats "how to do this class of task" as a
+first-class, self-editing store.
+
+### 3.1 Skills = reusable-procedure packages
+
+A skill is a `SKILL.md` (+ `references/`/`templates/`/`scripts/`) under `~/.hermes/skills/`.
+The skills **index** sits in the volatile band of the system prompt; full bodies load on demand.
+Descriptions are capped at **≤60 chars** because the index truncates there.
+
+### 3.2 Three tiers of "learning"
+
+1. **`/learn`** (explicit, user-invoked) — the live agent gathers sources (files, URLs, "what
+   we just did") and authors a skill via `skill_manage`. Handles both small (one tight
+   `SKILL.md`) and large (knowledge-base layout: lean index + per-chapter `references/`).
+2. **Background review** (automatic, post-turn fork) — the "learn from experience" loop. Fires
+   on turn-count nudges (default every **10**), on a final response, tools whitelisted to
+   memory + skill management. Separate **memory-review** and **skill-review** prompts.
+3. **Curator** (background lifecycle) — inactivity-triggered; pins/archives/consolidates
+   *agent-created* skills only, **archive-only (never deletes)**, pinned skills bypass all
+   transitions. This is Hermes' autoDream analogue but for *skills*.
+
+### 3.3 The anti-self-poisoning rules (the standout lesson)
+
+The skill-review prompt is explicit about what it must **NOT** capture — because a
+self-improving loop can poison itself:
+> - environment-dependent failures (missing binaries, "command not found")
+> - **negative claims about tools** — *"'browser tools do not work'… These harden into
+>   refusals the agent cites against itself for months after the actual problem was fixed."*
+> - transient errors that resolved; one-off task narratives
+> - **unresolved failures** — *"do NOT write those attempts up as a 'reliable workflow'…
+>   presents an untested sequence of failures as validated guidance."*
+
+And a clean division of labor it states outright: *"Memory captures 'who the user is and what
+the current situation… is'; skills capture 'how to do this class of task for this user.'"*
+
+**→ For Dim0:** a full skill-authoring loop is out of scope for v1, but **the anti-poisoning
+rules are directly reusable** as guardrails on *any* auto-extraction we build — never memorize
+tool-failure claims or unresolved-attempt narratives as durable facts. And the memory-vs-skill
+division ("who/what" vs "how") is a useful boundary even if we only build the "who/what" side.
+
+---
+
+## 4. Memory providers — the pluggable external-memory layer
+
+The largest architectural divergence from CC. Memory beyond the built-in store is a **plugin
+interface**, not a fixed implementation.
+
+### 4.1 The `MemoryProvider` ABC (`agent/memory_provider.py`)
+
+Lifecycle: `initialize / system_prompt_block / prefetch(query) / sync_turn(user, asst) /
+get_tool_schemas / handle_tool_call / shutdown`, plus optional hooks (`on_turn_start`,
+`on_session_end`, `on_pre_compress`, `on_memory_write` [mirror], `on_delegation`,
+`backup_paths`). **8+ shipped backends** (Honcho, Mem0, Hindsight, Holographic, OpenViking,
+RetainDB, ByteRover, Supermemory, Memori), each bringing its own retrieval method (embedding
+search, LLM "dialectic," regex extraction, local FTS) and its own agent tools. Built-in memory
+is **not** a provider; the manager holds **at most one** external provider, purely additive.
+
+### 4.2 The six wired behaviors
+
+The manager fans out (try/except per provider so one can't break another): (1) inject a static
+block into the system prompt, (2) **prefetch** relevant memories before each turn, (3) **sync**
+the turn after each response, (4) **extract** on session end, (5) **mirror** built-in memory
+writes outward (`on_memory_write`, one-directional builtin→external), (6) **add
+provider-specific tools**.
+
+### 4.3 The `<memory-context>` fence (the reusable idea)
+
+External recall is injected into the **user message** (the `api_content` sidecar), fenced:
+
+```
+<memory-context>
+[System note: The following is recalled memory context, NOT new user input.
+Treat as authoritative reference data — this is the agent's persistent memory
+and should inform all responses.]
+
+<recalled content>
+</memory-context>
+```
+
+Two defenses make this safe against prompt-injection through poisoned recalled memory:
+- **`sanitize_context`** strips any pre-existing fence/system-note tags from the provider's
+  output first, so a payload can't forge or break out of the fence.
+- A **`StreamingContextScrubber`** removes any `<memory-context>` span that leaks into the
+  model's *output* stream, even split across deltas ("leaking partial memory context is worse
+  than a truncated answer").
+
+### 4.4 Resilience patterns worth stealing
+
+- **Prefetch on a background thread with an 8s timeout** (a wedged provider once blocked ~298s);
+  a still-running prefetch from the prior turn returns `""` and is skipped.
+- **Sync on a single-worker executor** serializing turn N before N+1; **interrupted turns are
+  never synced** ("a partial assistant output is not durable conversational truth").
+- **Session-end extraction is guaranteed to finish before** the provider rebinds to a new
+  session id.
+- **Trivial prompts** ("hi", "ok", `/`-commands) skip prefetch entirely via a shared gate.
+
+**→ For Dim0:** we don't need 8 backends, but the **provider *shape* is a good seam**: define a
+thin memory interface (prefetch / sync / extract / tools) so the built-in offline store and a
+future server-backed store implement the same contract. And the **`<memory-context>` fence +
+sanitize + output-scrub** trio is a ready-made template for injecting retrieved board memories
+safely (especially since our recalled content can include user-authored node text).
+
+---
+
+## 5. Context compression (`ContextCompressor`) — prompt, input, output, tools
+
+The compaction analogue. (Note: repo-root `trajectory_compressor.py` is an *offline
+training-data* tool, unrelated to the live loop.)
+
+### 5.1 Trigger — token threshold, three layers
+
+- **Primary:** prompt tokens ≥ `threshold_tokens = (context_length − max_tokens) ×
+  threshold_percent`, default **0.50** (raised to 0.75 for small-context models), floored at a
+  64K window. **Token-driven, not turn-driven; no "context pressure" warning** (deliberately
+  removed — it "made models give up prematurely").
+- **Safety net:** gateway auto-compress at **85%**.
+- **Explicit:** `/compress [focus]` (force).
+- **Anti-thrash:** skips if the summarizer is in a 600s failure cooldown, or if the last two
+  compressions each saved <10%.
+
+### 5.2 What it does — 4-phase middle-summarization
+
+1. **Prune old tool results** (cheap, no LLM): dedup identical results by md5, replace old
+   >200-char results with one-line summaries (`[terminal] ran \`npm test\` -> exit 0, 47 lines`),
+   truncate large tool-arg JSON. Survives even an aborted summary.
+2. **Boundaries:** protect head (first 3) + a token-budgeted tail (≥ last user turn kept
+   verbatim); never split tool_call/result pairs.
+3. **Summarize the middle** with an **auxiliary LLM** into one structured message.
+4. **Assemble** head + summary + tail; sanitize orphaned tool pairs.
+
+Also a rolling "micro-compaction" mode (merge one exchange at a time into a running summary),
+and an in-place default (same session id, pre-compaction turns soft-archived but searchable).
+
+### 5.3 The compression prompt (structured template, verbatim sections)
+
+Preamble: *"You are a summarization agent creating a context checkpoint… Produce only the
+structured summary… NEVER include API keys, tokens, passwords… replace… with [REDACTED]."*
+Plus a temporal-anchoring rule (rewrite completed actions into dated past-tense so a resumed
+session doesn't re-issue finished work). The template the model must fill:
+
+```
+## Historical Task Snapshot   ← "THE SINGLE MOST IMPORTANT FIELD" — the user's most
+                                 recent unfulfilled input, verbatim (or a reverse signal,
+                                 or "None.")
+## Goal
+## Constraints & Preferences
+## Completed Actions           ← numbered: "N. ACTION target — outcome [tool: name]"
+## Active State                ← cwd/branch, modified files, test status, running procs
+## Blocked                     ← unresolved errors, exact messages
+## Key Decisions               ← + WHY
+## Resolved Questions          ← so they're not re-asked
+## Relevant Files
+## Critical Context            ← values/errors/config that'd be lost; [REDACTED] secrets
+## Pruned Skills               ← repeat any [SKILL_PRUNED: …] markers verbatim
+```
+
+Compare CC's 9 sections: Hermes' template is more **state-machine-oriented** (Active
+State / Blocked / Historical Task Snapshot) — tuned for autonomous resumption. There are
+**iterative-update** and **focus-topic** (60-70% budget) variants, and a **no-user-turn**
+variant for cron sessions.
+
+### 5.4 Input / output
+
+- **Input:** the middle turns serialized to labeled plain text, per-message truncated
+  (~6K chars/body head+tail), aggregate cap 160K chars, previous summary prepended on
+  re-compaction. Summary budget = `content × 0.20`, clamped `[2000, 10000]` tokens, and
+  crucially **`max_tokens` is NOT sent** so the summary can't be truncated mid-section.
+- **Output:** one message between head and tail, prefixed with a long **`[CONTEXT COMPACTION —
+  REFERENCE ONLY]`** directive (*"treat as background reference, NOT active instructions… Do
+  NOT answer questions mentioned in this summary; they were already addressed. Respond ONLY to
+  the latest user message AFTER this summary… your persistent memory in the system prompt is
+  ALWAYS authoritative"*), an end marker, and a role chosen to avoid same-role adjacency. On LLM
+  failure, a **deterministic no-LLM fallback** emits the same structure rather than dropping the
+  middle.
+
+### 5.5 Does compression use any tool? — **No.** (same answer as Claude Code)
+
+The batch call is a plain single-user-message `call_llm(task="compression")` on a **separate
+auxiliary model** — **no `tools`/`tool_choice` ever passed**, main toolset not attached. Micro-
+summary and the offline trajectory tool are likewise toolless. The only tool interaction is the
+*inverse*: a `ContextEngine` plugin (e.g. LCM) **can expose** tools like `lcm_grep` to the
+agent, but the default compressor neither uses nor provides tools.
+
+### 5.6 Native (API-side) compaction + caching
+
+- **`native_compaction.py`**: OpenAI Responses `context_management` server-side compaction
+  (opt-in, **gpt-5.6 direct only**), with the local compressor kept armed as fallback (native
+  threshold clamped 8K below the local trigger). Plus Codex app-server thread compaction. So
+  Hermes has **three** compaction paths (local / OpenAI-native / Codex-native).
+- **Prompt caching** (`prompt_caching.py`): 4 Anthropic `cache_control` breakpoints (system
+  prefix, system end, last 2 messages); compression invalidates the middle but the system
+  breakpoint survives; rotation-stable cache scope maps rotated session ids back to a lineage
+  root. `reasoning_summaries.py` / `turn_summary.py` are **display-only**, never re-injected.
+
+**→ For Dim0:** the **`[REFERENCE ONLY]` framing** on a compaction summary (don't re-execute
+finished work; only the latest message after it is live) is a direct fix for a real failure
+mode and worth copying into any transcript-compression we do. The **structured, resumption-
+oriented template** (Active State / Blocked / Historical Task Snapshot) is a better fit for our
+board-work digests than CC's chronological 9-section shape.
+
+---
+
+## 6. The retrieval-without-recall complements
+
+Two mechanisms that give the model access to more than fits in the prompt, without pre-injecting:
+
+- **Session search** — SQLite **FTS5** over the full transcript (`~/.hermes/state.db`), exposed
+  as a `session_search` tool (~20ms query, no LLM, no truncation). The "unlimited, on-demand"
+  complement to the ~1,300-token in-prompt memory. (CC's analogue is grepping transcript JSONL.)
+- **Context references** (`@file:`, `@diff`, `@git:5`, `@url:`) — inline **user-driven**
+  attachments expanded into the user message with budget guards (refuse >50% of window) and a
+  path-safety denylist. Distinct from auto-discovered **context files** (the AGENTS.md chain).
+
+And the **coding workspace snapshot** (`coding_context.py`) is the richer gitStatus analogue:
+`"Workspace (snapshot at session start — re-check with git before acting on it): Root / Branch
+→ upstream (ahead/behind) / Status / Recent commits / Project manifests / Verify commands"`.
+
+The `/context` command (`context_breakdown.py`) renders a CC-style token breakdown with a 5×20
+glyph grid, bucketed by system prompt / tools / skills / MCP / memory / conversation.
+
+---
+
+## 7. Transferable principles (Hermes-specific, beyond the CC list)
+
+1. **Prompt-cache stability is a design constraint, not an afterthought.** Tier the system
+   prompt (stable/context/volatile), put volatile last, keep per-turn injection off the system
+   prompt via a byte-stable user-message sidecar.
+2. **Split memory by subject: agent-notes (`MEMORY.md`) vs user-profile (`USER.md`).** Two small
+   bounded stores beat one blob; each gets its own budget and guidance.
+3. **Overflow → consolidate, not truncate.** Reject the write, show current entries, make the
+   model merge/prune and retry atomically. Show remaining capacity in the injected block.
+4. **A self-improvement loop needs anti-poisoning guardrails.** Never persist tool-failure
+   claims, env-specific failures, or unresolved-attempt narratives as durable facts/skills.
+5. **Make external memory a provider interface**, additive to a built-in store, with a mirror so
+   the two don't diverge.
+6. **Fence recalled memory and defend the fence** — sanitize provider output (no forged tags)
+   and scrub leaked fence spans from the model's output.
+7. **Resilience: time-box prefetch, background-thread the writes, never sync interrupted turns.**
+8. **Compaction summaries are "reference only"** — tell the model not to re-execute finished
+   work; keep persistent memory authoritative over the summary.
+9. **Give the model on-demand retrieval (FTS session search)** so the small always-on memory
+   doesn't have to hold everything.
+
+---
+
+## 8. Claude Code vs Hermes — side by side
+
+| Dimension | Claude Code | Hermes |
+|---|---|---|
+| Durable curated memory | memdir: `MEMORY.md` index + per-fact files, 4-type taxonomy | `MEMORY.md` (2200c) + `USER.md` (1375c), single-file/§-delimited |
+| Memory cap handling | 200-line truncation of the index | hard error → model consolidates & retries |
+| Retrieval | per-turn LLM-select over a name+desc manifest → ≤5 files | provider-specific (embedding / LLM dialectic / FTS); built-in is injected whole |
+| On-demand recall | grep transcript JSONL | `session_search` FTS5 tool |
+| Passive extraction | forked agent at end of loop (memory dir only) | background review fork (memory **and** skills), nudge every 10 turns |
+| Self-improvement | autoDream distills memory | `/learn` + background skill review + Curator lifecycle (**authors reusable skills**) |
+| External memory | team memory (server sync, one blob) | **pluggable providers** (8+), `<memory-context>` fence + scrub |
+| Recall injection site | `<system-reminder>` attachment messages | `<memory-context>` on the user-message sidecar |
+| Repo/state snapshot | `gitStatus` block | coding workspace snapshot (+ verify commands) |
+| Compaction trigger | ~% window auto + `/compact` | 50% token threshold + 85% gateway + `/compress` |
+| Compaction template | 9 chronological sections | 10+ state-machine sections (Active State/Blocked/Historical Task Snapshot) |
+| Compaction tools | none | none |
+| Native/API compaction | Anthropic context editing | OpenAI Responses (gpt-5.6) + Codex app-server |
+| Compaction re-hydration | re-attach recent files/plan/skills | prune+summarize middle, keep head+tail verbatim; `[REFERENCE ONLY]` framing |
+| Extensibility | flags, hooks | **swappable context engine + memory-provider plugins** |
+
+**The one-sentence contrast:** Claude Code is a *curated-file* memory system with LLM-select
+recall and a distillation loop; Hermes is a *bounded-store + pluggable-provider* memory system
+with a self-improving **skill** loop and prompt-cache-stability baked into every placement
+decision.
+
+---
+
+## 9. Mapping to Dim0 (`agent-context-memory.md`)
+
+The two studies converge on the same v1 for us, with Hermes sharpening several choices:
+
+| Our layer | Take from CC | Take from Hermes |
+|---|---|---|
+| **L0 board snapshot** | labeled point-in-time, memoized | coding-snapshot richness (inventory + "re-check before acting") |
+| **L1 board memory** | two-tier index+files, taxonomy, freshness-text | `MEMORY.md`-style bounded store, overflow→consolidate, show capacity |
+| **L2 global/user memory** | user-scoped memdir | **dedicated `USER.md`-style profile store** (clean L1/L2 split) |
+| **Retrieval** | LLM-select over manifest | fence recalled memory (`<memory-context>` + sanitize + scrub); FTS-style on-demand search tool |
+| **Write path** | tools + stood-down passive fork | passive review fork + **anti-poisoning guardrails** |
+| **Shared-board memory** | server-synced, local-wins | **provider-interface seam** (built-in + optional external, mirror) |
+| **Transcript compaction** | selective re-hydration | structured resumption template + `[REFERENCE ONLY]` framing; no tools |
+
+Concrete deltas to fold into `agent-context-memory.md`:
+- Adopt Hermes' **two-store split** for our L1/L2 (board-notes vs user-profile) rather than one
+  memory type-space.
+- Adopt **overflow-consolidate** (reject + show entries + retry) over silent truncation, and
+  **surface remaining capacity** in the injected block.
+- Wrap retrieved board memories in a **sanitized `<memory-context>` fence** — important because
+  recalled node text is user-authored and could carry injection.
+- If we ever add passive extraction, ship the **anti-poisoning rules** from day one.
+- Model the built-in store behind a **thin provider-shaped interface** so a future
+  server/collab-backed store drops in without touching the agent loop.

--- a/docs/plans/inspiration-mem0-and-landscape.md
+++ b/docs/plans/inspiration-mem0-and-landscape.md
@@ -1,0 +1,269 @@
+# Inspiration: mem0 + the 2026 agent-memory landscape
+
+Third study in the series (after `inspiration-claude-code-memory.md` and
+`inspiration-hermes-memory.md`). Two parts: (A) a deep-dive on **mem0** — the dedicated
+memory *library* (not a full agent), and the simplest of the systems we've looked at — and
+(B) a **2026 landscape** of reference memory/context solutions to situate all of it. Ends
+with what to take for Dim0. Code cites `~/workspace/mem0/` (mem0ai v2.0.18); landscape claims
+cite the sources listed at the end.
+
+---
+
+# Part A — mem0
+
+mem0 is a **memory layer you bolt onto any agent**: `memory.add(messages, user_id=…)` after
+each exchange, `memory.search(query, user_id=…)` before the next. It owns extraction, storage,
+and retrieval; it is not an agent runtime. That narrow scope is why it's the cleanest thing to
+learn the core "extract → store → retrieve" loop from.
+
+## A.0 The headline: mem0 replaced both of its own famous designs
+
+The mem0 pattern cited everywhere — **"extract facts, then have an LLM decide ADD / UPDATE /
+DELETE / NOOP against existing memories," backed by a vector store + a Neo4j-style graph** — is
+**no longer what the current code does.** In this checkout (v2.0.18):
+
+- The **ADD/UPDATE/DELETE/NOOP decision prompt** (`DEFAULT_UPDATE_MEMORY_PROMPT`) still exists
+  in `mem0/configs/prompts.py` but is **dead code** — nothing calls it.
+- The **external graph DBs** (Neo4j/Memgraph/Kuzu/Apache AGE) documented in mem0's own
+  `AGENTS.md` are **absent from the code** — no `graphs/`, no `graph_memory.py`, no
+  `graph_store` config field, no factory.
+
+Both were replaced by a simpler, more deterministic design (corroborated by mem0's own 2026
+writeups: *"a recent algorithmic shift… replacing external graph store support with built-in
+entity linking"*). **The shift itself is the lesson** — see A.6. Below documents both the
+classic pattern (still the widely-cited reference) and what actually ships now.
+
+## A.1 The classic mem0 pattern (the widely-cited reference; now dead code)
+
+Worth knowing because it's what most write-ups mean by "mem0," and it's a clean articulation
+of the LLM-mutation approach:
+
+1. **Extract** — `FACT_RETRIEVAL_PROMPT` turns the exchange into a list of atomic facts
+   (`{"facts": [...]}`), with the nice guardrail examples (`"Hi." → {"facts": []}`,
+   `"There are branches in trees." → {"facts": []}`).
+2. **Decide** — for each new fact vs the top-k similar existing memories,
+   `DEFAULT_UPDATE_MEMORY_PROMPT` has the LLM emit one of:
+   - **ADD** (new info → new id),
+   - **UPDATE** (same topic, more info → keep the id, replace text; "keep the fact which has
+     the most information"),
+   - **DELETE** (the new fact *contradicts* an existing one),
+   - **NONE** (already present / irrelevant).
+   Anti-hallucination: existing memories are shown with integer ids, and "do not generate any
+   new ID" for updates.
+
+That's **two LLM calls per add** (extract, then decide) and the decision loop is what keeps the
+store deduped/consistent.
+
+## A.2 What mem0 actually ships now — the additive pipeline
+
+The live `add(infer=True)` path (`mem0/memory/main.py`) is **one LLM call, ADD-only**, with
+dedup and consistency handled *deterministically*:
+
+- **Phase 0 — context:** pull the last ~10 messages for this scope (SQLite cache) + the top-10
+  semantically-similar existing memories (shown to the LLM with integer ids, never real UUIDs).
+- **Phase 2 — extract (1 LLM call):** `ADDITIVE_EXTRACTION_PROMPT` — *"Your sole operation is
+  ADD."* The model emits contextually-rich, self-contained facts (15–80 words each), each with
+  an optional `linked_memory_ids` array pointing at related existing memories (by UUID). It
+  extracts from **both user and assistant** messages. If a new fact is *"semantically
+  equivalent to an Existing Memory with no meaningful new context, skip it."*
+- **Phase 4/5 — dedup (no LLM):** `md5(text)` hash; collisions with existing or in-batch hashes
+  are dropped. **Exact-string only** — reworded-but-equivalent facts accumulate as new,
+  *linked*, memories rather than mutating old ones.
+- **Phase 6 — persist:** batch insert into the vector store; one `ADD` row in the SQLite
+  history table per memory.
+- **Phase 7 — entity linking (no LLM):** spaCy NER extracts entities (PERSON/ORG/PRODUCT/etc.,
+  deliberately *not* dates/quantities), which are embedded and upserted into a **parallel entity
+  vector collection**; each entity row accumulates the `linked_memory_ids` it appears in. This
+  is the "graph."
+
+`infer=False` skips the LLM entirely (store messages verbatim). One extra mode:
+`procedural_memory` (one summarization call → an agent execution-history memory).
+
+## A.3 The two prompts (the reusable bits)
+
+- **Extraction (live):** *"You are a Memory Extractor — a precise, evidence-bound processor…
+  Your sole operation is ADD."* Quality bar worth copying: *"Contextually Rich, Not Atomic /
+  Self-Contained / Concise but Complete (15–80 words) / Temporally Grounded / Numerically
+  Precise / Preserve Specific Details — Never Generalize."* Output is strict JSON; *"If nothing
+  is worth extracting, return {"memory": []}."*
+- **Decision (dead, but the reference):** the four-operation manager prompt in A.1. Keep it in
+  mind as the *alternative* to additive-plus-dedup.
+
+## A.4 Retrieval — hybrid, no LLM
+
+`search()` is **semantic + BM25 + entity-boost, additively fused** — zero LLM calls (unless an
+optional reranker is enabled):
+
+1. embed the query; also lemmatize it and spaCy-extract its entities;
+2. **semantic** vector search (over-fetch `max(4×limit, 60)`);
+3. **BM25 keyword** search (if the backend supports `keyword_search`; else degrades to
+   semantic-only with a warning), normalized through a query-length-adaptive sigmoid;
+4. **entity boost**: query entities → entity store → propagate a bounded boost to their
+   `linked_memory_ids` (down-weighting entities linked to *many* memories);
+5. **fuse**: `combined = min((semantic + bm25 + entity_boost)/max_possible, 1.0)`, with the
+   `threshold` gating the *semantic* score *before* fusion;
+6. optional **reranker** (Cohere / sentence-transformer / LLM / etc.), off by default, as a
+   final pass.
+
+## A.5 Scoping + storage
+
+- **Three-tier scoping:** `user_id` (person) / `agent_id` (AI identity) / `run_id` (session).
+  At least one required; **identity keys are stripped from freeform metadata** so a memory can't
+  smuggle itself into another scope. Filters are ANDed — `{user_id}` = everything for the user;
+  `{user_id, run_id}` = one session. `agent_id`-only triggers agent-perspective extraction.
+- **Per-memory payload:** `data` (text), `hash`, `text_lemmatized`, `created_at`/`updated_at`,
+  scope ids, optional `role`/`actor_id`/`attributed_to`/`expiration_date`.
+- **History/audit:** a SQLite table logging every ADD/UPDATE/DELETE (`old_memory`/`new_memory`)
+  — a full mutation trail, exposed via `memory.history(id)`.
+- **Pluggability:** uniform factory + Pydantic config for **LLM (~20) / embedder (~13) / vector
+  store (25) / reranker (5)**. The entity "graph" inherits the vector-store backend
+  automatically (no separate config). Graph store is the one category with no code.
+
+## A.6 Why the shift matters (the design lesson)
+
+mem0 moving from *"LLM decides ADD/UPDATE/DELETE"* to *"additive ADD + deterministic hash dedup
++ accumulate-and-link"* is a bet worth internalizing:
+
+- **An LLM mutation loop is a reliability liability** — a wrong DELETE/UPDATE silently corrupts
+  durable state, and it costs a second LLM call per add. Deterministic dedup can't hallucinate a
+  destructive edit.
+- **Accumulate-and-link over mutate** — contradictions/refinements become *new linked memories*;
+  recency + retrieval sort out which wins, and nothing is destroyed. (Compare Zep's "close, never
+  delete" temporal edges in Part B — same instinct, different mechanism.)
+- **Cost drops** — one LLM call per add, none per search.
+- The trade: the store grows and can hold stale/contradictory facts; you lean on retrieval
+  ranking (and explicit `update`/`delete` APIs) instead of write-time consistency.
+
+**→ For Dim0:** mem0's shape *is* our L1/L2 minus the vector store. We can adopt the **additive +
+deterministic-dedup** pipeline (cheaper, safer) rather than an LLM decision loop, keep an
+explicit `update_memory`/`delete_memory` tool for real corrections, and — critically — since our
+volumes are small and front-end, we can **skip vectors/BM25/entity-graph entirely** and use
+Claude Code's LLM-select-over-manifest for retrieval. mem0 tells us what we *don't* need at our
+scale as much as what we do.
+
+---
+
+# Part B — the 2026 agent-memory landscape
+
+Memory is, as of 2026, a first-class architectural component with its own benchmark suite and a
+crowded ecosystem. The map:
+
+## B.1 The taxonomy everyone uses
+
+Borrowed from cognitive science, now standard:
+
+- **Working memory** — the live context window (what's in the prompt right now).
+- **Episodic** — specific past experiences bound to time/place ("what we did last session"). ≈
+  session memory / transcript.
+- **Semantic** — atemporal declarative facts ("user prefers X", entity properties). ≈ memdir /
+  MEMORY.md / mem0 facts.
+- **Procedural** — how to do a class of task. ≈ Hermes skills, mem0 procedural memory.
+
+Most write-ups frame the design problem as **"memory vs context"**: context is the window you
+assemble each turn; memory is the durable store you retrieve *into* that window.
+
+## B.2 The named reference systems
+
+| System | Approach | Distinctive idea | License / form |
+|---|---|---|---|
+| **mem0** | hybrid vector + entity-link, LLM extraction | simplest; additive pipeline (Part A) | OSS library |
+| **Zep / Graphiti** | **bi-temporal knowledge graph** | every fact has *valid-time* + *transaction-time*; contradicted facts are **closed, never deleted** → "what was true in March vs now"; incremental, hybrid (semantic+keyword+graph traversal). **LongMemEval leader (~63.8% vs mem0 ~49%)** | OSS + hosted |
+| **Letta (MemGPT)** | **OS-inspired self-editing memory** | tiers: **Core** (in-context, char-limited blocks the LLM edits via tool calls) / **Recall** (searchable cache) / **Archival** (long-term); the agent pages memory between tiers itself | OSS + hosted |
+| **Cognee** | graph + vector ("cognify" pipeline) | deep knowledge retrieval; Apache-2, nothing gated | OSS |
+| **Pinecone / vector DBs** | managed vector recall | fast fuzzy recall as a primitive others build on | hosted |
+| research: **Memanto, MemMachine, MOSS, MemGuard** | typed semantic memory / ground-truth-preserving / auditable / contamination-defense | the frontier is *reliability* (auditability, poisoning defense), not just recall | papers |
+
+## B.3 The cross-cutting patterns
+
+1. **Hybrid dual-store** is the dominant production shape: **vector for fuzzy recall + graph for
+   entity/temporal queries + an extraction pipeline** turning messages into atomic facts. Many
+   add an **episodic buffer** for short-term coherence; the agent routes between them.
+2. **LLM extraction into scoped atomic facts** (user / session / agent) is near-universal.
+3. **Temporal awareness** is the 2026 differentiator — bi-temporal graphs (Zep) or at least
+   dated facts (mem0's temporal grounding, CC's "convert relative → absolute dates").
+4. **Async consolidation / "dreaming"** — a background pass between sessions that reviews
+   transcripts + memory, merges duplicates, and surfaces insights. **Anthropic shipped a
+   "Dreaming" primitive (May 2026)** explicitly modeled on hippocampal consolidation. This is
+   the *same idea* as Claude Code's **autoDream** and Hermes' **Curator** — convergent evolution.
+5. **Self-editing / self-improving memory** — Letta's tiers and Hermes' skill-review loop both
+   let the agent maintain its own store; the frontier concern is **poisoning** (MemGuard;
+   Hermes' anti-self-poisoning rules).
+6. **Benchmarks exist now:** **LoCoMo** (1,540 Q; single/multi-hop, open-domain, temporal),
+   **LongMemEval** (500 Q; 6 categories incl. knowledge-update + temporal), **BEAM**. Use them if
+   we ever want to measure.
+
+## B.4 Where our three studied systems sit on this map
+
+- **Claude Code** — file-based **semantic** memory (memdir) + **episodic** (session transcript,
+  grep-searchable) + **consolidation** (autoDream). No graph, no vectors; retrieval is
+  LLM-select. Curated, human-editable.
+- **Hermes** — bounded **semantic** stores (`MEMORY.md`/`USER.md`) + **procedural** (skills) +
+  **episodic** (session_search FTS5) + **pluggable providers** (which can bring vector/graph) +
+  **consolidation** (Curator). Prompt-cache-obsessed placement.
+- **mem0** — **semantic** facts in a hybrid vector+entity store; a *library*, so it's the
+  "memory backend" the others (Hermes) can plug in as a provider.
+
+They're complementary lenses: CC and Hermes are *harness* designs (assembly, injection,
+compaction, self-improvement); mem0 is a *storage/retrieval* design. Zep/Letta show the two
+frontier axes CC/Hermes/mem0 mostly *don't* chase — **temporal graphs** and **agent-managed
+tiers**.
+
+---
+
+# Part C — synthesis for Dim0
+
+## C.1 What's convergent across ALL sources (high-confidence for our design)
+
+1. **Separate durable memory from the live context window**, and separate memory-*mechanics*
+   (instructions) from memory-*content* (data) at injection time.
+2. **Extract atomic, self-contained, scoped facts** (user vs session vs board/agent) — the
+   scoping triad is universal (mem0's user/agent/run ≈ our global/agent/board).
+3. **Two-tier: a small always-loaded surface + a larger retrieved-on-demand store.** CC's
+   index+files, Hermes' bounded block + session_search, mem0's top-k retrieval — same shape.
+4. **Ground facts in time** ("47 days old / convert to absolute dates / valid-time") and
+   **verify before asserting** — memory is a snapshot.
+5. **A background consolidation pass** is now table stakes at the high end (autoDream / Curator /
+   Anthropic Dreaming) — but it's a *phase-2* luxury, not v1.
+6. **Guard against poisoning** — sanitize/scan recalled content; don't memorize tool-failure
+   claims or unresolved-attempt narratives.
+
+## C.2 What mem0 specifically changes in our plan
+
+- **Prefer additive + deterministic dedup over an LLM ADD/UPDATE/DELETE loop.** Cheaper, safer,
+  no hallucinated destructive edits. Keep explicit `update`/`delete` tools for real corrections.
+  (This resolves the "write path" open decision in `agent-context-memory.md` toward
+  *tool-driven additive*, optionally + a stood-down extraction fork.)
+- **We can skip the entire vector/BM25/entity-graph stack for v1.** mem0 needs it because it's a
+  general-purpose backend at arbitrary scale; our per-board memory is small and lives front-end,
+  so **LLM-select-over-a-manifest (Claude Code style) is sufficient** and far less machinery. Add
+  a BM25 index (we already have Orama) only if volume demands it.
+- **Keep a mutation history/audit** (mem0's SQLite trail) — cheap, and it makes memory
+  inspectable/undoable, which fits our offline-first, user-trust posture.
+- **The three-tier scope maps directly**: `user_id`→L2 global, `board_id`→L1 board,
+  `run_id`→ephemeral session digest.
+
+## C.3 The one-paragraph takeaway
+
+Across Claude Code, Hermes, mem0, and the 2026 field, the durable core is the same: **extract
+scoped atomic facts, keep a small always-on surface + a retrieved-on-demand store, ground facts
+in time, and consolidate in the background.** The live disagreements are *how* to keep the store
+consistent (LLM mutation loop → losing ground to additive+dedup and temporal "close-don't-delete")
+and *how* to retrieve (vectors+graph vs LLM-select — and at our scale, LLM-select wins on
+simplicity). For Dim0 that argues for a **deliberately minimal v1**: a two-store curated memory
+(board + global), additive writes with deterministic dedup and an audit trail, LLM-select
+retrieval over a fenced manifest, a labeled board snapshot — and consolidation/temporal/graph
+deferred until we have volume that demands them.
+
+---
+
+## Sources (2026 landscape)
+
+- Vectorize — *Best AI Agent Memory Systems in 2026: 8 Frameworks Compared*
+- mem0.ai — *State of AI Agent Memory 2026*; *AI Memory Benchmarks 2026: LoCoMo, LongMemEval & BEAM*; *Graph-Based Memory Solutions*
+- n1n.ai / particula.tech / developersdigest — *Mem0 vs Zep vs Letta vs Cognee (2026)*
+- Zep/Graphiti + Letta/MemGPT explainers (gamgee.ai, codepointer, theaiengineer)
+- arXiv 2026: Memanto (typed semantic memory), MemMachine, MOSS (auditable memory), MemGuard (contamination defense)
+- Anthropic "Dreaming" consolidation primitive (May 2026), per landscape coverage
+
+(Cross-check any specific number against the primary source before quoting it externally — these
+are secondary write-ups.)

--- a/docs/plans/synthesis-agent-memory.md
+++ b/docs/plans/synthesis-agent-memory.md
@@ -1,0 +1,198 @@
+# Synthesis: agent memory & context across Claude Code, Hermes, and mem0
+
+Cross-cutting synthesis of the three systems studied in depth
+(`inspiration-claude-code-memory.md`, `inspiration-hermes-memory.md`,
+`inspiration-mem0-and-landscape.md`). Two questions: **what is the recurrent design every one
+of them converges on**, and **where do they genuinely differ** (those differences are the real
+design decisions we'll have to make). This doc deliberately stops short of resolving anything
+for Dim0 — that comes next, in `agent-context-memory.md`.
+
+## The three in one line each
+
+- **Claude Code** — a *curated-file* memory system: a capped `MEMORY.md` index + one file per
+  fact, LLM-select retrieval, a nightly distillation loop. Human-editable, no vectors.
+- **Hermes** — a *bounded-store + pluggable-provider* system: char-capped `MEMORY.md`/`USER.md`,
+  a self-improving skill loop, an external-provider plugin layer, and prompt-cache stability
+  baked into every placement decision.
+- **mem0** — a *storage/retrieval library* (not an agent): LLM extraction → atomic facts,
+  additive writes with deterministic dedup, hybrid vector+entity retrieval, scoped
+  user/session/agent. The "memory backend" the others could plug in.
+
+CC and Hermes are **harness** designs (assembly, injection, compaction, upkeep); mem0 is a
+**backend** design (extract, store, retrieve). That asymmetry explains most of the differences
+below — but the recurrent core holds across all three anyway.
+
+---
+
+## Part 1 — The recurrent design (what all three converge on)
+
+Twelve patterns appear in all three (or in both harnesses + implied by mem0's shape). These are
+the high-confidence, "this is just how it's done" core.
+
+### 1. Memory ≠ context. Durable store, retrieved into a per-request window.
+All three separate a **durable store** from the **live window** you assemble each turn. Nobody
+keeps everything in the prompt; nobody retrieves from raw history alone.
+
+### 2. Two-tier: a small always-on surface + a larger retrieved-on-demand store.
+- CC: `MEMORY.md` index (always, capped 200 lines/25KB) + per-fact files (retrieved ≤5).
+- Hermes: bounded `MEMORY.md`/`USER.md` block (always) + `session_search` FTS5 (on demand).
+- mem0: (implicit) top-k retrieval each call; the caller injects the small result set.
+The index/surface keeps always-on cost flat while the store grows unbounded.
+
+### 3. Extract atomic, self-contained, scoped facts.
+All three turn raw conversation into discrete facts, not transcripts.
+- CC: 4-type taxonomy, one fact per file.
+- Hermes: `memory` tool add/replace with a WHEN/SKIP rule.
+- mem0: LLM extraction, "15–80 words, self-contained, never generalize."
+
+### 4. A scope triad: user / session / agent(-or-project).
+- mem0: `user_id` / `run_id` / `agent_id` (explicit).
+- CC: user-scope vs project-scope (per-repo dir) + team scope.
+- Hermes: `USER.md` (user) vs `MEMORY.md` (agent/project) + per-profile isolation.
+"Who the user is" vs "what this workspace is" vs "the current session" is a universal axis.
+
+### 5. "Don't store what's derivable." A hard exclusion rule.
+- CC: *"Code patterns, architecture, git history… can be derived — do NOT save."*
+- Hermes: SKIP list — *"trivial/obvious info, easily re-discovered facts, task progress."*
+- mem0: extraction guardrails (`"There are branches in trees." → {"facts": []}`).
+Memory is for the non-derivable; everything else is re-read at request time.
+
+### 6. A cheap salience gate before extraction.
+All three refuse to memorize noise: CC's "explicit-save gate" (ask what's *surprising*),
+Hermes' trivial-prompt skip, mem0's empty-facts examples.
+
+### 7. Facts are time-stamped, and freshness is surfaced — memory is a snapshot.
+- CC: `"This memory is 47 days old… verify against current code before asserting."`
+- Hermes: date-only timestamps; frozen snapshot with a "re-check with git" workspace banner.
+- mem0: `created_at`/`updated_at`, temporal grounding ("convert relative → absolute dates").
+And all three inject a **point-in-time contract**: the model is told the store may be stale and
+to verify against current reality.
+
+### 8. Injection is layered and *placed* deliberately, with content fenced.
+Every system separates **mechanics** (how memory works) from **content** (the facts), and fences
+content so the model treats it as reference, not instruction:
+- CC: mechanics in system prompt; content in a hedged `<system-reminder>` user message;
+  per-turn recall as separate attachments.
+- Hermes: three-tier system prompt (stable/context/volatile) + per-turn recall in a
+  `<memory-context>` block on the user message.
+- mem0: returns results; the caller fences them (and Hermes-as-host does exactly this).
+
+### 9. Retrieval is per-turn and top-k-bounded.
+CC (LLM-select ≤5 per turn), Hermes (provider prefetch each turn), mem0 (top-k search) all
+recompute relevance for the *current* query and cap what's injected.
+
+### 10. Compaction is text-only, structured, and uses NO tools.
+Both harnesses compress the conversation with a **plain single-shot summarization call on a
+separate/aux model, no tools attached** (CC hard-denies tool calls; Hermes never passes a tools
+key), into a **fixed-section template**, and both frame the result as **reference-only** so the
+model doesn't re-execute finished work. (mem0 has no conversation loop, so N/A — but its
+`procedural_memory` summarization is likewise a plain call.)
+
+### 11. Persistent memory stays authoritative over the compaction summary.
+CC and Hermes both explicitly tell the model: the summary is background; your persistent memory
+(and current reality) win.
+
+### 12. A background/asynchronous consolidation-or-review pass.
+- CC: **autoDream** — nightly distill logs → curated `MEMORY.md` + topic files.
+- Hermes: **background review** (post-turn) + **Curator** (skill lifecycle).
+- mem0: no built-in pass, but the field's convergent answer (Anthropic "Dreaming", May 2026) is
+  the same idea; mem0 leans on additive-accumulate instead.
+Upkeep is a first-class, separate activity — not something the main loop does inline.
+
+**The recurrent core, in one sentence:** *extract scoped atomic non-derivable facts → keep a
+small always-on surface plus a retrieved-on-demand store → inject them fenced and time-stamped,
+recomputed per turn → compress the conversation (not the memory) with a tool-less structured
+summary → and consolidate the store in a background pass.*
+
+---
+
+## Part 2 — Where they genuinely differ (the real forks)
+
+These are the dimensions where the three make *different* choices. Each is a decision we'll
+inherit.
+
+### 2.1 Comparison matrix
+
+| Dimension | Claude Code | Hermes | mem0 |
+|---|---|---|---|
+| **Store form** | one file per fact + `MEMORY.md` index | two char-capped files (`MEMORY.md`+`USER.md`) | vector rows + entity collection + SQLite history |
+| **Cap unit** | lines/bytes (200 lines/25KB index) | **characters** (2200 / 1375), "model-independent" | none (unbounded; retrieval-gated) |
+| **Overflow handling** | truncate the index (+warning) | **reject → model consolidates → retry** | never overflows (accumulate) |
+| **Write consistency** | agent + passive fork write files; dedup by prompt | agent tool + background review; dedup by prompt | **additive + deterministic MD5 dedup**; no LLM mutation |
+| **UPDATE/DELETE** | model edits/removes files | model replace/remove; overflow forces it | explicit API only; classic LLM decision-loop now **dead code** |
+| **Retrieval** | **LLM-select over name+desc manifest** (≤5) | provider-specific (embedding / LLM dialectic / FTS) | **hybrid: semantic + BM25 + entity boost**, no LLM |
+| **Vectors/embeddings?** | **none** | optional (via provider) | **yes, core** |
+| **On-demand recall** | grep transcript JSONL | `session_search` FTS5 tool | the whole store is on-demand |
+| **User profile** | folded into `user`-type memories | **dedicated `USER.md` store** | `user_id`-scoped facts |
+| **Procedural memory** | — (no reusable procedures) | **skills** (first-class, self-authored) | `procedural_memory` mode (agent run summaries) |
+| **Self-improvement** | autoDream distills *memory* | `/learn` + review + Curator author *skills* | none (library) |
+| **External/shared memory** | team memory (server sync, one blob) | **pluggable provider interface** (8+ backends) | it *is* the pluggable backend |
+| **Injection site for recall** | `<system-reminder>` attachment | `<memory-context>` on user-message sidecar | caller's choice |
+| **Prompt-cache concern** | present (memoize) | **central design driver** (3-tier, sidecar, frozen snapshot) | N/A (library) |
+| **Consolidation** | nightly dream (time+session gated) | Curator (inactivity) + per-turn review | additive-accumulate (no pass) |
+| **Compaction template** | 9 chronological sections | 10+ state-machine sections (Active State/Blocked) | N/A |
+| **Native/API compaction** | Anthropic context editing | OpenAI Responses + Codex app-server | N/A |
+| **Editability** | `/memory` opens files in `$EDITOR` | `/journey`, write-approval gate | API + history/audit trail |
+| **Poisoning defense** | (light) | **scan on write+load; anti-self-poisoning rules; fence scrub** | (relies on host) |
+
+### 2.2 The four decisions that actually matter (where the disagreement is load-bearing)
+
+Most rows above are cosmetic. Four are genuine forks:
+
+**A. Write consistency: LLM mutation loop vs additive + deterministic dedup.**
+This is the sharpest disagreement — and it *moved*. mem0 **abandoned** its own LLM
+ADD/UPDATE/DELETE decision loop for additive writes with hash dedup (cheaper, no hallucinated
+destructive edits; the store grows and leans on retrieval ranking). CC/Hermes still let the model
+edit/remove, but gate it (overflow-forced consolidation in Hermes; passive-fork-writes-once in
+CC). Zep's "close, never delete" (temporal) is a third answer. **The trend is away from
+write-time LLM mutation.**
+
+**B. Retrieval: LLM-select vs vector/hybrid.**
+CC proves you can skip embeddings entirely — an LLM picks ≤5 files from a name+description
+manifest. mem0 is full hybrid (semantic+BM25+entity). Hermes punts to the provider. The choice is
+**scale-dependent**: LLM-select is dead simple and great at small N; hybrid scales but is
+machinery. This is the single biggest "what do we actually need" question for us.
+
+**C. Overflow: truncate vs consolidate vs accumulate.**
+CC truncates the index; Hermes rejects the write and makes the model consolidate (and shows
+remaining capacity); mem0 never caps (accumulate + retrieve). Three coherent philosophies for the
+same problem.
+
+**D. Upkeep: distill (dream) vs review-loop (skills) vs accumulate-and-forget.**
+CC distills memory nightly; Hermes runs a per-turn review *and* a Curator, and authors reusable
+*skills* (a capability the other two lack); mem0 does no upkeep and relies on additive growth +
+ranking. How much background machinery is worth it is a real cost/benefit call.
+
+### 2.3 The one capability only Hermes has
+
+**Procedural self-improvement — the agent authoring and maintaining its own reusable skills.**
+Neither CC (distills *facts*) nor mem0 (stores *facts*) turn "how we did this class of task" into
+a reusable, self-editing artifact. It's the most ambitious idea in the set — and the one with the
+most explicit **guardrails** (anti-self-poisoning rules), because a self-editing capability store
+can corrupt itself.
+
+---
+
+## Part 3 — The shape of the decision space (for the next pass)
+
+Reading the recurrent core + the four real forks together, the design space for *our* system
+collapses to a few choices, each with a clear default the evidence points to:
+
+- **Take the entire recurrent core (Part 1) as settled.** It's not controversial; build it.
+- **Fork A (write consistency):** evidence leans **additive + deterministic dedup + explicit
+  update/delete tool** (mem0's move, safest).
+- **Fork B (retrieval):** at our scale, evidence leans **LLM-select over a manifest** (CC), not
+  vectors — with BM25 (we have Orama) as a later pre-filter if volume demands.
+- **Fork C (overflow):** evidence leans **consolidate-on-overflow + show capacity** (Hermes) over
+  silent truncation.
+- **Fork D (upkeep):** evidence leans **defer** — additive-accumulate for v1 (mem0), add a
+  background distill later (CC/Hermes) only if the store gets noisy.
+- **Procedural skills:** powerful but **out of scope** for a first cut; note the anti-poisoning
+  rules for if/when we add any auto-extraction.
+
+Plus the two cross-cutting borrowings that cost little and matter a lot: **fence + sanitize
+recalled content** (Hermes) since our recalled node text is user-authored, and **a two-store
+split** (Hermes' `MEMORY.md`/`USER.md`) mapping to our board vs global memory.
+
+The next document (`agent-context-memory.md` revision) turns these leanings into resolved
+decisions with our offline-first / front-end-first constraints applied.


### PR DESCRIPTION
Add the design and research for the agent context/memory initiative: how the browser agent should gain board awareness, curated memory, and a better representation of past turns, plus the studies of Claude Code, Hermes, and mem0 that the design draws on. Documentation only, no code. This is the foundation the phased implementation PRs reference (Phase 1, the board snapshot, is a sibling code PR: `feat/board-snapshot`).

## Design

Ten markdown files under `docs/plans/`, in three groups:

| Group | Files | What it is |
| --- | --- | --- |
| Design | `agent-context-architecture.md`, `dim0-agent-context-review.md`, `synthesis-agent-memory.md`, `context-update-mechanisms.md` | the proposed architecture (schemas, triggers, phasing, test plan), the current-code review, the cross-system synthesis, and the update-mechanism model |
| CC deep-dives | `claude-code-message-representation.md`, `claude-code-compaction-prompt.md` | how Claude Code represents past turns and compresses context |
| Research | `inspiration-claude-code-memory.md`, `inspiration-hermes-memory.md`, `inspiration-mem0-and-landscape.md`, `agent-context-memory.md` | studies of each system and the 2026 landscape |

The single source for the plan is `agent-context-architecture.md`; the others are reference and are cited from it (Golden Rule: each fact lives in one place).

## Test plan

Documentation only, nothing to run. Code references in the review and architecture docs were verified against the actual source (file:line), and one overstatement was corrected: the browser engine does not capture reasoning, but the reasoning model and UI already exist from the legacy path, so the reasoning phase is a wiring task, not a from-scratch build.

## Notes

- No code, no behaviour change. Intended to land before or alongside the phased code PRs so they can reference the design.
- The research docs are large but on-demand (they live in `docs/plans/`, not the always-on `AGENTS.md`), per the repo's own docs guide.
- Could be split into a "research" and a "design" PR if lighter review is preferred.
