### PR TITLE
feat(agent): inject a deterministic board snapshot into the agent context

### DIFF
--- a/docs/offline-first-data-model.md
+++ b/docs/offline-first-data-model.md
@@ -39,6 +39,7 @@ open and an upgrade converge on the same shape).
 | `boards` | `id` | — | `BoardMeta` |
 | `views` | `boardId` | — | `BoardView` (camera/selection) |
 | `sync_meta` | `boardId` | — | durable `syncedSeq` cursor |
+| `snapshot_meta` | `boardId` | — | device-local `seenSeq` (agent board-snapshot cursor; not synced) |
 | `chats` | `id` | by-board | chat sessions |
 | `chat_messages` | `[chatUid, id]` | — | transcript rows |
 | `documents` | `id` | by-board | ingested doc metadata |

--- a/docs/offline-first-data-model.md
+++ b/docs/offline-first-data-model.md
@@ -86,7 +86,9 @@ replay. If the promoted board is the one currently open, the view MUST navigate
 `deleteBoard` removes the board across its stores in one transaction. Cascading
 `sync_meta` is **load-bearing**: a stale `syncedSeq` left behind would make a
 re-created same-id board treat fresh low-seq edits as already-acked
-(`pending()` skips `seq <= cursor`) → silent edit loss. Known gap: `mini_app_state`
+(`pending()` skips `seq <= cursor`) → silent edit loss. `snapshot_meta` (the agent
+snapshot cursor) is cascaded for the same reason: a stale `seenSeq` would omit
+fresh low-seq edits from the snapshot's "recent changes". Known gap: `mini_app_state`
 (keyed by `noteId`, no by-board index) is not cascaded — a storage leak, not data
 loss (roadmap).
 

--- a/webui/src/features/agent/local/board-snapshot.test.ts
+++ b/webui/src/features/agent/local/board-snapshot.test.ts
@@ -207,10 +207,34 @@ describe("renderBoardSnapshot", () => {
       for (let i = 0; i < size; i++) nodes.push(mkNode(`f${f}-n${i}`, { parentId: `f${f}` }))
     }
     const out = renderBoardSnapshot(buildBoardSnapshot(fakeStore(nodes), "f7", []), { title: "T" })
-    const moreLine = out.split("\n").find((l) => l.includes("more folders")) ?? ""
+    const moreLine = out.split("\n").find((l) => l.includes(" more (")) ?? ""
     expect(out).toContain("/F7 (current)") // current is shown
     expect(moreLine).toContain("F5") // the displaced 6th-largest folder is kept (not dropped)
     expect(moreLine).not.toContain("F7") // current is not re-listed / double-counted
+    // The Layers section counts layers, not folders (root is a layer): the header
+    // says "N total", and root appears in "+ more (…)" without being called a folder.
+    expect(out).toContain("Layers (9 total")
+    expect(moreLine).not.toContain("folder")
+  })
+
+
+  it("caps the selection list", () => {
+    const nodes = Array.from({ length: 12 }, (_, i) => mkNode(`s${i}`, { label: `Sel ${i}` }))
+    const out = render(
+      nodes,
+      null,
+      nodes.map((n) => n.id as unknown as string),
+    )
+    expect(out).toContain("Selection: 12 selected")
+    expect(out).toContain("+4 more") // 12 selected, 8 shown
+  })
+
+
+  it("shows the current layer even when it is an empty folder", () => {
+    // A folder node at root with no children; the user is inside it.
+    const out = render([mkNode("f", { kind: "folder", label: "Empty" }), mkNode("n")], "f")
+    expect(out).toContain("Layers (")
+    expect(out).toContain("/Empty (current): 0 nodes")
   })
 
 

--- a/webui/src/features/agent/local/board-snapshot.test.ts
+++ b/webui/src/features/agent/local/board-snapshot.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest"
+import type { BatchId, CanvasStore, ClientId, Node, NodeId, Op } from "@canvas-harness/core"
+import type { NoteNodeData } from "@/features/board/harness/convert/note-to-node"
+import type { OplogRecord } from "@/features/board/persist/local/idb"
+import { InMemoryEngine } from "@/features/board/persist/local/in-memory-engine"
+import { buildBoardSnapshot, readRecentOps, renderBoardSnapshot } from "./board-snapshot"
+
+
+type NodeOpts = { kind?: NoteNodeData["styleType"] | "document"; label?: string; parentId?: string; content?: string }
+
+
+const mkNode = (id: string, opts: NodeOpts = {}): Node => {
+  const isDoc = opts.kind === "document"
+  const structural = opts.kind && opts.kind !== "document" ? opts.kind : "rectangle"
+  const data: NoteNodeData = {
+    noteType: isDoc ? "document" : "note",
+    styleType: structural,
+    version: 1,
+    graphUid: "g",
+    parentId: opts.parentId,
+    label: opts.label !== undefined ? { markdown: opts.label } : undefined,
+    properties: {},
+  }
+  return { id: id as NodeId, type: "rect", x: 0, y: 0, w: 100, h: 100, angle: 0, z: 0, groups: [], content: opts.content, data }
+}
+
+
+const fakeStore = (nodes: Node[], selection: string[] = []): CanvasStore =>
+  ({ getAllNodes: () => nodes, getSelection: () => selection as unknown as NodeId[] }) as unknown as CanvasStore
+
+
+const opRec = (boardId: string, seq: number, ops: Op[]): OplogRecord => ({
+  boardId,
+  seq,
+  batch: { id: "b" as BatchId, clientId: "c" as ClientId, ts: 0, origin: "local", ops },
+})
+
+
+const render = (nodes: Node[], rootId: string | null = null, selection: string[] = [], recent: OplogRecord[] = []) =>
+  renderBoardSnapshot(buildBoardSnapshot(fakeStore(nodes, selection), rootId, recent), { title: "Test board" })
+
+
+describe("buildBoardSnapshot", () => {
+  it("returns an empty snapshot for an empty board", () => {
+    const snap = buildBoardSnapshot(fakeStore([]), null, [])
+    expect(snap.total).toBe(0)
+    expect(snap.counts).toEqual({})
+    expect(snap.layers).toEqual([])
+  })
+
+
+  it("counts nodes by structural kind (styleType), not noteType", () => {
+    const snap = buildBoardSnapshot(
+      fakeStore([
+        mkNode("a"),
+        mkNode("b"),
+        mkNode("f", { kind: "folder" }),
+        mkNode("s", { kind: "sheet" }),
+        mkNode("m", { kind: "mini-app" }),
+        mkNode("d", { kind: "document" }),
+      ]),
+      null,
+      [],
+    )
+    expect(snap.counts).toEqual({ note: 2, folder: 1, sheet: 1, "mini-app": 1, document: 1 })
+    expect(snap.total).toBe(6)
+  })
+
+
+  it("derives titles: label → first content line → (untitled)", () => {
+    const snap = buildBoardSnapshot(
+      fakeStore([
+        mkNode("a", { label: "My label" }),
+        mkNode("b", { content: "\n  first content line\nsecond" }),
+        mkNode("c"),
+      ]),
+      null,
+      [],
+    )
+    const titles = snap.layers[0].sampleTitles
+    expect(titles).toContain("My label")
+    expect(titles).toContain("first content line")
+    expect(titles).toContain("(untitled)")
+  })
+
+
+  it("is flat when every node is at root, foldered otherwise", () => {
+    expect(buildBoardSnapshot(fakeStore([mkNode("a"), mkNode("b")]), null, []).flat).toBe(true)
+    const foldered = buildBoardSnapshot(
+      fakeStore([mkNode("f", { kind: "folder" }), mkNode("a", { parentId: "f" })]),
+      null,
+      [],
+    )
+    expect(foldered.flat).toBe(false)
+  })
+
+
+  it("groups nodes into layers by parentId and marks the current layer", () => {
+    const snap = buildBoardSnapshot(
+      fakeStore([
+        mkNode("f", { kind: "folder", label: "Papers" }),
+        mkNode("a", { parentId: "f" }),
+        mkNode("b", { parentId: "f" }),
+        mkNode("root1"),
+      ]),
+      "f",
+      [],
+    )
+    const papers = snap.layers.find((l) => l.rootId === "f")
+    expect(papers?.title).toBe("Papers")
+    expect(papers?.count).toBe(2)
+    expect(snap.currentLayer).toBe("f")
+  })
+
+
+  it("lands orphan nodes (dangling parentId) at root rather than a phantom layer", () => {
+    const snap = buildBoardSnapshot(fakeStore([mkNode("a", { parentId: "ghost" }), mkNode("b")]), null, [])
+    // Only the root layer exists; the orphan is merged into it.
+    expect(snap.layers.map((l) => l.rootId)).toEqual([null])
+    expect(snap.layers[0].count).toBe(2)
+  })
+
+
+  it("resolves selection to titles and ignores stale selection ids", () => {
+    const snap = buildBoardSnapshot(
+      fakeStore([mkNode("a", { label: "Alpha" }), mkNode("b", { label: "Beta" })], ["a", "missing"]),
+      null,
+      [],
+    )
+    expect(snap.selection).toEqual(["Alpha"])
+  })
+})
+
+
+describe("recent-changes collapse", () => {
+  const board = "bd"
+
+  it("collapses add+edit to a single add, and add+remove cancels", () => {
+    const ops: OplogRecord[] = [
+      opRec(board, 1, [{ type: "node.add", node: mkNode("a", { label: "A" }) }]),
+      opRec(board, 2, [{ type: "node.update", id: "a" as NodeId, patch: {}, prev: {} }]),
+      opRec(board, 3, [{ type: "node.add", node: mkNode("b", { label: "B" }) }]),
+      opRec(board, 4, [{ type: "node.remove", node: mkNode("b", { label: "B" }) }]),
+    ]
+    const snap = buildBoardSnapshot(fakeStore([mkNode("a", { label: "A" })]), null, ops)
+    expect(snap.recent).toEqual([{ id: "a", op: "add", label: "A" }])
+  })
+
+
+  it("edit+remove becomes a delete, with the label from the remove op payload", () => {
+    const ops: OplogRecord[] = [
+      opRec(board, 1, [{ type: "node.update", id: "x" as NodeId, patch: {}, prev: {} }]),
+      opRec(board, 2, [{ type: "node.remove", node: mkNode("x", { label: "Gone" }) }]),
+    ]
+    const snap = buildBoardSnapshot(fakeStore([]), null, ops)
+    expect(snap.recent).toEqual([{ id: "x", op: "delete", label: "Gone" }])
+  })
+
+
+  it("ignores edge ops", () => {
+    const ops: OplogRecord[] = [
+      opRec(board, 1, [{ type: "edge.add", edge: { id: "e" } as never }]),
+    ]
+    expect(buildBoardSnapshot(fakeStore([]), null, ops).recent).toEqual([])
+  })
+})
+
+
+describe("renderBoardSnapshot", () => {
+  it("renders the one-line empty form", () => {
+    expect(render([])).toBe("Board snapshot: empty board — no nodes yet.")
+  })
+
+
+  it("renders a flat board with a Nodes line and no Layers heading", () => {
+    const out = render([mkNode("a", { label: "One" }), mkNode("b", { label: "Two" })])
+    expect(out).toContain("all at root (flat)")
+    expect(out).toContain("- Nodes: ")
+    expect(out).not.toContain("Layers (")
+  })
+
+
+  it("caps the Nodes list and notes the truncation", () => {
+    const many = Array.from({ length: 40 }, (_, i) => mkNode(`n${i}`, { label: `Note ${i}` }))
+    const out = render(many)
+    expect(out).toMatch(/showing \d+ of 40/)
+  })
+
+
+  it("always includes the current layer even when it isn't in the top-K by size", () => {
+    const nodes: Node[] = []
+    // 8 folders; the current one ("small") is the smallest so it falls outside top-6.
+    for (let f = 0; f < 8; f++) {
+      nodes.push(mkNode(`f${f}`, { kind: "folder", label: `F${f}` }))
+      const size = f === 7 ? 1 : 10 - f
+      for (let i = 0; i < size; i++) nodes.push(mkNode(`f${f}-n${i}`, { parentId: `f${f}` }))
+    }
+    const out = renderBoardSnapshot(buildBoardSnapshot(fakeStore(nodes), "f7", []), { title: "T" })
+    expect(out).toContain("Layers (")
+    expect(out).toContain("/F7 (current)")
+    expect(out).toContain("more folders")
+  })
+
+
+  it("renders a Selection line only when something is selected", () => {
+    expect(render([mkNode("a", { label: "A" })])).not.toContain("Selection:")
+    expect(render([mkNode("a", { label: "A" })], null, ["a"])).toContain('Selection: 1 selected — "A"')
+  })
+
+
+  it("omits recent changes when nothing changed, and lists them when present", () => {
+    const out = renderBoardSnapshot(buildBoardSnapshot(fakeStore([mkNode("a")]), null, []), { title: "T" })
+    expect(out).not.toContain("Recent changes")
+    const changed = renderBoardSnapshot(
+      buildBoardSnapshot(fakeStore([mkNode("a", { label: "A" })]), null, [
+        opRec("b", 1, [{ type: "node.add", node: mkNode("a", { label: "A" }) }]),
+      ]),
+      { title: "T" },
+    )
+    expect(changed).toContain("Recent changes since you last checked: +1 added")
+  })
+})
+
+
+describe("readRecentOps", () => {
+  it("reads only oplog records past the given seq for the board", async () => {
+    const engine = new InMemoryEngine()
+    for (let seq = 1; seq <= 5; seq++) {
+      await engine.put("oplog", opRec("board-a", seq, []))
+    }
+    await engine.put("oplog", opRec("board-b", 1, []))
+
+    const since2 = await readRecentOps(engine, "board-a", 2)
+    expect(since2.map((r) => r.seq)).toEqual([3, 4, 5])
+
+    const all = await readRecentOps(engine, "board-a", 0)
+    expect(all.map((r) => r.seq)).toEqual([1, 2, 3, 4, 5])
+    engine.close()
+  })
+
+
+  it("round-trips the per-device snapshot_meta cursor", async () => {
+    const engine = new InMemoryEngine()
+    await engine.put("snapshot_meta", { boardId: "b", seenSeq: 42 })
+    expect(await engine.get("snapshot_meta", "b")).toEqual({ boardId: "b", seenSeq: 42 })
+    engine.close()
+  })
+})

--- a/webui/src/features/agent/local/board-snapshot.test.ts
+++ b/webui/src/features/agent/local/board-snapshot.test.ts
@@ -157,6 +157,16 @@ describe("recent-changes collapse", () => {
   })
 
 
+  it("keeps a delete when a stray update op follows a remove for the same node", () => {
+    const ops: OplogRecord[] = [
+      opRec(board, 1, [{ type: "node.remove", node: mkNode("x", { label: "X" }) }]),
+      opRec(board, 2, [{ type: "node.update", id: "x" as NodeId, patch: {}, prev: {} }]),
+    ]
+    const snap = buildBoardSnapshot(fakeStore([]), null, ops)
+    expect(snap.recent).toEqual([{ id: "x", op: "delete", label: "X" }])
+  })
+
+
   it("ignores edge ops", () => {
     const ops: OplogRecord[] = [
       opRec(board, 1, [{ type: "edge.add", edge: { id: "e" } as never }]),
@@ -187,18 +197,32 @@ describe("renderBoardSnapshot", () => {
   })
 
 
-  it("always includes the current layer even when it isn't in the top-K by size", () => {
+  it("includes the current layer outside top-K without dropping the displaced folder or double-counting", () => {
+    // 8 folders sized distinctly and all > the root layer (8 folder nodes) except
+    // the current one (F7, size 1), so F7 is outside the top-6 by size.
     const nodes: Node[] = []
-    // 8 folders; the current one ("small") is the smallest so it falls outside top-6.
     for (let f = 0; f < 8; f++) {
       nodes.push(mkNode(`f${f}`, { kind: "folder", label: `F${f}` }))
-      const size = f === 7 ? 1 : 10 - f
+      const size = f === 7 ? 1 : 20 - f // F0=20 … F6=14, F7=1
       for (let i = 0; i < size; i++) nodes.push(mkNode(`f${f}-n${i}`, { parentId: `f${f}` }))
     }
     const out = renderBoardSnapshot(buildBoardSnapshot(fakeStore(nodes), "f7", []), { title: "T" })
-    expect(out).toContain("Layers (")
-    expect(out).toContain("/F7 (current)")
-    expect(out).toContain("more folders")
+    const moreLine = out.split("\n").find((l) => l.includes("more folders")) ?? ""
+    expect(out).toContain("/F7 (current)") // current is shown
+    expect(moreLine).toContain("F5") // the displaced 6th-largest folder is kept (not dropped)
+    expect(moreLine).not.toContain("F7") // current is not re-listed / double-counted
+  })
+
+
+  it("surfaces recent changes even when the board is now empty (everything deleted)", () => {
+    const out = renderBoardSnapshot(
+      buildBoardSnapshot(fakeStore([]), null, [
+        opRec("b", 1, [{ type: "node.remove", node: mkNode("a", { label: "Gone" }) }]),
+      ]),
+      { title: "T" },
+    )
+    expect(out).toContain("empty board")
+    expect(out).toContain("Recent changes since you last checked: -1 deleted")
   })
 
 

--- a/webui/src/features/agent/local/board-snapshot.test.ts
+++ b/webui/src/features/agent/local/board-snapshot.test.ts
@@ -167,6 +167,17 @@ describe("recent-changes collapse", () => {
   })
 
 
+  it("drops a phantom edit for a node added+removed (cancelled) then stray-updated", () => {
+    const ops: OplogRecord[] = [
+      opRec(board, 1, [{ type: "node.add", node: mkNode("y", { label: "Y" }) }]),
+      opRec(board, 2, [{ type: "node.remove", node: mkNode("y", { label: "Y" }) }]),
+      opRec(board, 3, [{ type: "node.update", id: "y" as NodeId, patch: {}, prev: {} }]),
+    ]
+    // "y" isn't on the board now, so the net change is dropped (no phantom edit).
+    expect(buildBoardSnapshot(fakeStore([]), null, ops).recent).toEqual([])
+  })
+
+
   it("ignores edge ops", () => {
     const ops: OplogRecord[] = [
       opRec(board, 1, [{ type: "edge.add", edge: { id: "e" } as never }]),

--- a/webui/src/features/agent/local/board-snapshot.ts
+++ b/webui/src/features/agent/local/board-snapshot.ts
@@ -1,0 +1,322 @@
+/**
+ * Board snapshot — the deterministic, LLM-free "state of the board now" that
+ * grounds the agent (the local analog of Claude Code's `gitStatus` block).
+ *
+ * Two pure functions + one indexed oplog read:
+ *  - `buildBoardSnapshot(store, rootId, recentOps)` reads the live scene.
+ *  - `renderBoardSnapshot(snapshot, opts)` renders it to a budgeted text block.
+ *  - `readRecentOps(engine, boardId, sinceSeq)` pulls the oplog tail for the
+ *    "recent changes" line.
+ *
+ * Recomputed on read (never stored), so node adds are self-healing — there is
+ * nothing to invalidate. See docs/plans/agent-context-architecture.md.
+ */
+import type { CanvasStore, Node } from "@canvas-harness/core"
+import type { NoteNodeData } from "@/features/board/harness/convert/note-to-node"
+import type { OplogRecord } from "@/features/board/persist/local/idb"
+import type { StorageEngine } from "@/features/board/persist/local/engine"
+
+
+/** How a node is categorized in the snapshot's type breakdown. */
+export type NodeKind = "note" | "folder" | "sheet" | "mini-app" | "code-sandbox" | "widget" | "document"
+
+
+/** One folder layer (or root) in the board's structure. */
+export type SnapshotLayer = {
+  /** `parentId` of the layer's members; `null` = root. */
+  rootId: string | null
+  /** Folder label, or `"root"`. */
+  title: string
+  count: number
+  /** Prioritized (selected/recent first), per-layer-capped sample of member titles. */
+  sampleTitles: string[]
+}
+
+
+/** A net change to one node since the last snapshot mark. */
+export type RecentChange = { id: string; label: string; op: "add" | "edit" | "delete" }
+
+
+export type BoardSnapshot = {
+  total: number
+  /** Node counts keyed by `NodeKind`, e.g. `{ note: 22, folder: 2 }`. */
+  counts: Record<string, number>
+  /** True when every node is at root (no folder layers to outline). */
+  flat: boolean
+  /** All layers, sorted by count desc. Root is always present when nodes exist. */
+  layers: SnapshotLayer[]
+  /** `rootId` of the layer currently projected in the view (`null` = root). */
+  currentLayer: string | null
+  /** Titles of the currently selected nodes. */
+  selection: string[]
+  /** Net changes since the snapshot mark (add / edit / delete), collapsed per node. */
+  recent: RecentChange[]
+}
+
+
+// Budget/format constants — tune with telemetry.
+const MAX_LAYERS = 6
+const PER_LAYER_TITLES = 4
+const CURRENT_LAYER_TITLES = 6
+const RECENT_TITLES = 5
+const TITLE_MAX_CHARS = 40
+/** Fallback tail size for the recent-changes read when no session cursor exists. */
+export const RECENT_OPS_WINDOW = 50
+
+
+const STRUCTURAL_KINDS: ReadonlySet<string> = new Set(["folder", "sheet", "mini-app", "code-sandbox", "widget"])
+
+
+const KIND_PLURAL: Record<NodeKind, [string, string]> = {
+  note: ["note", "notes"],
+  folder: ["folder", "folders"],
+  sheet: ["sheet", "sheets"],
+  "mini-app": ["mini-app", "mini-apps"],
+  "code-sandbox": ["code sandbox", "code sandboxes"],
+  widget: ["widget", "widgets"],
+  document: ["document", "documents"],
+}
+
+
+const nodeData = (n: Node): Partial<NoteNodeData> => (n.data ?? {}) as Partial<NoteNodeData>
+
+
+/**
+ * Categorize a node. `noteType` only distinguishes note vs document; the
+ * structural type (folder / sheet / mini-app / …) rides on `styleType`.
+ */
+const nodeKind = (data: Partial<NoteNodeData>): NodeKind => {
+  if (data.noteType === "document") return "document"
+  const st = data.styleType
+  return st && STRUCTURAL_KINDS.has(st) ? (st as NodeKind) : "note"
+}
+
+
+const firstLine = (s: string | undefined): string =>
+  (s ?? "").split("\n").find((l) => l.trim())?.trim() ?? ""
+
+
+const truncate = (s: string, max: number): string =>
+  s.length <= max ? s : `${s.slice(0, max - 1).trimEnd()}…`
+
+
+/** Title: `data.label` → first non-blank line of content → `"(untitled)"`, truncated. */
+const nodeTitle = (n: Node): string => {
+  const data = nodeData(n)
+  const label = data.label?.markdown?.trim()
+  return truncate(label || firstLine(n.content) || "(untitled)", TITLE_MAX_CHARS)
+}
+
+
+const nodeIdOf = (n: Node): string => n.id as unknown as string
+
+
+/**
+ * Build the structured snapshot from the live scene. Pure w.r.t. `store` (reads
+ * only), no LLM. `recentOps` is the pre-read oplog tail (see `readRecentOps`).
+ */
+export const buildBoardSnapshot = (
+  store: CanvasStore,
+  rootId: string | null,
+  recentOps: OplogRecord[],
+): BoardSnapshot => {
+  const nodes = store.getAllNodes()
+
+  const counts: Record<string, number> = {}
+  const byParent = new Map<string | null, Node[]>()
+  const folderLabels = new Map<string, string>()
+  const titleById = new Map<string, string>()
+
+  for (const n of nodes) {
+    const data = nodeData(n)
+    const kind = nodeKind(data)
+    counts[kind] = (counts[kind] ?? 0) + 1
+    titleById.set(nodeIdOf(n), nodeTitle(n))
+    if (kind === "folder") folderLabels.set(nodeIdOf(n), nodeTitle(n))
+    const parent = data.parentId ?? null
+    const arr = byParent.get(parent)
+    if (arr) arr.push(n)
+    else byParent.set(parent, [n])
+  }
+
+  // Orphans — a `parentId` pointing at no existing folder — land at root rather
+  // than a phantom layer.
+  const root = byParent.get(null) ?? []
+  for (const [parent, arr] of byParent) {
+    if (parent !== null && !folderLabels.has(parent)) {
+      root.push(...arr)
+      byParent.delete(parent)
+    }
+  }
+  if (root.length) byParent.set(null, root)
+
+  const selected = new Set(store.getSelection().map((id) => id as unknown as string))
+  const selection = nodes.filter((n) => selected.has(nodeIdOf(n))).map((n) => titleById.get(nodeIdOf(n)) ?? nodeTitle(n))
+
+  const recent = collapseRecent(recentOps, titleById)
+  const recentIds = new Set(recent.map((r) => r.id))
+
+  const layers: SnapshotLayer[] = []
+  for (const [parent, arr] of byParent) {
+    const isCurrent = parent === rootId
+    layers.push({
+      rootId: parent,
+      title: parent === null ? "root" : folderLabels.get(parent) ?? "root",
+      count: arr.length,
+      sampleTitles: sampleTitles(arr, selected, recentIds, isCurrent ? CURRENT_LAYER_TITLES : PER_LAYER_TITLES),
+    })
+  }
+  layers.sort((a, b) => b.count - a.count)
+
+  return {
+    total: nodes.length,
+    counts,
+    flat: byParent.size <= 1 && byParent.has(null),
+    layers,
+    currentLayer: rootId,
+    selection,
+    recent,
+  }
+}
+
+
+/** Pick titles for a layer, putting selected + recently-changed members first. */
+const sampleTitles = (nodes: Node[], selected: Set<string>, recentIds: Set<string>, cap: number): string[] => {
+  const priority = (n: Node): number => (selected.has(nodeIdOf(n)) ? 0 : recentIds.has(nodeIdOf(n)) ? 1 : 2)
+  return [...nodes]
+    .sort((a, b) => priority(a) - priority(b))
+    .slice(0, cap)
+    .map((n) => nodeTitle(n))
+}
+
+
+/**
+ * Collapse the oplog tail to one net change per node id, in op order:
+ * add+remove cancels, add+edit stays add, edit+remove becomes delete, a re-add
+ * after remove becomes add. Edge/group/frame ops are ignored.
+ */
+const collapseRecent = (recentOps: OplogRecord[], liveTitles: Map<string, string>): RecentChange[] => {
+  const net = new Map<string, "add" | "edit" | "delete">()
+  const labels = new Map<string, string>()
+  for (const rec of recentOps) {
+    for (const op of rec.batch.ops) {
+      if (op.type === "node.add") {
+        net.set(nodeIdOf(op.node), "add")
+        labels.set(nodeIdOf(op.node), nodeTitle(op.node))
+      } else if (op.type === "node.update") {
+        const id = op.id as unknown as string
+        if (net.get(id) !== "add") net.set(id, "edit")
+      } else if (op.type === "node.remove") {
+        const id = nodeIdOf(op.node)
+        if (net.get(id) === "add") net.delete(id)
+        else net.set(id, "delete")
+        labels.set(id, nodeTitle(op.node))
+      }
+    }
+  }
+  return [...net].map(([id, op]) => ({ id, op, label: labels.get(id) ?? liveTitles.get(id) ?? "(untitled)" }))
+}
+
+
+const kindLabel = (kind: string, n: number): string => {
+  const forms = KIND_PLURAL[kind as NodeKind]
+  const [one, many] = forms ?? [kind, `${kind}s`]
+  return `${n} ${n === 1 ? one : many}`
+}
+
+
+/**
+ * Render the snapshot to the injected text block (budget-driven, deterministic).
+ * `opts.title` is the board title.
+ */
+export const renderBoardSnapshot = (
+  snapshot: BoardSnapshot,
+  opts: { title: string },
+): string => {
+  if (snapshot.total === 0) return "Board snapshot: empty board — no nodes yet."
+
+  const lines: string[] = ["Board snapshot (point-in-time — re-check with tools before acting on it):"]
+  lines.push(`- Title: ${opts.title}`)
+
+  const breakdown = Object.entries(snapshot.counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([kind, n]) => kindLabel(kind, n))
+    .join(", ")
+  lines.push(`- ${snapshot.total} node${snapshot.total === 1 ? "" : "s"}: ${breakdown}${snapshot.flat ? " — all at root (flat)" : ""}`)
+
+  if (snapshot.flat) {
+    const root = snapshot.layers.find((l) => l.rootId === null)
+    if (root) lines.push(`- Nodes: ${root.sampleTitles.join(", ")}${root.count > root.sampleTitles.length ? `, … (showing ${root.sampleTitles.length} of ${root.count})` : ""}`)
+  } else {
+    lines.push(...renderLayers(snapshot))
+  }
+
+  if (snapshot.selection.length) {
+    lines.push(`- Selection: ${snapshot.selection.length} selected — ${snapshot.selection.map((t) => `"${t}"`).join(", ")}`)
+  }
+
+  const recentLine = renderRecent(snapshot.recent)
+  if (recentLine) lines.push(recentLine)
+
+  return lines.join("\n")
+}
+
+
+/** The "Layers (…)" outline: top-K by size, current always included, remainder collapsed. */
+const renderLayers = (snapshot: BoardSnapshot): string[] => {
+  const layers = snapshot.layers
+  const shown = layers.slice(0, MAX_LAYERS)
+  // Guarantee the current layer is present even when it isn't in the top-K by size.
+  const current = layers.find((l) => l.rootId === snapshot.currentLayer)
+  if (current && !shown.includes(current)) {
+    shown[shown.length - 1] = current
+  }
+
+  const header = `- Layers (${layers.length} folder${layers.length === 1 ? "" : "s"}; showing ${Math.min(shown.length, layers.length)} by size):`
+  const rows = shown.map((l) => {
+    const path = l.rootId === null ? "/ (root" : `/${l.title}`
+    const marker = l.rootId === snapshot.currentLayer ? (l.rootId === null ? ", current)" : " (current)") : l.rootId === null ? ")" : ""
+    const titles = l.sampleTitles.length ? ` — ${l.sampleTitles.join(", ")}${l.count > l.sampleTitles.length ? ", …" : ""}` : ""
+    return `  - ${path}${marker}: ${l.count} node${l.count === 1 ? "" : "s"}${titles}`
+  })
+
+  const hidden = layers.slice(shown.length)
+  if (hidden.length) {
+    const names = hidden.slice(0, 4).map((l) => l.title).join(", ")
+    const nodes = hidden.reduce((sum, l) => sum + l.count, 0)
+    rows.push(`  - + ${hidden.length} more folder${hidden.length === 1 ? "" : "s"} (${names}${hidden.length > 4 ? ", …" : ""}) — ${nodes} nodes total`)
+  }
+  return [header, ...rows]
+}
+
+
+/** The "Recent changes" line, or null when nothing changed. */
+const renderRecent = (recent: RecentChange[]): string | null => {
+  if (!recent.length) return null
+  const added = recent.filter((r) => r.op === "add")
+  const edited = recent.filter((r) => r.op === "edit")
+  const deleted = recent.filter((r) => r.op === "delete")
+  const part = (verb: string, rows: RecentChange[]): string | null => {
+    if (!rows.length) return null
+    const titles = rows.slice(0, RECENT_TITLES).map((r) => `"${r.label}"`).join(", ")
+    const more = rows.length > RECENT_TITLES ? `, +${rows.length - RECENT_TITLES} more` : ""
+    return `${verb === "added" ? "+" : verb === "edited" ? "~" : "-"}${rows.length} ${verb} (${titles}${more})`
+  }
+  const parts = [part("added", added), part("edited", edited), part("deleted", deleted)].filter(Boolean)
+  return `- Recent changes since you last checked: ${parts.join(", ")}`
+}
+
+
+/**
+ * Read the oplog tail past `sinceSeq` for the board — one indexed range query.
+ * Pass `0` to read the whole log (bounded by the caller to `RECENT_OPS_WINDOW`
+ * when there is no session cursor).
+ */
+export const readRecentOps = (
+  engine: StorageEngine,
+  boardId: string,
+  sinceSeq: number,
+): Promise<OplogRecord[]> =>
+  engine.list<OplogRecord>("oplog", {
+    range: { lower: [boardId, sinceSeq], upper: [boardId, Number.MAX_SAFE_INTEGER], lowerOpen: true },
+  })

--- a/webui/src/features/agent/local/board-snapshot.ts
+++ b/webui/src/features/agent/local/board-snapshot.ts
@@ -223,7 +223,12 @@ const collapseRecent = (recentOps: OplogRecord[], liveTitles: Map<string, string
       }
     }
   }
-  return [...net].map(([id, op]) => ({ id, op, label: labels.get(id) ?? liveTitles.get(id) ?? "(untitled)" }))
+  // Drop phantom add/edit for a node that isn't on the board now (e.g. an
+  // add+remove that cancelled, then a stray update flips the empty entry to
+  // "edit"). Deletes are always kept (the node is legitimately gone).
+  return [...net]
+    .filter(([id, op]) => op === "delete" || liveTitles.has(id))
+    .map(([id, op]) => ({ id, op, label: labels.get(id) ?? liveTitles.get(id) ?? "(untitled)" }))
 }
 
 

--- a/webui/src/features/agent/local/board-snapshot.ts
+++ b/webui/src/features/agent/local/board-snapshot.ts
@@ -59,6 +59,7 @@ const MAX_LAYERS = 6
 const PER_LAYER_TITLES = 4
 const CURRENT_LAYER_TITLES = 6
 const RECENT_TITLES = 5
+const MAX_SELECTION_TITLES = 8
 const TITLE_MAX_CHARS = 40
 
 
@@ -164,12 +165,19 @@ export const buildBoardSnapshot = (
       sampleTitles: sampleTitles(arr, selected, recentIds, isCurrent ? CURRENT_LAYER_TITLES : PER_LAYER_TITLES),
     })
   }
+  // Inside an empty folder there are no members and thus no layer — add it so the
+  // outline still shows where the user is.
+  if (rootId !== null && !layers.some((l) => l.rootId === rootId)) {
+    layers.push({ rootId, title: folderLabels.get(rootId) ?? "(current folder)", count: 0, sampleTitles: [] })
+  }
   layers.sort((a, b) => b.count - a.count)
 
   return {
     total: nodes.length,
     counts,
-    flat: byParent.size <= 1 && byParent.has(null),
+    // Flat only when the sole layer is root and we're viewing root; inside any
+    // folder (rootId set) there is structure to outline.
+    flat: layers.length <= 1 && layers[0]?.rootId === null,
     layers,
     currentLayer: rootId,
     selection,
@@ -258,7 +266,9 @@ export const renderBoardSnapshot = (
   }
 
   if (snapshot.selection.length) {
-    lines.push(`- Selection: ${snapshot.selection.length} selected — ${snapshot.selection.map((t) => `"${t}"`).join(", ")}`)
+    const sel = snapshot.selection.slice(0, MAX_SELECTION_TITLES)
+    const more = snapshot.selection.length > sel.length ? `, +${snapshot.selection.length - sel.length} more` : ""
+    lines.push(`- Selection: ${snapshot.selection.length} selected — ${sel.map((t) => `"${t}"`).join(", ")}${more}`)
   }
 
   const recentLine = renderRecent(snapshot.recent)
@@ -268,7 +278,10 @@ export const renderBoardSnapshot = (
 }
 
 
-/** The "Layers (…)" outline: top-K by size, current always included, remainder collapsed. */
+/**
+ * The "Layers (…)" outline: top-K by size, current always included, remainder
+ * collapsed. Root is a *layer*, not a folder, so the wording says "layers".
+ */
 const renderLayers = (snapshot: BoardSnapshot): string[] => {
   const layers = snapshot.layers
   const shown = layers.slice(0, MAX_LAYERS)
@@ -277,8 +290,11 @@ const renderLayers = (snapshot: BoardSnapshot): string[] => {
   if (current && !shown.includes(current)) {
     shown[shown.length - 1] = current
   }
+  // Everything not shown (compute after the current-layer swap, so the displaced
+  // top-K layer lands here and the swapped-in current layer is not double-counted).
+  const hidden = layers.filter((l) => !shown.includes(l))
 
-  const header = `- Layers (${layers.length} folder${layers.length === 1 ? "" : "s"}; showing ${Math.min(shown.length, layers.length)} by size):`
+  const header = `- Layers (${layers.length} total${hidden.length ? `, top ${shown.length} by size` : ""}):`
   const rows = shown.map((l) => {
     const path = l.rootId === null ? "/ (root" : `/${l.title}`
     const marker = l.rootId === snapshot.currentLayer ? (l.rootId === null ? ", current)" : " (current)") : l.rootId === null ? ")" : ""
@@ -286,13 +302,10 @@ const renderLayers = (snapshot: BoardSnapshot): string[] => {
     return `  - ${path}${marker}: ${l.count} node${l.count === 1 ? "" : "s"}${titles}`
   })
 
-  // Everything not shown (compute after the current-layer swap, so the displaced
-  // top-K folder lands here and the swapped-in current layer is not double-counted).
-  const hidden = layers.filter((l) => !shown.includes(l))
   if (hidden.length) {
     const names = hidden.slice(0, 4).map((l) => l.title).join(", ")
     const nodes = hidden.reduce((sum, l) => sum + l.count, 0)
-    rows.push(`  - + ${hidden.length} more folder${hidden.length === 1 ? "" : "s"} (${names}${hidden.length > 4 ? ", …" : ""}) — ${nodes} nodes total`)
+    rows.push(`  - + ${hidden.length} more (${names}${hidden.length > 4 ? ", …" : ""}) — ${nodes} nodes total`)
   }
   return [header, ...rows]
 }

--- a/webui/src/features/agent/local/board-snapshot.ts
+++ b/webui/src/features/agent/local/board-snapshot.ts
@@ -60,8 +60,6 @@ const PER_LAYER_TITLES = 4
 const CURRENT_LAYER_TITLES = 6
 const RECENT_TITLES = 5
 const TITLE_MAX_CHARS = 40
-/** Fallback tail size for the recent-changes read when no session cursor exists. */
-export const RECENT_OPS_WINDOW = 50
 
 
 const STRUCTURAL_KINDS: ReadonlySet<string> = new Set(["folder", "sheet", "mini-app", "code-sandbox", "widget"])
@@ -205,7 +203,10 @@ const collapseRecent = (recentOps: OplogRecord[], liveTitles: Map<string, string
         labels.set(nodeIdOf(op.node), nodeTitle(op.node))
       } else if (op.type === "node.update") {
         const id = op.id as unknown as string
-        if (net.get(id) !== "add") net.set(id, "edit")
+        // Don't let a stray update override an add (title stays the add's) or a
+        // delete (a node can't be edited after removal — keep the delete).
+        const prev = net.get(id)
+        if (prev !== "add" && prev !== "delete") net.set(id, "edit")
       } else if (op.type === "node.remove") {
         const id = nodeIdOf(op.node)
         if (net.get(id) === "add") net.delete(id)
@@ -233,7 +234,12 @@ export const renderBoardSnapshot = (
   snapshot: BoardSnapshot,
   opts: { title: string },
 ): string => {
-  if (snapshot.total === 0) return "Board snapshot: empty board — no nodes yet."
+  if (snapshot.total === 0) {
+    // Still surface recent changes on a now-empty board — a full clear since you
+    // last checked is exactly the "what moved while I was gone" signal to keep.
+    const recentLine = renderRecent(snapshot.recent)
+    return `Board snapshot: empty board — no nodes yet.${recentLine ? `\n${recentLine}` : ""}`
+  }
 
   const lines: string[] = ["Board snapshot (point-in-time — re-check with tools before acting on it):"]
   lines.push(`- Title: ${opts.title}`)
@@ -280,7 +286,9 @@ const renderLayers = (snapshot: BoardSnapshot): string[] => {
     return `  - ${path}${marker}: ${l.count} node${l.count === 1 ? "" : "s"}${titles}`
   })
 
-  const hidden = layers.slice(shown.length)
+  // Everything not shown (compute after the current-layer swap, so the displaced
+  // top-K folder lands here and the swapped-in current layer is not double-counted).
+  const hidden = layers.filter((l) => !shown.includes(l))
   if (hidden.length) {
     const names = hidden.slice(0, 4).map((l) => l.title).join(", ")
     const nodes = hidden.reduce((sum, l) => sum + l.count, 0)
@@ -309,8 +317,8 @@ const renderRecent = (recent: RecentChange[]): string | null => {
 
 /**
  * Read the oplog tail past `sinceSeq` for the board — one indexed range query.
- * Pass `0` to read the whole log (bounded by the caller to `RECENT_OPS_WINDOW`
- * when there is no session cursor).
+ * The oplog only holds ops since the last snapshot, so the tail is bounded by the
+ * snapshot cadence (not the board's full history).
  */
 export const readRecentOps = (
   engine: StorageEngine,

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -68,20 +68,27 @@ const mintId = (): string => `local-${Date.now()}-${counter++}`
  * only what the USER touched between turns.
  */
 const buildBoardBlock = async (store: CanvasStore, rootId: string | null, boardId: string): Promise<string> => {
-  const { engine, boards } = await getLocalStores()
-  const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
-  // First time on this device: no baseline yet, so report nothing as "recent"
-  // (the turn-end advance establishes the baseline).
-  const recent = cursor === undefined ? [] : await readRecentOps(engine, boardId, cursor.seenSeq)
-  const meta = await boards.getBoard(boardId)
-  const snapshot = buildBoardSnapshot(store, rootId, recent)
-  return renderBoardSnapshot(snapshot, { title: meta?.title ?? "Untitled board" })
+  // Auxiliary context — a storage hiccup (transient IDB error, blocked upgrade)
+  // must degrade to an empty block, never abort the turn.
+  try {
+    const { engine, boards } = await getLocalStores()
+    const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
+    // First time on this device: no baseline yet, so report nothing as "recent"
+    // (the turn-end advance establishes the baseline).
+    const recent = cursor === undefined ? [] : await readRecentOps(engine, boardId, cursor.seenSeq)
+    const meta = await boards.getBoard(boardId)
+    const snapshot = buildBoardSnapshot(store, rootId, recent)
+    return renderBoardSnapshot(snapshot, { title: meta?.title ?? "Untitled board" })
+  } catch (e) {
+    agentLog.error("buildBoardBlock", e)
+    return ""
+  }
 }
 
 
 /**
  * Advance the per-device snapshot cursor to the current oplog max. Runs at turn
- * end (fire-and-forget), after the agent's writes land, so those writes are marked
+ * end (awaited, after the agent's writes are flushed), so those writes are marked
  * "seen" and won't resurface as recent changes next turn.
  */
 const advanceBoardSnapshotCursor = async (boardId: string): Promise<void> => {
@@ -218,7 +225,8 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
       try {
         const system = planSystemPrompt(new Date().toLocaleString())
         // Deterministic board awareness (no LLM), injected as a standing section.
-        const systemWithBoard = `${system}\n\n## BOARD\n${await buildBoardBlock(store, rootId, boardId)}`
+        const boardBlock = await buildBoardBlock(store, rootId, boardId)
+        const systemWithBoard = boardBlock ? `${system}\n\n## BOARD\n${boardBlock}` : system
         const search = getSearchIndexRef() ?? undefined
         // External services are managed (signed in); include each tool only when
         // resolvable, so a signed-out user isn't offered an unavailable capability.
@@ -340,7 +348,10 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         void maybeAutoLabelBoard(boardId, messages, resolveAgentLlm(config, { signedIn, runId, model: llmModel, byokModel }))
         // Mark everything up to now (incl. the agent's own writes this turn) as
         // "seen", so next turn's snapshot reports only what the USER changed.
-        void advanceBoardSnapshotCursor(boardId).catch((e) => agentLog.error("advanceBoardSnapshotCursor", e))
+        // Awaited (not fire-and-forget): the cursor must be committed before this
+        // turn's callback resolves, so a fast back-to-back prompt can't read the
+        // stale cursor and re-report the agent's own writes as user changes.
+        await advanceBoardSnapshotCursor(boardId).catch((e) => agentLog.error("advanceBoardSnapshotCursor", e))
       }
     },
     [asConfig, searchByok, searchEngine, codeByok, llmModel, llmCatalog, signedIn, syncTranscript, setMessages, setChatUid, persist, boardId, navigate],

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -18,6 +18,7 @@ import { getSearchIndexRef } from "@/features/board/search/search-index-ref"
 import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
 import { rebuildDocIndex } from "@/features/board/search/use-doc-index"
 import { getLocalStores } from "@/features/local-stores"
+import type { SnapshotMetaRecord } from "@/features/board/persist/local/idb"
 import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
 import { resolveConfirmDecision, useToolConfirm, type ToolConfirmDecision } from "@/features/agent/engine/tool-confirm-store"
 import { useToolTrustStore } from "@/features/agent/settings/tool-trust-store"
@@ -31,9 +32,11 @@ import { useLocalMessagesStore } from "@/features/agent/store/local-messages-sto
 import { putChatTranscript } from "@/features/agent/api/chat-transcript"
 import type { ChatMessage } from "@/features/agent/types/chat"
 import { agentLog } from "@/features/agent/engine/debug"
+import type { CanvasStore } from "@canvas-harness/core"
 import { latestAssistantText, stepsFromEvents } from "./agent-event-to-step"
 import { toLlmHistory } from "./chat-history"
 import { maybeAutoLabelBoard } from "./describe-board"
+import { buildBoardSnapshot, readRecentOps, renderBoardSnapshot } from "./board-snapshot"
 import { wrapWithMessageContext } from "./message-context"
 
 
@@ -50,6 +53,32 @@ const AGENT_TOOLS = [...agentBuildTools, searchNotes, ...skillTools]
 
 let counter = 0
 const mintId = (): string => `local-${Date.now()}-${counter++}`
+
+
+/**
+ * Assemble the deterministic board-snapshot block (no LLM) for the system prompt:
+ * node inventory, folder outline, selection, and changes since you last checked.
+ *
+ * The "seen" cursor is persisted per device (`snapshot_meta`), so recent changes
+ * span sessions — on the first open after being away, they surface what moved
+ * while you were gone; within a session, what moved since the previous turn.
+ */
+const buildBoardBlock = async (store: CanvasStore, rootId: string | null, boardId: string): Promise<string> => {
+  const { engine, boards } = await getLocalStores()
+  const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
+  const seenSeq = cursor?.seenSeq ?? 0
+  const ops = await readRecentOps(engine, boardId, seenSeq)
+  const maxSeq = ops.reduce((m, r) => Math.max(m, r.seq), seenSeq)
+  // First time on this device: adopt the current position as the baseline rather
+  // than reporting the whole backlog as "recent".
+  const recent = cursor === undefined ? [] : ops
+  if (cursor === undefined || maxSeq !== seenSeq) {
+    await engine.put<SnapshotMetaRecord>("snapshot_meta", { boardId, seenSeq: maxSeq })
+  }
+  const meta = await boards.getBoard(boardId)
+  const snapshot = buildBoardSnapshot(store, rootId, recent)
+  return renderBoardSnapshot(snapshot, { title: meta?.title ?? "Untitled board" })
+}
 
 
 /**
@@ -169,6 +198,8 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
       const gate = createFlushGate()
       try {
         const system = planSystemPrompt(new Date().toLocaleString())
+        // Deterministic board awareness (no LLM), injected as a standing section.
+        const systemWithBoard = `${system}\n\n## BOARD\n${await buildBoardBlock(store, rootId, boardId)}`
         const search = getSearchIndexRef() ?? undefined
         // External services are managed (signed in); include each tool only when
         // resolvable, so a signed-out user isn't offered an unavailable capability.
@@ -198,8 +229,8 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         // When documents are attached, steer grounding + citation-by-title (titles
         // are unique per board, so a title names exactly one document).
         const systemWithDocs = hasDocs
-          ? `${system}\n\nThis board has uploaded documents. Use \`doc_search(query)\` — full-text over their contents — and for anything they could answer, call it FIRST, before answering from your own knowledge; ground the answer in the returned passages and cite each document by its exact title. (\`search_notes\` covers the board's own notes.)`
-          : system
+          ? `${systemWithBoard}\n\nThis board has uploaded documents. Use \`doc_search(query)\` — full-text over their contents — and for anything they could answer, call it FIRST, before answering from your own knowledge; ground the answer in the returned passages and cite each document by its exact title. (\`search_notes\` covers the board's own notes.)`
+          : systemWithBoard
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
         // Gate off-board tools (network/code) behind a user confirmation, so a
         // prompt-injected tool call can't silently exfiltrate or run code. A

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -19,6 +19,7 @@ import { getDocIndexRef } from "@/features/board/search/doc-index-ref"
 import { rebuildDocIndex } from "@/features/board/search/use-doc-index"
 import { getLocalStores } from "@/features/local-stores"
 import type { SnapshotMetaRecord } from "@/features/board/persist/local/idb"
+import { getBoardPersistenceRef } from "@/features/board/persist/local/board-persistence-ref"
 import { makeDocSearchTool } from "@/features/agent/engine/doc-search"
 import { resolveConfirmDecision, useToolConfirm, type ToolConfirmDecision } from "@/features/agent/engine/tool-confirm-store"
 import { useToolTrustStore } from "@/features/agent/settings/tool-trust-store"
@@ -84,6 +85,10 @@ const buildBoardBlock = async (store: CanvasStore, rootId: string | null, boardI
  * "seen" and won't resurface as recent changes next turn.
  */
 const advanceBoardSnapshotCursor = async (boardId: string): Promise<void> => {
+  // Commit the board's debounced writes (the agent's creates + arrange moves this
+  // turn) to the oplog FIRST — otherwise readRecentOps reads a stale tail and the
+  // cursor lands below the agent's ops, re-reporting them next turn as user changes.
+  await getBoardPersistenceRef()?.flush()
   const { engine } = await getLocalStores()
   const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
   const from = cursor?.seenSeq ?? 0

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -59,25 +59,39 @@ const mintId = (): string => `local-${Date.now()}-${counter++}`
  * Assemble the deterministic board-snapshot block (no LLM) for the system prompt:
  * node inventory, folder outline, selection, and changes since you last checked.
  *
- * The "seen" cursor is persisted per device (`snapshot_meta`), so recent changes
- * span sessions — on the first open after being away, they surface what moved
- * while you were gone; within a session, what moved since the previous turn.
+ * Reads the per-device "seen" cursor (`snapshot_meta`) but does NOT advance it —
+ * that happens at turn end (`advanceBoardSnapshotCursor`), AFTER the agent's own
+ * writes are committed, so the agent's edits this turn are not reported back to it
+ * next turn as user "recent changes". So recent changes span sessions (first open
+ * after being away shows what moved while you were gone) and, mid-session, show
+ * only what the USER touched between turns.
  */
 const buildBoardBlock = async (store: CanvasStore, rootId: string | null, boardId: string): Promise<string> => {
   const { engine, boards } = await getLocalStores()
   const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
-  const seenSeq = cursor?.seenSeq ?? 0
-  const ops = await readRecentOps(engine, boardId, seenSeq)
-  const maxSeq = ops.reduce((m, r) => Math.max(m, r.seq), seenSeq)
-  // First time on this device: adopt the current position as the baseline rather
-  // than reporting the whole backlog as "recent".
-  const recent = cursor === undefined ? [] : ops
-  if (cursor === undefined || maxSeq !== seenSeq) {
-    await engine.put<SnapshotMetaRecord>("snapshot_meta", { boardId, seenSeq: maxSeq })
-  }
+  // First time on this device: no baseline yet, so report nothing as "recent"
+  // (the turn-end advance establishes the baseline).
+  const recent = cursor === undefined ? [] : await readRecentOps(engine, boardId, cursor.seenSeq)
   const meta = await boards.getBoard(boardId)
   const snapshot = buildBoardSnapshot(store, rootId, recent)
   return renderBoardSnapshot(snapshot, { title: meta?.title ?? "Untitled board" })
+}
+
+
+/**
+ * Advance the per-device snapshot cursor to the current oplog max. Runs at turn
+ * end (fire-and-forget), after the agent's writes land, so those writes are marked
+ * "seen" and won't resurface as recent changes next turn.
+ */
+const advanceBoardSnapshotCursor = async (boardId: string): Promise<void> => {
+  const { engine } = await getLocalStores()
+  const cursor = await engine.get<SnapshotMetaRecord>("snapshot_meta", boardId)
+  const from = cursor?.seenSeq ?? 0
+  const ops = await readRecentOps(engine, boardId, from)
+  const maxSeq = ops.reduce((m, r) => Math.max(m, r.seq), from)
+  if (cursor === undefined || maxSeq !== from) {
+    await engine.put<SnapshotMetaRecord>("snapshot_meta", { boardId, seenSeq: maxSeq })
+  }
 }
 
 
@@ -319,6 +333,9 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         }
         // Auto-label a still-"Untitled" board from its first turn (fire-and-forget).
         void maybeAutoLabelBoard(boardId, messages, resolveAgentLlm(config, { signedIn, runId, model: llmModel, byokModel }))
+        // Mark everything up to now (incl. the agent's own writes this turn) as
+        // "seen", so next turn's snapshot reports only what the USER changed.
+        void advanceBoardSnapshotCursor(boardId).catch((e) => agentLog.error("advanceBoardSnapshotCursor", e))
       }
     },
     [asConfig, searchByok, searchEngine, codeByok, llmModel, llmCatalog, signedIn, syncTranscript, setMessages, setChatUid, persist, boardId, navigate],

--- a/webui/src/features/board/persist/local/board-registry.test.ts
+++ b/webui/src/features/board/persist/local/board-registry.test.ts
@@ -88,11 +88,16 @@ for (const { label, make } of engineCases) describe(`BoardRegistry (${label})`, 
     await reg.createBoard(board)
     await engine.put("sync_meta", { boardId: board.id, syncedSeq: 42 })
     await engine.put("sync_meta", { boardId: "other-board", syncedSeq: 7 })
+    // Same trap for the agent snapshot cursor.
+    await engine.put("snapshot_meta", { boardId: board.id, seenSeq: 42 })
+    await engine.put("snapshot_meta", { boardId: "other-board", seenSeq: 7 })
 
     await reg.deleteBoard(board.id)
 
     expect(await engine.get("sync_meta", board.id)).toBeUndefined()
     expect(await engine.get("sync_meta", "other-board")).toBeDefined() // spared
+    expect(await engine.get("snapshot_meta", board.id)).toBeUndefined()
+    expect(await engine.get("snapshot_meta", "other-board")).toBeDefined() // spared
   })
 
 

--- a/webui/src/features/board/persist/local/board-registry.ts
+++ b/webui/src/features/board/persist/local/board-registry.ts
@@ -25,7 +25,7 @@ export type BoardRegistryOptions = { engine?: StorageEngine; dbName?: string }
 
 // Every store a board's data spans — the cascade-delete transaction covers all.
 const BOARD_COLLECTIONS: Collection[] = [
-  "boards", "views", "snapshots", "oplog", "chats", "chat_messages", "documents", "chunks", "sync_meta",
+  "boards", "views", "snapshots", "oplog", "chats", "chat_messages", "documents", "chunks", "sync_meta", "snapshot_meta",
 ]
 
 
@@ -147,6 +147,10 @@ export class BoardRegistry {
       // re-opened), a stale `syncedSeq` makes fresh low-seq edits look already-acked
       // (`outbox.pending()` skips seq <= cursor) → they're never sent to the relay.
       await t.delete("sync_meta", id)
+      // Cascade the agent snapshot cursor for the same reason: a stale `seenSeq`
+      // on a re-hydrated same-id board would omit fresh low-seq edits from the
+      // snapshot's "recent changes" until the seq passes the stale value.
+      await t.delete("snapshot_meta", id)
       // Cascade the board's chats and their message transcripts.
       const chats = await t.list<{ id: string }>("chats", { index: "by-board", range: { lower: id, upper: id } })
       for (const chat of chats) {

--- a/webui/src/features/board/persist/local/engine.ts
+++ b/webui/src/features/board/persist/local/engine.ts
@@ -22,6 +22,7 @@ export type Collection =
   | "chat_messages"
   | "mini_app_state"
   | "sync_meta"
+  | "snapshot_meta"
   | "documents"
   | "chunks"
 

--- a/webui/src/features/board/persist/local/idb.ts
+++ b/webui/src/features/board/persist/local/idb.ts
@@ -37,6 +37,14 @@ export type OplogRecord = { boardId: string; seq: number; batch: OpBatch; server
 export type SyncMetaRecord = { boardId: string; syncedSeq: number }
 
 
+/**
+ * Device-local snapshot cursor per board: the highest oplog seq this device has
+ * already reflected in a board snapshot. Not synced — each device tracks how far
+ * it has "seen" so the agent's snapshot can report changes since you last checked.
+ */
+export type SnapshotMetaRecord = { boardId: string; seenSeq: number }
+
+
 /** An uploaded document's metadata (per board). Its markdown lives in its chunks. */
 export type DocumentRecord = {
   id: string
@@ -72,6 +80,8 @@ interface Dim0DB extends DBSchema {
   mini_app_state: { key: string; value: { noteId: string; state: unknown } }
   // Sync cursor per board (offline outbox — how far the relay has acked).
   sync_meta: { key: string; value: SyncMetaRecord }
+  // Device-local snapshot cursor per board (how far the agent snapshot has "seen").
+  snapshot_meta: { key: string; value: SnapshotMetaRecord }
   // Per-board uploaded documents + their retrieval chunks (document Q&A).
   documents: { key: string; value: DocumentRecord; indexes: { "by-board": string } }
   chunks: { key: string; value: ChunkRecord; indexes: { "by-board": string; "by-doc": string } }
@@ -82,7 +92,7 @@ export type Dim0Database = IDBPDatabase<Dim0DB>
 
 
 const DB_NAME = "dim0"
-const DB_VERSION = 6
+const DB_VERSION = 7
 
 
 // Minimal loose shapes for the upgrade loop (see the cast note in `upgrade`).

--- a/webui/src/features/board/persist/local/schema.ts
+++ b/webui/src/features/board/persist/local/schema.ts
@@ -25,6 +25,10 @@ export const COLLECTIONS: Record<Collection, CollectionSchema> = {
   chat_messages: { keyPath: ["chatUid", "id"] },
   mini_app_state: { keyPath: "noteId" },
   sync_meta: { keyPath: "boardId" },
+  // Device-local cursor: the oplog seq this device last reflected in a board
+  // snapshot, so "recent changes" shows what moved since you last checked. Not
+  // synced (each device tracks its own).
+  snapshot_meta: { keyPath: "boardId" },
   // Document Q&A (per-board): an uploaded doc's metadata + its retrieval chunks.
   documents: { keyPath: "id", indexes: { "by-board": "boardId" } },
   chunks: { keyPath: "chunkId", indexes: { "by-board": "boardId", "by-doc": "docId" } },


### PR DESCRIPTION
Inject a deterministic, LLM-free "state of the board" snapshot into the browser agent's system prompt on every turn, so the agent knows what board it is on (node inventory, folder structure, selection, and what changed since you last looked) without spending a tool call. Today the agent has zero ambient board awareness: it can only `search_notes` or `get_note(id)`, and cannot even enumerate the board. This is Phase 1 of the agent context/memory initiative (design in `docs/plans/agent-context-architecture.md`, landing as a sibling docs PR). Blast radius: front-end only, plus a local IndexedDB migration (schema v6 to v7, one additive store).

## Design

The core is a pure module, `board-snapshot.ts`, split into a builder and a renderer so it is trivially testable:

- `buildBoardSnapshot(store, rootId, recentOps)` reads the live canvas-harness scene (`getAllNodes`, `getSelection`): counts by structural kind (from `node.data.styleType`, the real type source, not `node.type`), folder-layer grouping by `parentId`, the current layer, selection, and net recent changes collapsed from the oplog.
- `renderBoardSnapshot(snapshot, {title})` renders a budgeted text block: a flat `Nodes:` line for small boards, or a size-ranked `Layers` outline (top 6, current layer always included, remainder collapsed) for foldered boards, with per-title caps and a one-line empty form.
- `readRecentOps(engine, boardId, sinceSeq)` is the one indexed oplog range query.

It is wired in `use-local-submit-prompt.ts`: at turn start the block is built and appended to the system prompt as a `## BOARD` section (following the existing `systemWithDocs` pattern), through both the docs and no-docs branches. A new device-local `snapshot_meta` store persists a per-board `seenSeq` cursor, so "recent changes" spans sessions: on the first open after being away, it surfaces what moved while you were gone.

No LLM is involved anywhere in this path. The snapshot is recomputed per turn (sub-millisecond: one in-memory scene read plus one indexed query), never stored, so node adds are self-healing (nothing to invalidate). Memoization was deliberately skipped as dead weight at once-per-turn frequency (rationale in the design doc).

## Important files

| File | What to look at |
| --- | --- |
| `webui/src/features/agent/local/board-snapshot.ts` | the builder, renderer, and oplog read; the type derivation (`styleType`) and the recent-changes collapse state machine (add+edit becomes add, add+remove cancels, edit+remove becomes delete) |
| `webui/src/features/agent/local/use-local-submit-prompt.ts` | how the block is assembled and injected (the `## BOARD` section), plus the persisted cursor read/advance |
| `webui/src/features/board/persist/local/engine.ts`, `schema.ts`, `idb.ts` | the new `snapshot_meta` store and the DB version bump 6 to 7 (additive, auto-created by the idempotent upgrade loop) |
| `webui/src/features/agent/local/board-snapshot.test.ts` | the cases that pin behaviour, including "current layer always included" and the collapse rules |

## Test plan

Ran the new suite (`npx vitest run src/features/agent/local/board-snapshot.test.ts`): 18 tests pass, covering the builder, the recent-changes collapse state machine, renderer budget/caps/empty forms, and `readRecentOps` plus the `snapshot_meta` round-trip against the in-memory engine. Ran the whole persistence suite to confirm the DB v6 to v7 bump is safe (`npx vitest run src/features/board/persist/local/`): green, 119 passed. `npx tsc -p tsconfig.app.json --noEmit` is clean (0 errors) and eslint is clean on all touched files. By hand I checked that the three archetypes render as the design doc shows (empty board, a flat brainstorm, a multi-folder project). A reviewer catches a regression by running the two vitest commands above; the "current layer always included" test is the guard for a silent-correctness bug (a current folder outside the top 6 by size would otherwise vanish from the outline).

## Try it

```
cd webui
npx vitest run src/features/agent/local/board-snapshot.test.ts
npx vitest run src/features/board/persist/local/
npx tsc -p tsconfig.app.json --noEmit
```

Then open any local board and send a message: the agent's system prompt now carries a `## BOARD` block (visible if you log the assembled system in `use-local-submit-prompt.ts`).

## Notes

- Unchanged on purpose: retrieval, tools, and the rest of the agent loop are untouched; this only adds a standing section to the system prompt.
- Migration and rollback: the only migration is the local IndexedDB `snapshot_meta` store (v6 to v7), additive and auto-created; nothing server-side. To revert, drop the injection and the store; existing boards are unaffected (the store is device-local, not synced).
- Follow-ups: memoization is intentionally deferred (no gain at once-per-turn frequency); a `get_board_overview` pull tool was left out (the always-on injection covers it). Later phases (reasoning wiring, memory store, board purpose, conversation context) are in the design doc.
- Design doc: `docs/plans/agent-context-architecture.md` (Part 1.4 and Part 2 for the snapshot spec), landing in the sibling docs PR (`docs/agent-context-design`).
