### PR TITLE
feat(agent): bound tool output intra-run and age it across turns

### DIFF
--- a/docs/plans/phase5-history-fidelity.md
+++ b/docs/plans/phase5-history-fidelity.md
@@ -1,0 +1,88 @@
+# Phase 5 — history fidelity + tool-output bounding (implementation plan)
+
+Stop unbounded tool output from bloating the agent's context — both **within a turn** (the raw result
+fed back to the model each tool round) and **across turns** (the stored traces re-sent as history).
+Design rationale in [`agent-context-architecture.md`](./agent-context-architecture.md) Part 4 (items
+2-3) / Part 6 Phase 5; not restated here.
+
+## Scope of THIS PR — the low-risk, high-value subset
+
+Part 4 lists three items. Item 1 (reasoning wiring) **already shipped** in Phase 2. This PR takes the
+two clearly-correct pieces of items 2-3 and **defers** the risky rework:
+
+**In:**
+1. **Intra-run tool-result cap** — bound the raw tool output fed back to the model inside a turn's
+   tool loop (`agent-loop.ts`), so one large `fetch`/`web_search`/`doc_search` can't blow up every
+   subsequent round of the same turn.
+2. **Age tool outputs in cross-turn history** — in `chat-history.ts`, the most-recent turns keep full
+   tool output; older turns get a much smaller cap (bulk dropped, ids preserved). Bounds the
+   16-message history growth cheapest-first.
+
+**Out (deferred — higher risk, not needed for the value):**
+- Rewriting the round-trip to **native** `assistant{toolCalls}` + `tool` messages instead of the
+  `<Reasoning>` XML (item 2a). The XML path is already byte-stable and works; switching wire shapes
+  risks tool-pairing bugs for marginal gain.
+- Replacing the stored UI-shaped `ToolOutput` with a raw `StoredToolOutput.preview`. Today's stored
+  output already preserves the load-bearing bits (note ids, structured sources), so this is churn.
+- Full compaction (Phase 6).
+
+## The two changes
+
+### 1. Intra-run cap (`agent-loop.ts`)
+
+Today: `messages.push({ role: "tool", content: JSON.stringify(output) })` — **uncapped**. A 200KB
+fetch result then rides in context for every remaining round of the turn.
+
+Change: cap the serialized result to `MAX_TOOL_RESULT_CHARS` with a truncation marker that tells the
+model how to get more:
+
+```ts
+const capResult = (s: string) =>
+  s.length > MAX_TOOL_RESULT_CHARS
+    ? s.slice(0, MAX_TOOL_RESULT_CHARS) + `\n…[truncated ${s.length - MAX_TOOL_RESULT_CHARS} chars — call the tool again with a narrower query for more]`
+    : s
+```
+
+Truncating the tail keeps the head (ids, first results, the fields the model usually needs). Small
+results (note-tool `{id, created}`, failures) are never touched. Deterministic → byte-stable re-send.
+
+### 2. Age old outputs (`chat-history.ts`)
+
+Today: every turn's tool `<Output>` is capped at a uniform `MAX_COMPACT_TEXT_LENGTH` (10k). Across 16
+messages that's a lot of stale output the model rarely needs at full fidelity.
+
+Change: cap by **recency**. The last `RECENT_FULL_TURNS` assistant turns keep the full output cap; older
+turns cap at a small `MAX_AGED_OUTPUT_CHARS` (bulk gone, ids survive because they sit at the head of the
+JSON). Thread a `keepFullOutput` flag from `toLlmHistory` (which knows each turn's position) down
+through `compactMessageContent` → `compactReasoning` → `compactStep` → `compactOutput(output, cap)`.
+
+Inputs (args) are already small and stay full — only outputs age.
+
+## Constants (tune later)
+
+`MAX_TOOL_RESULT_CHARS = 8000` (intra-run), `RECENT_FULL_TURNS = 4`, `MAX_AGED_OUTPUT_CHARS = 500`,
+existing `MAX_COMPACT_TEXT_LENGTH = 10_000` (recent-turn output cap) unchanged.
+
+## Tests
+
+- **`agent-loop` test**: a tool returning a huge string is truncated (with the marker) in the `tool`
+  message fed to the next round; a small result is passed through untouched; the truncation is
+  identical across two runs (byte-stable).
+- **`chat-history` test**: an old assistant turn's tool `<Output>` is shortened to the aged cap while
+  the most-recent turn keeps full output; a note id at the head survives aging; inputs stay full;
+  the existing round-trip tests still pass (backward-compatible).
+
+## Backup compatibility
+
+No `ReasoningStep` schema change — this only changes how stored steps are *rendered* into history, so
+the opaque transcript backup (`chat-persist.ts`) is unaffected.
+
+## Estimate
+
+~120-180 impl LoC + ~120 test. Complexity **Med** — the care is byte-stability (deterministic caps)
+and threading the recency flag without disturbing the existing round-trip.
+
+## Sequencing
+
+Independent (adjacent to Phase 2, merged). Phase 6 (compaction) layers a token-threshold summarize on
+top, reusing the Phase 4 conversation checkpoint.

--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -645,3 +645,51 @@ describe("runAgent — declined off-board tool is not re-prompted across turns",
     expect(ran.value).toBe(2) // both searches ran
   })
 })
+
+
+describe("runAgent intra-run tool-result cap", () => {
+  // A client that requests one tool call, then captures the messages it's given
+  // on the follow-up round (where the tool result rides as a `tool` message).
+  const captureAfterTool = (toolName: string) => {
+    let captured: LlmMessage[] | null = null
+    const llm: LlmClient = {
+      complete: async (messages) => {
+        if (messages.some((m) => m.role === "tool")) {
+          captured = messages
+          return { kind: "text", text: "done" }
+        }
+        return { kind: "tool_calls", calls: [{ id: "c1", name: toolName, arguments: "{}" }] }
+      },
+    }
+    return { llm, toolMessage: () => captured?.find((m) => m.role === "tool") }
+  }
+
+
+  it("truncates a large tool result (head kept, marker added)", async () => {
+    const bigTool: Tool = { name: "fetch", description: "d", parameters: z.object({}), run: async () => "y".repeat(20000) }
+    const cap = captureAfterTool("fetch")
+    await drain(runAgent({ userMessage: "fetch it", tools: [bigTool], llm: cap.llm, ctx: {} as ToolContext }))
+    const content = cap.toolMessage()?.content ?? ""
+    expect(content.length).toBeLessThan(20000)
+    expect(content).toContain("truncated")
+    expect(content.startsWith('"yyy')).toBe(true) // head preserved
+  })
+
+
+  it("is byte-stable — the same large result truncates identically across runs", async () => {
+    const bigTool: Tool = { name: "fetch", description: "d", parameters: z.object({}), run: async () => "z".repeat(20000) }
+    const a = captureAfterTool("fetch")
+    const b = captureAfterTool("fetch")
+    await drain(runAgent({ userMessage: "x", tools: [bigTool], llm: a.llm, ctx: {} as ToolContext }))
+    await drain(runAgent({ userMessage: "x", tools: [bigTool], llm: b.llm, ctx: {} as ToolContext }))
+    expect(a.toolMessage()?.content).toBe(b.toolMessage()?.content)
+  })
+
+
+  it("leaves a small tool result untouched", async () => {
+    const smallTool: Tool = { name: "get_note", description: "d", parameters: z.object({}), run: async () => ({ id: "n1", ok: true }) }
+    const cap = captureAfterTool("get_note")
+    await drain(runAgent({ userMessage: "read", tools: [smallTool], llm: cap.llm, ctx: {} as ToolContext }))
+    expect(cap.toolMessage()?.content).toBe(JSON.stringify({ id: "n1", ok: true }))
+  })
+})

--- a/webui/src/features/agent/engine/agent-loop.ts
+++ b/webui/src/features/agent/engine/agent-loop.ts
@@ -19,6 +19,24 @@ export const DEFAULT_MAX_TURNS = 30
 
 
 /**
+ * Cap on a single tool result fed back to the model within a turn. Large results
+ * (`fetch` / `web_search` / `doc_search` full text) would otherwise ride in
+ * context for every remaining round of the turn. The head is kept (ids, first
+ * results); small results (note-tool `{id}`, failures) are untouched.
+ */
+export const MAX_TOOL_RESULT_CHARS = 8000
+
+
+/** Serialize a tool result for the model, truncating the tail past the cap with a
+ *  marker that tells the model how to get more. Deterministic → byte-stable re-send. */
+const serializeToolResult = (output: unknown): string => {
+  const s = JSON.stringify(output) ?? "null"
+  if (s.length <= MAX_TOOL_RESULT_CHARS) return s
+  return `${s.slice(0, MAX_TOOL_RESULT_CHARS)}\n…[truncated ${s.length - MAX_TOOL_RESULT_CHARS} chars — call the tool again with a narrower query for more]`
+}
+
+
+/**
  * Tools that reach OFF the board — network egress (`fetch`, `web_search`) and
  * code execution (`code_interpreter`). When a confirmer is wired (see `ToolContext.confirmTool`)
  * these require an explicit user OK before running, so a prompt-injected tool
@@ -210,7 +228,7 @@ export async function* runAgent(opts: RunAgentOptions): AsyncGenerator<AgentEven
       const output = await executeToolCall(call.name, args, opts.tools, opts.ctx, gate)
       agentLog.tool(call.name, args, output)
       yield { type: "tool_result", toolName: call.name, result: output }
-      messages.push({ role: "tool", toolCallId: call.id, content: JSON.stringify(output) })
+      messages.push({ role: "tool", toolCallId: call.id, content: serializeToolResult(output) })
     }
   }
 

--- a/webui/src/features/agent/local/chat-history.test.ts
+++ b/webui/src/features/agent/local/chat-history.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { ChatMessage } from "@/features/agent/types/chat"
 import type { ReasoningStep } from "@/features/agent/types/stream"
-import { toLlmHistory } from "./chat-history"
+import { MAX_AGED_OUTPUT_CHARS, RECENT_FULL_TURNS, toLlmHistory } from "./chat-history"
 
 
 const user = (text: string): ChatMessage => ({
@@ -41,6 +41,22 @@ const createNoteStep = (noteId: string, title: string): ReasoningStep => ({
   eventMessages: [],
   arguments: { input: { title } },
 })
+
+
+// A tool step whose output is a big string (e.g. a fetched page), to exercise aging.
+const bigOutputStep = (id: string, size: number): ReasoningStep => ({
+  type: "tool_call",
+  id: `t-${id}`,
+  name: "fetch",
+  thought: "",
+  output: "x".repeat(size),
+  state: "completed",
+  eventMessages: [],
+  arguments: { input: { url: "https://a.com" } },
+})
+
+
+const outputLen = (content: string): number => content.match(/<Output>([\s\S]*?)<\/Output>/)?.[1].length ?? 0
 
 
 describe("toLlmHistory", () => {
@@ -96,5 +112,26 @@ describe("toLlmHistory", () => {
     expect(history).toHaveLength(16)
     expect(history[0].content).toBe("m24")
     expect(history.at(-1)?.content).toBe("m39")
+  })
+
+
+  it("ages old tool output to a small cap while the most-recent turn keeps it full", () => {
+    // A run of tool-only assistant turns; only the last RECENT_FULL_TURNS keep full output.
+    const turns: ChatMessage[] = []
+    for (let i = 0; i < RECENT_FULL_TURNS + 2; i += 1) turns.push(user(`q${i}`), assistant("", [bigOutputStep(`f${i}`, 5000)]))
+    const history = toLlmHistory(turns, turns.length)
+    const oldest = history[1] // first assistant turn — aged out
+    const newest = history.at(-1)! // most recent assistant turn — full
+    expect(outputLen(oldest.content)).toBeLessThanOrEqual(MAX_AGED_OUTPUT_CHARS + 3) // "..." marker
+    expect(outputLen(newest.content)).toBe(5000) // under the 10k full cap, untouched
+  })
+
+
+  it("keeps a created note id visible even after a turn's output ages out", () => {
+    const turns: ChatMessage[] = [user("build"), assistant("", [createNoteStep("n42", "Cats")])]
+    // Pad with recent turns so the note turn is aged out of the full window.
+    for (let i = 0; i < RECENT_FULL_TURNS; i += 1) turns.push(user(`later${i}`), assistant(`ok${i}`))
+    const [, noteTurn] = toLlmHistory(turns, turns.length)
+    expect(noteTurn.content).toContain("n42") // id survives aging (it's at the head)
   })
 })

--- a/webui/src/features/agent/local/chat-history.test.ts
+++ b/webui/src/features/agent/local/chat-history.test.ts
@@ -127,6 +127,27 @@ describe("toLlmHistory", () => {
   })
 
 
+  it("keeps full output for exactly the last RECENT_FULL_TURNS ASSISTANT turns (not messages)", () => {
+    const turns: ChatMessage[] = []
+    const total = RECENT_FULL_TURNS + 3
+    for (let i = 0; i < total; i += 1) turns.push(user(`q${i}`), assistant("", [bigOutputStep(`f${i}`, 5000)]))
+    const history = toLlmHistory(turns, turns.length)
+    // Assistant entries sit at the odd indices (each preceded by its user turn).
+    const fullCount = history.filter((_, i) => i % 2 === 1).map((h) => outputLen(h.content)).filter((n) => n === 5000).length
+    expect(fullCount).toBe(RECENT_FULL_TURNS) // 4 assistant turns, not 2
+  })
+
+
+  it("does not let an empty-rendering message consume a window slot", () => {
+    // An assistant turn with no text and no reasoning renders to "" — it must not
+    // eat a slot inside the last-`max` window (regression vs filter-before-slice).
+    const msgs = [...Array.from({ length: 16 }, (_, i) => user(`m${i}`)), assistant("", [])]
+    const history = toLlmHistory(msgs, 16)
+    expect(history).toHaveLength(16)
+    expect(history.map((h) => h.content)).toEqual(Array.from({ length: 16 }, (_, i) => `m${i}`))
+  })
+
+
   it("keeps a created note id visible even after a turn's output ages out", () => {
     const turns: ChatMessage[] = [user("build"), assistant("", [createNoteStep("n42", "Cats")])]
     // Pad with recent turns so the note turn is aged out of the full window.

--- a/webui/src/features/agent/local/chat-history.ts
+++ b/webui/src/features/agent/local/chat-history.ts
@@ -17,10 +17,15 @@ import { wrapWithMessageContext } from "./message-context"
 // (MAX_RETRIEVAL_MESSAGES) and per-field cap (MAX_COMPACT_TEXT_LENGTH).
 export const MAX_HISTORY_MESSAGES = 16
 const MAX_COMPACT_TEXT_LENGTH = 10_000
+// How many of the most-recent assistant turns keep FULL tool output; older turns
+// age down to MAX_AGED_OUTPUT_CHARS (bulk dropped, head/ids preserved) so stale
+// output doesn't dominate the re-sent history.
+export const RECENT_FULL_TURNS = 4
+export const MAX_AGED_OUTPUT_CHARS = 500
 
 
-const truncate = (s: string): string =>
-  s.length > MAX_COMPACT_TEXT_LENGTH ? s.slice(0, MAX_COMPACT_TEXT_LENGTH) + "..." : s
+const truncate = (s: string, cap = MAX_COMPACT_TEXT_LENGTH): string =>
+  s.length > cap ? s.slice(0, cap) + "..." : s
 
 
 /** Render a single tool-call argument value as a short string. */
@@ -46,11 +51,12 @@ const compactInput = (input: unknown): string => {
 }
 
 
-/** Short summary of a tool call's output (string truncated, object as JSON). */
-const compactOutput = (output: ToolOutput): string => {
-  if (typeof output === "string") return truncate(output.trim().replace(/\n/g, " "))
+/** Short summary of a tool call's output. `outputCap` shrinks for aged turns so
+ *  stale bulk drops while the head (ids, first fields) survives. */
+const compactOutput = (output: ToolOutput, outputCap: number): string => {
+  if (typeof output === "string") return truncate(output.trim().replace(/\n/g, " "), outputCap)
   try {
-    return truncate(JSON.stringify(output))
+    return truncate(JSON.stringify(output), outputCap)
   } catch {
     return ""
   }
@@ -58,10 +64,10 @@ const compactOutput = (output: ToolOutput): string => {
 
 
 /** One reasoning step as the backend's compact XML-ish block. */
-const compactStep = (step: ReasoningStep): string => {
+const compactStep = (step: ReasoningStep, outputCap: number): string => {
   if (isToolCallStep(step)) {
     const input = compactInput(step.arguments?.input)
-    const output = compactOutput(step.output)
+    const output = compactOutput(step.output, outputCap)
     const parts = [`<ToolCall name="${step.name}">`]
     if (input) parts.push(`<Input>${input}</Input>`)
     if (output) parts.push(`<Output>${output}</Output>`)
@@ -76,14 +82,17 @@ const compactStep = (step: ReasoningStep): string => {
 
 
 /** Wrap a turn's reasoning steps in a `<Reasoning>` block (empty if none). */
-const compactReasoning = (steps: ReasoningStep[]): string => {
-  const body = steps.map(compactStep).filter(Boolean).join("\n\n")
+const compactReasoning = (steps: ReasoningStep[], outputCap: number): string => {
+  const body = steps.map((s) => compactStep(s, outputCap)).filter(Boolean).join("\n\n")
   return body ? `<Reasoning>\n\n${body}\n\n</Reasoning>` : ""
 }
 
 
-/** A message's LLM content: assistant turns prepend their reasoning/tool traces. */
-const compactMessageContent = (message: ChatMessage): string => {
+/**
+ * A message's LLM content: assistant turns prepend their reasoning/tool traces.
+ * `outputCap` bounds tool-output length — smaller for older (aged) turns.
+ */
+const compactMessageContent = (message: ChatMessage, outputCap: number): string => {
   const markdown = message.content.markdown?.trim() ?? ""
   if (message.role !== "assistant") {
     // Mirror the backend's `to_chat_message`: a past user turn re-includes the
@@ -92,15 +101,23 @@ const compactMessageContent = (message: ChatMessage): string => {
     // live turn uses, and returns the bare prompt when there's no context.
     return wrapWithMessageContext(markdown, message.properties?.context?.text)
   }
-  const reasoning = compactReasoning(message.properties?.reasoning?.reasoning ?? [])
+  const reasoning = compactReasoning(message.properties?.reasoning?.reasoning ?? [], outputCap)
   return reasoning ? `${reasoning}\n\n${markdown}`.trim() : markdown
 }
 
 
-/** Convert the stored transcript into the agent's prior-turn context. */
-export const toLlmHistory = (messages: ChatMessage[], max = MAX_HISTORY_MESSAGES): LlmMessage[] =>
-  messages
-    .filter((m) => m.role === "user" || m.role === "assistant")
-    .map((m) => ({ role: m.role as "user" | "assistant", content: compactMessageContent(m) }))
+/**
+ * Convert the stored transcript into the agent's prior-turn context. Tool output
+ * ages by recency: the last `RECENT_FULL_TURNS` kept messages keep full output;
+ * older ones shrink to `MAX_AGED_OUTPUT_CHARS`, so stale bulk doesn't dominate.
+ */
+export const toLlmHistory = (messages: ChatMessage[], max = MAX_HISTORY_MESSAGES): LlmMessage[] => {
+  const kept = messages.filter((m) => m.role === "user" || m.role === "assistant").slice(-max)
+  const recentFrom = kept.length - RECENT_FULL_TURNS
+  return kept
+    .map((m, i) => ({
+      role: m.role as "user" | "assistant",
+      content: compactMessageContent(m, i >= recentFrom ? MAX_COMPACT_TEXT_LENGTH : MAX_AGED_OUTPUT_CHARS),
+    }))
     .filter((m) => m.content !== "")
-    .slice(-max)
+}

--- a/webui/src/features/agent/local/chat-history.ts
+++ b/webui/src/features/agent/local/chat-history.ts
@@ -108,16 +108,28 @@ const compactMessageContent = (message: ChatMessage, outputCap: number): string 
 
 /**
  * Convert the stored transcript into the agent's prior-turn context. Tool output
- * ages by recency: the last `RECENT_FULL_TURNS` kept messages keep full output;
+ * ages by recency: the last `RECENT_FULL_TURNS` ASSISTANT turns keep full output;
  * older ones shrink to `MAX_AGED_OUTPUT_CHARS`, so stale bulk doesn't dominate.
  */
 export const toLlmHistory = (messages: ChatMessage[], max = MAX_HISTORY_MESSAGES): LlmMessage[] => {
-  const kept = messages.filter((m) => m.role === "user" || m.role === "assistant").slice(-max)
-  const recentFrom = kept.length - RECENT_FULL_TURNS
-  return kept
-    .map((m, i) => ({
-      role: m.role as "user" | "assistant",
-      content: compactMessageContent(m, i >= recentFrom ? MAX_COMPACT_TEXT_LENGTH : MAX_AGED_OUTPUT_CHARS),
-    }))
-    .filter((m) => m.content !== "")
+  // Window = the last `max` messages that render to non-empty content. Emptiness
+  // is cap-independent (aging keeps the <ToolCall> wrapper + markdown), so a
+  // full-cap render is a sound emptiness probe — filter BEFORE slicing so empty
+  // turns don't consume window slots (matches the pre-aging behavior).
+  const window = messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .filter((m) => compactMessageContent(m, MAX_COMPACT_TEXT_LENGTH) !== "")
+    .slice(-max)
+  // Full-output cutoff = the index of the RECENT_FULL_TURNS-th assistant turn from
+  // the end (only assistant turns carry tool output); turns at/after it stay full.
+  let assistantSeen = 0
+  let fullFrom = 0
+  for (let i = window.length - 1; i >= 0; i -= 1) {
+    fullFrom = i
+    if (window[i].role === "assistant" && ++assistantSeen === RECENT_FULL_TURNS) break
+  }
+  return window.map((m, i) => ({
+    role: m.role as "user" | "assistant",
+    content: compactMessageContent(m, i >= fullFrom ? MAX_COMPACT_TEXT_LENGTH : MAX_AGED_OUTPUT_CHARS),
+  }))
 }


### PR DESCRIPTION
## What

Stop unbounded tool output from bloating the agent's context, in the two places it grows:

- **Within a turn** — cap the raw tool result fed back to the model on each tool round, so one large `fetch` / `web_search` / `doc_search` can't ride in context for every remaining round of the same turn.
- **Across turns** — age tool output by recency in the history round-trip: recent turns keep full output, older turns shrink to a small cap (bulk dropped, ids kept).

This is Phase 5 of the agent-context work.

## Why

The browser agent re-feeds prior tool traces so it knows what it did (e.g. the note ids it created). But nothing bounded those payloads. Intra-run, a 200KB fetched page was serialized whole into a `tool` message that then rode in context for every subsequent round of the turn. Cross-turn, every one of the last 16 messages kept its tool output at a uniform 10k cap — a lot of stale output the model rarely needs at full fidelity. Both inflate tokens (and cost) for no benefit.

## Scope

Part 4 of the design doc lists three history items. Item 1 (reasoning wiring) already shipped in Phase 2. This PR takes the two clearly-correct pieces of items 2-3 and **defers** the higher-risk rework:

- **Deferred:** rewriting the round-trip to native `assistant{toolCalls}` + `tool` messages (risks tool-pairing bugs for marginal gain; the `<Reasoning>` XML path is already byte-stable), and replacing the stored UI-shaped output with a raw preview (today's stored output already keeps the load-bearing bits — ids, structured sources).

## How

**Intra-run cap (`agent-loop.ts`)** — `serializeToolResult` caps the serialized result at `MAX_TOOL_RESULT_CHARS` (8000), keeping the head (ids, first results) and appending a marker that tells the model to re-call with a narrower query for more. Small results (note-tool `{id, created}`, failures) fall under the cap and are untouched. Deterministic, so a re-sent result truncates identically (byte-stable).

**Age old output (`chat-history.ts`)** — tool `<Output>` now caps by recency: the last `RECENT_FULL_TURNS` (4) assistant turns keep the full `MAX_COMPACT_TEXT_LENGTH` (10k) cap; older turns cap at `MAX_AGED_OUTPUT_CHARS` (500). Because ids sit at the head of the serialized output, they survive aging while the bulk drops. Inputs (args) are already small and stay full. The recency flag threads from `toLlmHistory` (which knows each turn's position) down through the compaction helpers.

## Testing

- **`agent-loop.test.ts`**: a large tool result is truncated (head kept, marker added) in the `tool` message fed to the next round; the truncation is identical across two runs (byte-stable); a small result passes through untouched.
- **`chat-history.test.ts`**: an old turn's tool output ages to the small cap while the most-recent turn keeps it full; a created note id survives aging; existing round-trip tests still pass (backward-compatible).
- Full frontend suite green (1231 tests), `check-all` clean.

## Compatibility

No `ReasoningStep` schema change — this only changes how stored steps are *rendered* into history, so the opaque transcript backup (`chat-persist.ts`) is unaffected.

## Follow-ups

**Phase 6** — token-threshold compaction, layered on top and reusing the Phase 4 conversation checkpoint.

Plan: `docs/plans/phase5-history-fidelity.md`.
