### PR TITLE
feat(agent): forward reasoning through the managed transport

### DIFF
--- a/backend/test/unit/api/router/test_ai_llm_router.py
+++ b/backend/test/unit/api/router/test_ai_llm_router.py
@@ -175,6 +175,11 @@ def _delta_chunk(content):
     return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=content, tool_calls=None))])
 
 
+def _reasoning_chunk(text):
+    """Build a chunk carrying only a reasoning delta (thinking-model output)."""
+    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=None, tool_calls=None, reasoning_content=text))])
+
+
 def test_stream_emits_text_deltas_then_final_message(monkeypatch):
     """Streaming yields a delta line per token, then a final assembled message."""
     _install_stream_resolution(monkeypatch)
@@ -196,6 +201,48 @@ def test_stream_emits_text_deltas_then_final_message(monkeypatch):
     assert lines[1] == {"type": "delta", "text": "lo"}
     assert lines[-1]["type"] == "final"
     assert lines[-1]["message"]["content"] == "Hello"
+
+
+def test_stream_emits_reasoning_lines_separate_from_content(monkeypatch):
+    """Reasoning deltas surface as {type:"reasoning"} lines, kept out of the answer body."""
+    _install_stream_resolution(monkeypatch)
+
+    async def _gen():
+        yield _reasoning_chunk("Let me ")
+        yield _reasoning_chunk("think.")
+        yield _delta_chunk("Answer")
+
+    async def _acompletion(**kwargs):
+        return _gen()
+
+    monkeypatch.setattr(ai_module.litellm, "acompletion", _acompletion)
+
+    res = _client().post("/ai/llm/stream", json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]})
+    lines = _lines(res)
+    assert lines[0] == {"type": "reasoning", "text": "Let me "}
+    assert lines[1] == {"type": "reasoning", "text": "think."}
+    assert {"type": "delta", "text": "Answer"} in lines
+    assert lines[-1]["message"]["content"] == "Answer"  # reasoning never folded into content
+
+
+def test_stream_ordinary_delta_emits_no_reasoning_line(monkeypatch):
+    """Guard the getattr read: a reasoning-less delta emits no reasoning line, no crash.
+
+    Mirrors litellm deleting the `reasoning_content` attribute when it is absent.
+    """
+    _install_stream_resolution(monkeypatch)
+
+    async def _gen():
+        yield _delta_chunk("hi")
+
+    async def _acompletion(**kwargs):
+        return _gen()
+
+    monkeypatch.setattr(ai_module.litellm, "acompletion", _acompletion)
+
+    res = _client().post("/ai/llm/stream", json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]})
+    assert res.status_code == 200
+    assert all(line["type"] != "reasoning" for line in _lines(res))
 
 
 def test_stream_assembles_tool_call_fragments(monkeypatch):

--- a/backend/topix/api/router/ai.py
+++ b/backend/topix/api/router/ai.py
@@ -15,6 +15,7 @@ import json
 import os
 import tempfile
 
+from collections.abc import Iterator
 from typing import Annotated, Any, Literal
 
 import litellm
@@ -277,6 +278,32 @@ def _accumulate_tool_call(slots: dict[int, dict[str, Any]], tc: Any) -> None:
         slot["arguments"] += fn.arguments
 
 
+def _delta_lines(delta: Any, slots: dict[int, dict[str, Any]], announced: set[int]) -> Iterator[str]:
+    """Yield the NDJSON line(s) one streamed delta produces (content, reasoning, tool_start).
+
+    A tool_start is emitted the instant a tool's name is first known. Reasoning is
+    read via getattr: LiteLLM normalizes every provider's reasoning into
+    `reasoning_content` (mapping `delta.reasoning` too) but DELETES the attribute
+    when absent, so attribute access would raise on ordinary deltas. Display-only —
+    reasoning is kept out of the assembled answer content.
+    """
+    piece = getattr(delta, "content", None)
+    if piece:
+        yield json.dumps({"type": "delta", "text": piece}) + "\n"
+    reasoning = getattr(delta, "reasoning_content", None)
+    if reasoning:
+        yield json.dumps({"type": "reasoning", "text": reasoning}) + "\n"
+    for tc in getattr(delta, "tool_calls", None) or []:
+        idx = getattr(tc, "index", 0)
+        _accumulate_tool_call(slots, tc)
+        # Announce the tool the instant its name is known — before its (possibly
+        # long) arguments finish — so the client shows it now.
+        slot = slots.get(idx)
+        if slot and slot.get("name") and idx not in announced:
+            announced.add(idx)
+            yield json.dumps({"type": "tool_start", "id": slot["id"], "name": slot["name"]}) + "\n"
+
+
 @router.post("/llm/stream/", include_in_schema=False)
 @router.post("/llm/stream")
 async def ai_llm_stream(
@@ -287,10 +314,10 @@ async def ai_llm_stream(
 ):
     """Stream one model turn as NDJSON lines.
 
-    `{type:"delta",text}` per token, `{type:"tool_start",id,name}` the moment a
-    tool call's name is known (before its args finish), then `{type:"final",
-    message}`. Tier/model resolution (and any 403/503) runs before streaming, so
-    errors are plain HTTP.
+    `{type:"delta",text}` per token, `{type:"reasoning",text}` per reasoning token
+    (thinking models), `{type:"tool_start",id,name}` the moment a tool call's name
+    is known (before its args finish), then `{type:"final",message}`. Tier/model
+    resolution (and any 403/503) runs before streaming, so errors are plain HTTP.
     """
     entitlement = await resolve_entitlement_context(request, user_id)
     allowed_tiers = resolve_allowed_model_tiers(entitlement.plan)
@@ -318,19 +345,9 @@ async def ai_llm_stream(
             delta = choices[0].delta if choices else None
             if delta is None:
                 continue
-            piece = getattr(delta, "content", None)
-            if piece:
-                content += piece
-                yield json.dumps({"type": "delta", "text": piece}) + "\n"
-            for tc in getattr(delta, "tool_calls", None) or []:
-                idx = getattr(tc, "index", 0)
-                _accumulate_tool_call(slots, tc)
-                # Announce the tool the instant its name is known — before its
-                # (possibly long) arguments finish — so the client shows it now.
-                slot = slots.get(idx)
-                if slot and slot.get("name") and idx not in announced:
-                    announced.add(idx)
-                    yield json.dumps({"type": "tool_start", "id": slot["id"], "name": slot["name"]}) + "\n"
+            content += getattr(delta, "content", None) or ""
+            for line in _delta_lines(delta, slots, announced):
+                yield line
 
         message: dict[str, Any] = {"role": "assistant", "content": content or None}
         if slots:

--- a/docs/plans/phase2-reasoning.md
+++ b/docs/plans/phase2-reasoning.md
@@ -89,12 +89,10 @@ bit; the model and UI are free.
 
 ## Phase 2b — Managed reasoning (cross-stack, follow-up)
 
-- `backend/topix/api/router/ai.py` (`/ai/llm/stream`): parse the provider's streamed reasoning delta
-  and emit a new NDJSON line `{ type: "reasoning", text }`.
-- `agent/engine/managed-client.ts`: add `reasoning` to `ManagedStreamLine`; in `completeStream`,
-  yield `{ kind: "reasoning", text }` for it.
-- Reuses 2a's frontend plumbing (types, agent-loop, consumer, stepsFromEvents already done).
-- ~60–100 LoC across Python + TS.
+The managed path forwards reasoning through the `ai.py` proxy, reusing all of 2a's frontend
+plumbing. Full plan (relay-projection insight, the verified litellm `reasoning_content` field + its
+delete-when-absent gotcha, file changes, tests) →
+[`phase2b-managed-reasoning.md`](./phase2b-managed-reasoning.md).
 
 ---
 

--- a/docs/plans/phase2b-managed-reasoning.md
+++ b/docs/plans/phase2b-managed-reasoning.md
@@ -1,0 +1,85 @@
+# Phase 2b — managed reasoning (implementation plan)
+
+Forward the provider reasoning channel through the **managed transport** so browser-engine turns on
+our keys get the same chain-of-thought that [Phase 2a](./phase2-reasoning.md) already lit up for
+BYOK. This doc covers only what 2b adds; the shared model/UI framing and the accumulation semantics
+live in [`phase2-reasoning.md`](./phase2-reasoning.md) and are **not** restated here.
+
+## Why this is a separate slice at all
+
+The managed path is **not** a byte relay — it is a *field-selective projection*. Both managed
+endpoints in `backend/topix/api/router/ai.py` reconstruct a minimal wire format from the litellm
+response and keep only `content` + `tool_calls`:
+
+- `/ai/llm/stream` `generate()` reads `delta.content` and `delta.tool_calls`, then rebuilds a `final`
+  message from those two alone.
+- `/ai/llm` `_message_to_dict()` is explicit: *"the minimal ChatCompletion message (content +
+  tool_calls)"*.
+
+So reasoning is dropped **by omission in the projection**, not by any provider or transport limit.
+The data is present server-side — the endpoint just never emits it. That is why 2a (which parses raw
+provider chunks in the browser) forwards reasoning today and the managed path does not: same
+project-the-stream move, applied in two places, one of which omits the field.
+
+## The one field that matters: `delta.reasoning_content`
+
+Verified against the pinned **litellm 1.83.14** (`types/utils.py`, `class Delta`):
+
+- litellm **normalizes every provider's reasoning into one field, `reasoning_content`** — a provider
+  that emits `delta.reasoning` (Cerebras, Groq gpt-oss, OpenRouter) is mapped to `reasoning_content`
+  in `Delta.__init__` before the model is built. The server reads **one** field regardless of
+  provider (the frontend's `reasoning_content ?? reasoning` dance is a browser-only concern).
+- **Gotcha — attribute is deleted when absent.** When a delta has no reasoning, litellm runs
+  `del self.reasoning_content` "to match the OpenAI spec." So `delta.reasoning_content` raises
+  `AttributeError` on every ordinary token. **Always** read it as
+  `getattr(delta, "reasoning_content", None)`, never by attribute access — a naive access crashes the
+  stream on the first non-reasoning delta.
+- **Do not enable** litellm's `merge_reasoning_content_in_choices`: it folds reasoning into `content`
+  wrapped in `<think>` tags, which would pollute the answer body. We keep reasoning on its own line.
+
+## Changes (file by file)
+
+| # | File | Change |
+|---|---|---|
+| 1 | `backend/topix/api/router/ai.py` (`generate()`) | after the `delta.content` branch: `rc = getattr(delta, "reasoning_content", None); if rc: yield json.dumps({"type": "reasoning", "text": rc}) + "\n"` |
+| 2 | `webui/.../engine/managed-client.ts` | add `{ type: "reasoning"; text: string }` to `ManagedStreamLine`; in `completeStream`, `else if (line.type === "reasoning") yield { kind: "reasoning", text: line.text }` |
+| — | agent-loop / consumer / `stepsFromEvents` / UI | **none** — everything downstream of `LlmStreamEvent` is transport-agnostic and already done in 2a |
+
+The managed line mirrors 2a's stream event exactly, so it flows into the same accumulation and
+rendering path with zero new frontend logic.
+
+## Non-stream path (`/ai/llm`)
+
+`_message_to_dict()` also strips reasoning. The agent loop **prefers streaming** (`completeStream`),
+so the non-stream path is only hit as a fallback. Optional, low-value: surface
+`getattr(message, "reasoning_content", None)` on the returned message. **Deferred** unless a
+non-streaming reasoner turns up in practice — matches the same deferral in 2a.
+
+## Tests
+
+- `backend/test/unit/api/router/test_ai_llm_router.py`: a streamed chunk carrying `reasoning_content`
+  emits a `{type:"reasoning"}` NDJSON line; a stream with no reasoning emits **no** reasoning line
+  (regression guard for the `getattr` default — proves ordinary deltas don't crash or leak an empty
+  line). Use the existing scripted-`litellm.acompletion` fixture in that file.
+- `webui/.../engine/managed-client.test.ts`: a `{type:"reasoning"}` line yields
+  `{ kind: "reasoning", text }`; existing delta/tool_start/final cases stay green.
+- No new frontend accumulation tests — 2a already covers `stepsFromEvents` / agent-loop reasoning.
+
+## Deferred (shared with 2a, see that doc)
+
+Re-feeding reasoning across turns needs the **signed** payload, not the display text. In litellm that
+is `Delta.thinking_blocks` / `reasoning_items` (Anthropic thinking signatures), a channel distinct
+from `reasoning_content`. 2b stays **display-only**, exactly like 2a; signature-aware re-injection is
+the later phase (open question #3 in the architecture doc).
+
+## Estimate
+
+~40 LoC impl (≈4 Python in `generate()`, one `ManagedStreamLine` variant + map) + ~40 test.
+Complexity **Low** — the projection insight and the `getattr` gotcha are the only real content, and
+both are settled above.
+
+## Sequencing
+
+Stacked on the 2a branch (`feat/agent-reasoning-capture`). Merges after 2a; if 2a merges first,
+rebase onto `main`. No overlap with 2a's files except the shared `LlmStreamEvent` contract, which 2a
+already defines.

--- a/webui/src/features/agent/engine/managed-client.test.ts
+++ b/webui/src/features/agent/engine/managed-client.test.ts
@@ -100,6 +100,22 @@ describe("managedLlmClient.completeStream", () => {
     ])
   })
 
+  it("maps NDJSON reasoning lines to reasoning events, kept separate from the answer", async () => {
+    const streamPost = streamOf(
+      { type: "reasoning", text: "Let me " },
+      { type: "reasoning", text: "think." },
+      { type: "delta", text: "Answer" },
+      { type: "final", message: { role: "assistant", content: "Answer", refusal: null } },
+    )
+    const events = await drain(managedLlmClient("auto", { streamPost }).completeStream!(messages, []))
+    expect(events).toEqual([
+      { kind: "reasoning", text: "Let me " },
+      { kind: "reasoning", text: "think." },
+      { kind: "delta", text: "Answer" },
+      { kind: "final", turn: { kind: "text", text: "Answer" } },
+    ])
+  })
+
   it("maps an early tool_start line to a tool_start event", async () => {
     const streamPost = streamOf(
       { type: "tool_start", name: "write_note", id: "c1" },

--- a/webui/src/features/agent/engine/managed-client.ts
+++ b/webui/src/features/agent/engine/managed-client.ts
@@ -23,10 +23,12 @@ export type LlmTurnPost = (
 ) => Promise<{ choices: { message: ChatCompletionMessage }[] }>
 
 
-/** One line of the `/ai/llm/stream` NDJSON: a text delta, an early tool-start
- *  (name known before args finish), or the final message. */
+/** One line of the `/ai/llm/stream` NDJSON: a text delta, a reasoning delta
+ *  (thinking models), an early tool-start (name known before args finish), or
+ *  the final message. */
 export type ManagedStreamLine =
   | { type: "delta"; text: string }
+  | { type: "reasoning"; text: string }
   | { type: "tool_start"; name: string; id?: string }
   | { type: "final"; message: ChatCompletionMessage }
 
@@ -73,6 +75,7 @@ export class ManagedLlmClient implements LlmClient {
   ): AsyncGenerator<LlmStreamEvent> {
     for await (const line of this.streamPost(this.body(messages, tools))) {
       if (line.type === "delta") yield { kind: "delta", text: line.text }
+      else if (line.type === "reasoning") yield { kind: "reasoning", text: line.text }
       else if (line.type === "tool_start") yield { kind: "tool_start", name: line.name, id: line.id }
       else yield { kind: "final", turn: fromOpenAiMessage(line.message) }
     }


### PR DESCRIPTION
## What

Forward the model's reasoning (chain-of-thought) through the **managed transport**, so browser-agent turns that run on our keys get the same reasoning capture that #227 shipped for BYOK. Managed users previously saw an empty "Reasoning" expander even on thinking models, because the relay dropped the reasoning channel.

This is Phase 2b, the cross-stack follow-up to #227 (Phase 2a, BYOK / frontend-only).

## Why

The browser agent reaches the model over two transports. #227 wired reasoning into the **BYOK** path, which parses raw provider chunks in the browser. The **managed** path is different: the frontend calls our `/ai/llm/stream`, which proxies to the provider via litellm and re-emits a slimmed NDJSON wire format.

That relay is a field-selective projection, not a byte passthrough. `generate()` kept only `content` + `tool_calls`, so reasoning was dropped by omission, not by any provider or transport limit. The data is present server-side; the endpoint just never emitted it. 2b emits it.

## How

**Backend (`ai.py`, `/ai/llm/stream`):** emit a `{type:"reasoning",text}` NDJSON line per reasoning delta, alongside the existing `delta` / `tool_start` / `final` lines.

The one real subtlety, verified against our pinned litellm `1.83.14`:
- litellm normalizes every provider's reasoning into a single `delta.reasoning_content` (it maps `delta.reasoning` too), so the server reads one field regardless of provider.
- litellm **deletes** that attribute when a delta has no reasoning ("to match the OpenAI spec"), so it must be read with `getattr(delta, "reasoning_content", None)`. Attribute access would raise `AttributeError` on every ordinary token.
- Reasoning is kept out of the assembled answer `content` (we do not enable litellm's `merge_reasoning_content_in_choices`, which would wrap it in `<think>` tags inside the body).

Per-chunk line emission is factored into a `_delta_lines` helper so the stream handler stays under the complexity limit.

**Frontend (`managed-client.ts`):** add `{ type:"reasoning"; text }` to `ManagedStreamLine` and map it to `{ kind:"reasoning" }` in `completeStream`. Everything downstream of `LlmStreamEvent` (accumulation, steps, UI) is transport-agnostic and already landed in 2a, so there is no new frontend logic.

## Testing

- `test_ai_llm_router.py`: reasoning deltas surface as `{type:"reasoning"}` lines and stay out of the final `content`; a reasoning-less delta emits no reasoning line and does not crash (the `getattr` regression guard for litellm's delete-when-absent behavior).
- `managed-client.test.ts`: a `reasoning` NDJSON line yields a `reasoning` event; existing delta / tool_start / final cases stay green.
- Backend: 13 tests pass, `ruff check` clean. Frontend: managed-client suite green, `check-all` clean.

## Follow-ups

Signature-aware re-feed of reasoning across turns (litellm `thinking_blocks` / `reasoning_items`) remains a later, separate phase. 2b is display-only, matching 2a.

Plan: `docs/plans/phase2b-managed-reasoning.md`.
