### PR TITLE
feat(agent): capture streamed reasoning in the browser engine (BYOK)

### DIFF
--- a/docs/plans/phase2-reasoning.md
+++ b/docs/plans/phase2-reasoning.md
@@ -1,0 +1,115 @@
+# Phase 2 — reasoning capture (implementation plan)
+
+Wire the browser engine's **provider reasoning channel** into the reasoning model + UI that already
+exist, so the agent's chain-of-thought is visible on browser-engine turns. Grounded in the
+post-merge code; the architecture rationale is in
+[`agent-context-architecture.md`](./agent-context-architecture.md) §1.5 / §4.1 / Part 6 Phase 2.
+
+## The core framing: wire, don't build
+
+The reasoning *model, normalization, and UI already exist* (from the legacy backend path):
+
+- **Model:** `ReasoningTextStep { reasoning, message, isSynthesis }` (`agent/types/stream.ts`).
+- **Accumulator:** `stepsFromEvents` (`agent/local/agent-event-to-step.ts`) already builds
+  `reasoning_step`s from `AgentEvent`s — it just leaves `reasoning: ""`.
+- **UI:** `reasoning-step-row.tsx` renders a collapsible "Reasoning" section **whenever
+  `step.reasoning !== ""`**, and `tool-step-row.tsx` renders `step.thought`. Both are empty for
+  browser turns today.
+
+So Phase 2 adds **capture + transport** only. **No new objects, no UI work.** The browser engine's
+stream clients currently parse only `delta.content` + `delta.tool_calls` and drop the provider's
+reasoning channel entirely (`engine/stream-assemble.ts`, `engine/managed-client.ts`).
+
+## The decisive split: by transport
+
+The two runtimes reach the model over different transports, so reasoning capture differs and can
+ship independently:
+
+| Path | Client → assembler | Where reasoning enters | Scope |
+|---|---|---|---|
+| **BYOK** | `ByokLlmClient.completeStream` → `assembleStreamedTurn` | parse `delta.reasoning_content` / `delta.reasoning` off the raw OpenAI chunk | **frontend-only** |
+| **Managed** | `ManagedLlmClient.completeStream` → our `/ai/llm/stream` NDJSON | the **backend `ai.py` proxy** must forward reasoning as a new NDJSON line, then the client parses it | **cross-stack (Python + TS)** |
+
+**Ship 2a (BYOK) first** — self-contained, no backend, lights up reasoning for signed-out / BYOK
+users. **2b (Managed)** follows, reusing 2a's frontend event plumbing.
+
+---
+
+## Phase 2a — BYOK reasoning (frontend-only)
+
+### Changes (file by file)
+
+| # | File | Change |
+|---|---|---|
+| 1 | `agent/engine/types.ts` | add `{ kind: "reasoning"; text: string }` to `LlmStreamEvent`; `{ type: "reasoning"; text: string }` to `AgentEvent` |
+| 2 | `agent/engine/stream-assemble.ts` | after the `delta.content` branch, read the reasoning field (see below) and `yield { kind: "reasoning", text }` (per-delta) |
+| 3 | `agent/engine/agent-loop.ts` | in the `completeStream` loop, accumulate `reasoningAcc += ev.text` and `yield { type: "reasoning", text: reasoningAcc }` (cumulative, mirroring how `assistant_text` accumulates `acc`) |
+| 4 | `agent/local/use-local-submit-prompt.ts` | in the `for await` consumer, coalesce consecutive `reasoning` events in `events[]` (same pattern the `assistant_text` coalescing uses) |
+| 5 | `agent/local/agent-event-to-step.ts` | in `stepsFromEvents`, handle `ev.type === "reasoning"`: set the trailing `reasoning_step.reasoning` (create one if the last step isn't a reasoning_step) — parallels the `assistant_text` branch that sets `.message` |
+| — | UI | **none** — the expanders already render `.reasoning` |
+
+### Provider reasoning formats (the only real subtlety)
+
+Neither field is in OpenAI's `ChatCompletionChunk` TS type, so read via a narrow cast off `delta`:
+
+- **OpenRouter** → `delta.reasoning` (its unified reasoning field). Some models need `reasoning: {}`
+  (or `include_reasoning: true`) in the request body to emit it — a follow-up knob if we want to
+  force it on; many reasoning models emit it by default.
+- **DeepSeek and other OpenAI-compatible reasoners** → `delta.reasoning_content`.
+- Parse **either**: `const r = (delta as { reasoning_content?: string; reasoning?: string }); const text = r.reasoning_content ?? r.reasoning`.
+
+### Accumulation model
+
+Reasoning is a **separate cumulative channel** alongside answer text:
+
+- The loop accumulates reasoning into `reasoningAcc` and answer text into `acc` independently, each
+  emitted cumulatively (the existing `assistant_text` pattern).
+- `stepsFromEvents` renders a turn as `reasoning_step { reasoning: <thought>, message: <answer> }`.
+  Reasoning arriving before the answer fills `.reasoning`; the answer text fills `.message` of the
+  same trailing step.
+- **Interleaved tool calls** split it naturally: `reasoning → tool_call → reasoning → answer` becomes
+  `reasoning_step(pre-tool thought) · tool_step · reasoning_step(post-tool thought + answer)` — the
+  chain-of-thought reads top to bottom.
+
+### Tests
+
+- `stream-assemble.test.ts`: a chunk with `reasoning_content` and one with `reasoning` each yield a
+  `reasoning` event; a stream with neither is unchanged (**regression guard**).
+- `agent-event-to-step.test.ts`: a `reasoning` event fills `reasoning_step.reasoning`;
+  reasoning-then-text lands in one step; reasoning-between-two-tools splits into two reasoning steps.
+- `agent-loop.stream.test.ts`: the loop emits cumulative `reasoning` events from `reasoning` stream
+  events.
+
+### Estimate
+
+~150–200 impl LoC + ~80 test. Complexity **Med** — the provider-format variance is the only tricky
+bit; the model and UI are free.
+
+---
+
+## Phase 2b — Managed reasoning (cross-stack, follow-up)
+
+- `backend/topix/api/router/ai.py` (`/ai/llm/stream`): parse the provider's streamed reasoning delta
+  and emit a new NDJSON line `{ type: "reasoning", text }`.
+- `agent/engine/managed-client.ts`: add `reasoning` to `ManagedStreamLine`; in `completeStream`,
+  yield `{ kind: "reasoning", text }` for it.
+- Reuses 2a's frontend plumbing (types, agent-loop, consumer, stepsFromEvents already done).
+- ~60–100 LoC across Python + TS.
+
+---
+
+## Deferred (not in Phase 2)
+
+- **Re-feed reasoning to the model across turns.** Provider reasoning blocks carry **signatures**
+  with re-send constraints (Anthropic thinking); re-feeding is a separate decision (open question #3
+  in the architecture doc). Phase 2 is **display-only**: reasoning is captured, stored on the step,
+  rendered, and backed up in the opaque transcript, but not re-injected into `history`.
+- **Non-streaming reasoning.** `complete()` (non-stream) drops reasoning; the loop prefers streaming,
+  so this is a minor gap, deferrable.
+
+## Sequencing
+
+1. **2a** (this PR): BYOK reasoning, display-only, frontend-only. Ships visible chain-of-thought for
+   BYOK / signed-out.
+2. **2b** (follow-up PR): managed path via the `ai.py` proxy.
+3. **Later:** re-feed with signature handling (needs a per-provider decision).

--- a/webui/src/features/agent/engine/agent-loop.stream.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.stream.test.ts
@@ -61,4 +61,17 @@ describe("runAgent (streaming)", () => {
     expect(texts(evs).at(-1)).toBe("finished")
     expect(evs.at(-1)).toEqual({ type: "done" })
   })
+
+  it("accumulates reasoning deltas into cumulative reasoning events, separate from the answer", async () => {
+    const llm = streamingClient([[
+      { kind: "reasoning", text: "Let me " },
+      { kind: "reasoning", text: "think." },
+      { kind: "delta", text: "Answer" },
+      { kind: "final", turn: { kind: "text", text: "Answer" } },
+    ]])
+    const evs = await run(llm)
+    const reasoning = evs.flatMap((e) => (e.type === "reasoning" ? [e.text] : []))
+    expect(reasoning).toEqual(["Let me ", "Let me think."]) // cumulative, not per-fragment
+    expect(texts(evs).at(-1)).toBe("Answer") // reasoning never leaks into the answer body
+  })
 })

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -175,7 +175,8 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
           yield { type: "assistant_text", text: acc }
         } else if (ev.kind === "reasoning") {
           // Reasoning/thinking streams on its own channel; accumulate + emit
-          // cumulatively (like assistant_text) so the UI renders it live.
+          // cumulatively (like assistant_text). The chat UI gates the Reasoning
+          // expander on turn-end, so this fills it once the turn completes.
           reasoningAcc += ev.text
           yield { type: "reasoning", text: reasoningAcc }
         } else if (ev.kind === "tool_start") {

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -167,11 +167,17 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
     let result: LlmTurn
     if (opts.llm.completeStream) {
       let acc = ""
+      let reasoningAcc = ""
       let final: LlmTurn | null = null
       for await (const ev of opts.llm.completeStream(messages, defs)) {
         if (ev.kind === "delta") {
           acc += ev.text
           yield { type: "assistant_text", text: acc }
+        } else if (ev.kind === "reasoning") {
+          // Reasoning/thinking streams on its own channel; accumulate + emit
+          // cumulatively (like assistant_text) so the UI renders it live.
+          reasoningAcc += ev.text
+          yield { type: "reasoning", text: reasoningAcc }
         } else if (ev.kind === "tool_start") {
           // Early signal: show the tool the moment its name is known; args are
           // filled in when the call actually runs below.

--- a/webui/src/features/agent/engine/stream-assemble.test.ts
+++ b/webui/src/features/agent/engine/stream-assemble.test.ts
@@ -91,4 +91,14 @@ describe("assembleStreamedTurn", () => {
     const events = await collect(chunksOf(textChunk("hi")))
     expect(events.some((e) => e.kind === "reasoning")).toBe(false)
   })
+
+  it("an empty reasoning_content does not mask a populated reasoning in the same delta", async () => {
+    const bothChunk = { choices: [{ index: 0, finish_reason: null, delta: { reasoning_content: "", reasoning: "real thought" } }] }
+    const events = await collect(chunksOf(bothChunk, textChunk("A")))
+    expect(events).toEqual([
+      { kind: "reasoning", text: "real thought" },
+      { kind: "delta", text: "A" },
+      { kind: "final", turn: { kind: "text", text: "A" } },
+    ])
+  })
 })

--- a/webui/src/features/agent/engine/stream-assemble.test.ts
+++ b/webui/src/features/agent/engine/stream-assemble.test.ts
@@ -74,4 +74,21 @@ describe("assembleStreamedTurn", () => {
       { kind: "final", turn: { kind: "text", text: "hi" } },
     ])
   })
+
+  it("captures the reasoning channel — DeepSeek `reasoning_content` and OpenRouter `reasoning`", async () => {
+    const reasoningContentChunk = (t: string) => ({ choices: [{ index: 0, finish_reason: null, delta: { reasoning_content: t } }] })
+    const reasoningChunk = (t: string) => ({ choices: [{ index: 0, finish_reason: null, delta: { reasoning: t } }] })
+    const events = await collect(chunksOf(reasoningContentChunk("Let me "), reasoningChunk("think."), textChunk("Answer")))
+    expect(events).toEqual([
+      { kind: "reasoning", text: "Let me " },
+      { kind: "reasoning", text: "think." },
+      { kind: "delta", text: "Answer" },
+      { kind: "final", turn: { kind: "text", text: "Answer" } },
+    ])
+  })
+
+  it("leaves a stream without a reasoning channel unchanged", async () => {
+    const events = await collect(chunksOf(textChunk("hi")))
+    expect(events.some((e) => e.kind === "reasoning")).toBe(false)
+  })
 })

--- a/webui/src/features/agent/engine/stream-assemble.ts
+++ b/webui/src/features/agent/engine/stream-assemble.ts
@@ -26,7 +26,12 @@ export async function* assembleStreamedTurn(
     // off the raw delta: OpenRouter uses `reasoning`, DeepSeek et al. use
     // `reasoning_content`. Display-only (never re-fed to the model in Phase 2).
     const r = delta as { reasoning?: unknown; reasoning_content?: unknown }
-    const reasoning = typeof r.reasoning_content === "string" ? r.reasoning_content : typeof r.reasoning === "string" ? r.reasoning : ""
+    // Prefer whichever field carries actual text: an empty `reasoning_content`
+    // must not mask a populated `reasoning` in the same delta.
+    const reasoning =
+      (typeof r.reasoning_content === "string" && r.reasoning_content) ||
+      (typeof r.reasoning === "string" && r.reasoning) ||
+      ""
     if (reasoning) yield { kind: "reasoning", text: reasoning }
     for (const tc of delta.tool_calls ?? []) {
       const slot = calls.get(tc.index) ?? { id: "", name: "", arguments: "" }

--- a/webui/src/features/agent/engine/stream-assemble.ts
+++ b/webui/src/features/agent/engine/stream-assemble.ts
@@ -22,6 +22,12 @@ export async function* assembleStreamedTurn(
       text += delta.content
       yield { kind: "delta", text: delta.content }
     }
+    // Provider reasoning/thinking channel — not in OpenAI's chunk type, so read
+    // off the raw delta: OpenRouter uses `reasoning`, DeepSeek et al. use
+    // `reasoning_content`. Display-only (never re-fed to the model in Phase 2).
+    const r = delta as { reasoning?: unknown; reasoning_content?: unknown }
+    const reasoning = typeof r.reasoning_content === "string" ? r.reasoning_content : typeof r.reasoning === "string" ? r.reasoning : ""
+    if (reasoning) yield { kind: "reasoning", text: reasoning }
     for (const tc of delta.tool_calls ?? []) {
       const slot = calls.get(tc.index) ?? { id: "", name: "", arguments: "" }
       if (tc.id) slot.id = tc.id

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -60,6 +60,7 @@ export type LlmToolDef = {
  *  then the final turn. */
 export type LlmStreamEvent =
   | { kind: "delta"; text: string }
+  | { kind: "reasoning"; text: string }
   | { kind: "tool_start"; name: string; id?: string }
   | { kind: "final"; turn: LlmTurn }
 
@@ -141,4 +142,5 @@ export type AgentEvent =
   | { type: "tool_start"; toolName: string; args: unknown }
   | { type: "tool_result"; toolName: string; result: unknown }
   | { type: "assistant_text"; text: string }
+  | { type: "reasoning"; text: string }
   | { type: "done" }

--- a/webui/src/features/agent/local/agent-event-to-step.test.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.test.ts
@@ -246,4 +246,40 @@ describe("stepsFromEvents", () => {
       ]),
     ).toBe("second")
   })
+
+
+  it("reasoning fills the same step whose message holds the answer", () => {
+    const events: AgentEvent[] = [
+      { type: "reasoning", text: "First I consider X." },
+      { type: "assistant_text", text: "The answer is X." },
+    ]
+    expect(stepsFromEvents(events, "b")).toEqual([
+      { type: "reasoning_step", id: expect.any(String), reasoning: "First I consider X.", message: "The answer is X." },
+    ])
+  })
+
+
+  it("splits reasoning around a tool call into pre-tool and post-tool steps", () => {
+    const events: AgentEvent[] = [
+      { type: "reasoning", text: "I should search." },
+      { type: "tool_start", toolName: "search_notes", args: { query: "x" } },
+      { type: "tool_result", toolName: "search_notes", result: { results: [] } },
+      { type: "reasoning", text: "Nothing found, I'll answer." },
+      { type: "assistant_text", text: "No matches." },
+    ]
+    const steps = stepsFromEvents(events, "b")
+    expect(steps.map((s) => s.type)).toEqual(["reasoning_step", "tool_call", "reasoning_step"])
+    expect(steps[0]).toMatchObject({ reasoning: "I should search.", message: "" })
+    expect(steps[2]).toMatchObject({ reasoning: "Nothing found, I'll answer.", message: "No matches." })
+  })
+
+
+  it("latestAssistantText ignores reasoning (answer body only)", () => {
+    expect(
+      latestAssistantText([
+        { type: "reasoning", text: "thinking…" },
+        { type: "assistant_text", text: "the answer" },
+      ]),
+    ).toBe("the answer")
+  })
 })

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -154,6 +154,14 @@ export const stepsFromEvents = (events: AgentEvent[], boardId: string): Reasonin
       const last = steps[steps.length - 1]
       if (last && last.type === "reasoning_step") last.message = ev.text
       else steps.push({ type: "reasoning_step", id: `text-${seq++}`, reasoning: "", message: ev.text })
+    } else if (ev.type === "reasoning") {
+      // Reasoning/thinking (cumulative) fills the trailing reasoning_step's
+      // `reasoning` slot — the same step whose `message` holds the answer, so the
+      // UI's "Reasoning" expander sits above the reply. A run of tool calls splits
+      // it into pre-tool and post-tool reasoning steps (chain-of-thought order).
+      const last = steps[steps.length - 1]
+      if (last && last.type === "reasoning_step") last.reasoning = ev.text
+      else steps.push({ type: "reasoning_step", id: `reason-${seq++}`, reasoning: ev.text, message: "" })
     }
   }
   // Match the online path: fold text-like "tool" steps (raw_message / synthesizer

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -289,7 +289,12 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             createdNodeIds.push(String((ev.result as { id: unknown }).id))
           }
           const now = Date.now()
-          if (gate.shouldFlush(now, { force: ev.type !== "assistant_text" })) {
+          // Token streams (assistant_text AND reasoning) ride the ~10fps throttle;
+          // only structural events (tool start/result) force an immediate repaint.
+          // Forcing on every reasoning token would re-derive stepsFromEvents (O(n))
+          // per token — O(n^2) over a long chain-of-thought.
+          const isTokenStream = ev.type === "assistant_text" || ev.type === "reasoning"
+          if (gate.shouldFlush(now, { force: !isTokenStream })) {
             render(true)
             gate.markFlushed(now)
           }

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -271,10 +271,11 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             () => useToolConfirm.getState().request(req),
           )
         for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search, confirmTool } })) {
-          // Streaming yields a cumulative assistant_text per token — replace the
-          // previous snapshot in place instead of appending one event per token.
+          // Streaming yields cumulative assistant_text / reasoning per token —
+          // replace the previous snapshot in place instead of appending one event
+          // per token.
           const prev = events[events.length - 1]
-          if (ev.type === "assistant_text" && prev?.type === "assistant_text") events[events.length - 1] = ev
+          if ((ev.type === "assistant_text" || ev.type === "reasoning") && prev?.type === ev.type) events[events.length - 1] = ev
           else events.push(ev)
           // Track notes CREATED this turn so we can arrange + recenter them. A
           // write_note that rewrote an existing note reports `created: false` —

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -273,7 +273,7 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, search, confirmTool } })) {
           // Streaming yields cumulative assistant_text / reasoning per token —
           // replace the previous snapshot in place instead of appending one event
-          // per token.
+          // per token. (assistant_text renders live; reasoning is shown at turn-end.)
           const prev = events[events.length - 1]
           if ((ev.type === "assistant_text" || ev.type === "reasoning") && prev?.type === ev.type) events[events.length - 1] = ev
           else events.push(ev)

--- a/webui/src/features/agent/local/use-local-transform.ts
+++ b/webui/src/features/agent/local/use-local-transform.ts
@@ -85,6 +85,9 @@ export function useLocalTransform() {
         llm,
         ctx,
       })) {
+        // The build-only transform inspects tool_result and never renders text;
+        // don't accumulate the cumulative reasoning token stream (pure bloat here).
+        if (ev.type === "reasoning") continue
         events.push(ev)
         if (
           ev.type === "tool_result" &&


### PR DESCRIPTION
## What

Capture the model's streamed reasoning (chain-of-thought) in the browser agent's BYOK path and route it into the reasoning slot the chat UI already renders. Before this change the browser engine dropped the provider's reasoning channel, so every BYOK turn showed an empty "Reasoning" expander even when the model was a thinking model.

This is the first slice of Phase 2 (Phase 2a). It touches only the frontend BYOK transport. The managed path needs a backend change and ships separately as Phase 2b.

## Why

The `ReasoningStep` model, the two-channel reasoning/answer split, and the "Reasoning" expander in the chat UI all already exist (the legacy server path populated them). The browser engine just never wired the provider's reasoning deltas into that model. This connects the existing pieces rather than building anything new.

Thinking models stream chain-of-thought on a side channel, not in `delta.content`: OpenRouter uses `delta.reasoning`, DeepSeek and several others use `delta.reasoning_content`. Neither is in OpenAI's TS chunk type, so we read them via a narrow cast.

## How

- **`stream-assemble.ts`** reads the reasoning channel off the raw chunk delta (either field) and emits a new `{ kind: "reasoning" }` stream event beside the existing text/tool events.
- **`agent-loop.ts`** accumulates reasoning cumulatively (mirroring how `assistant_text` accumulates) and emits `{ type: "reasoning" }` AgentEvents, kept strictly separate from the answer body.
- **`agent-event-to-step.ts`** fills the trailing `reasoning_step`'s `reasoning` slot, so the expander sits above the reply it belongs to. A run of tool calls splits reasoning into pre-tool and post-tool steps, preserving chain-of-thought order.
- **`use-local-submit-prompt.ts`** coalesces the cumulative reasoning events (same treatment as cumulative text) so the live view updates in place instead of appending per fragment.
- **`types.ts`** adds the `reasoning` variants to `LlmStreamEvent` and `AgentEvent`.

## Testing

- `stream-assemble.test.ts`: captures both `reasoning_content` and `reasoning` channels; leaves a no-reasoning stream unchanged.
- `agent-loop.stream.test.ts`: reasoning deltas accumulate into cumulative events and never leak into the answer body.
- `agent-event-to-step.test.ts`: reasoning fills the step whose message holds the answer; reasoning around a tool call splits into pre/post steps; `latestAssistantText` ignores reasoning.
- Full frontend suite green (444 tests), `npm run check-all` clean (type-check + eslint).

## Follow-ups

- **Phase 2b**: managed-path reasoning (requires the backend `ai.py` stream to forward the reasoning channel).
- Re-feeding captured reasoning back to the model with provider signature handling, deferred.

Planning doc: `docs/plans/phase2-reasoning.md`.
