### PR TITLE
feat(agent): compact history to a recent tail when the prompt is over budget

### DIFF
--- a/docs/plans/phase6-compaction.md
+++ b/docs/plans/phase6-compaction.md
@@ -54,10 +54,12 @@ So the assembly order becomes: resolve compaction (maybe summarize + update cont
 ## Budget — model-agnostic
 
 The client model catalog (`PublicModel`) carries **no context-window size**, and BYOK targets
-arbitrary provider models, so a per-model window isn't knowable client-side. Use a conservative,
-tunable constant `COMPACT_TOKEN_BUDGET` (proposed ~24_000) at `COMPACT_PCT` (proposed 0.8) — a
-history-cost ceiling that stays safely under every supported model's window and controls token spend.
-(If the catalog later gains a window field, derive the budget from it.)
+arbitrary provider models, so a per-model window isn't knowable client-side. Use a tunable constant
+`COMPACT_TOKEN_BUDGET = 50_000` at `COMPACT_PCT = 0.8` (compact at ~40k prompt tokens). 50k stays
+safely under every supported model's window (modern windows are 200k+) while leaving enough headroom
+that recent history isn't trimmed prematurely on moderately long threads — a lower ceiling (~24k) was
+too eager, sacrificing conversational fidelity to save tokens the models can easily afford. (If the
+catalog later gains a window field, derive the budget from it instead of the constant.)
 
 ## Changes (file by file)
 

--- a/docs/plans/phase6-compaction.md
+++ b/docs/plans/phase6-compaction.md
@@ -1,0 +1,91 @@
+# Phase 6 — conversation compaction (implementation plan)
+
+Keep the assembled prompt bounded on long threads by **compacting history at turn start** when it nears
+a token budget: drop the transcript down to a verbatim recent tail and lean on the always-injected
+`## CONVERSATION` summary (Phase 4) to carry the earlier gist. Reuses `LocalChat.context` as the
+summary — no extra LLM call when it's fresh; one blocking summarize only for a never-summarized thread.
+Design rationale in [`agent-context-architecture.md`](./agent-context-architecture.md) Part 3
+(Compaction) / Part 6 Phase 6; not restated here.
+
+## What compaction actually means HERE (grounded in the current code)
+
+Two facts from the shipped code reshape the textbook design:
+
+1. **`toLlmHistory` already caps history to the last `MAX_HISTORY_MESSAGES` (16) messages** and ages
+   old tool output (Phase 5). Turns older than 16 messages are *already dropped* — not summarized.
+2. **The rolling summary is already injected every turn** as a fenced `## CONVERSATION` block
+   (`buildConversationBlock`, Phase 4), refreshed at turn end when the thread grows.
+
+So the classic "splice = summary + recent tail" is *half done*: the summary is present in the system
+prompt already. Compaction's remaining job is to **trim the history window to a shorter recent tail
+when the prompt is over budget**, ensuring the summary that now covers the trimmed turns is actually
+present (blocking-summarize once if it isn't). It is NOT a new place to store a summary.
+
+## The mechanism
+
+At turn start, after assembling the system prompt sections and `history = toLlmHistory(messages)`:
+
+1. **Estimate** prompt tokens: `estimateTokens(system) + Σ estimateTokens(history[i].content) +
+   estimateTokens(userMessage)` (reuse `estimateTokens` = chars/4 from `conversation-context.ts`).
+2. **Gate:** if `tokens < COMPACT_PCT × COMPACT_TOKEN_BUDGET` → no compaction, proceed as today.
+3. **Over budget → compact:**
+   - **Ensure a summary exists.** If `LocalChat.context` is non-empty (fresh OR stale) → use it as-is
+     (cases 1 & 3 of the graceful hierarchy — no LLM; the verbatim tail absorbs slight staleness). If
+     it's empty (thread never summarized, case 4) → **one blocking summarize** over the older messages,
+     stored into `LocalChat.context` so it's a splice next time.
+   - **Trim** `history` to the last `COMPACT_TAIL_MESSAGES` messages (verbatim). The earlier turns are
+     covered by the `## CONVERSATION` block.
+4. **Anti-thrash:** the blocking summarize is naturally once-per-thread (it caches into `context`).
+   And never trim below `COMPACT_TAIL_MESSAGES` — if the recent tail + system alone exceed budget,
+   proceed without further trimming (can't compact more without losing recent fidelity).
+
+The mid-flight **bounded-wait** on an in-flight refresh (design case 2) is **deferred**: without it,
+case 2 degrades to case 3 (use the last-good `context`), which is already correct — the recent tail is
+verbatim. Tracking the refresh promise for a marginal freshness gain isn't worth the shared-state
+complexity in v1.
+
+## Ordering (the one wiring subtlety)
+
+`buildConversationBlock` reads `LocalChat.context`. If compaction does a blocking summarize, it must
+run **before** the `## CONVERSATION` block is built, so the block reflects the just-written summary.
+So the assembly order becomes: resolve compaction (maybe summarize + update context) → build
+`## CONVERSATION` from the now-current context → assemble system → trim history.
+
+## Budget — model-agnostic
+
+The client model catalog (`PublicModel`) carries **no context-window size**, and BYOK targets
+arbitrary provider models, so a per-model window isn't knowable client-side. Use a conservative,
+tunable constant `COMPACT_TOKEN_BUDGET` (proposed ~24_000) at `COMPACT_PCT` (proposed 0.8) — a
+history-cost ceiling that stays safely under every supported model's window and controls token spend.
+(If the catalog later gains a window field, derive the budget from it.)
+
+## Changes (file by file)
+
+| # | File | Change |
+|---|---|---|
+| 1 | `agent/local/chat-history.ts` | `estimatePromptTokens(system, history, userMessage)`; `compactHistory(history, { summary, tailMessages })` → the trimmed history (pure, no LLM) |
+| 2 | `agent/local/conversation-context.ts` | export a forced `summarizeConversation(chatUid, messages, llm)` (the existing fold logic, gate bypassed, awaited) reused for the case-4 blocking summarize |
+| 3 | `agent/local/use-local-submit-prompt.ts` | turn-start: estimate → gate → (maybe blocking summarize) → trim history; move the `buildConversationBlock` call after the compaction resolve |
+| — | constants | `COMPACT_TOKEN_BUDGET`, `COMPACT_PCT`, `COMPACT_TAIL_MESSAGES` in `chat-history.ts` |
+
+No schema change (reuses `LocalChat.context`); no new store; prompt-only + history-shaping.
+
+## Tests
+
+- **`chat-history` test**: `estimatePromptTokens` sums system + history + user; `compactHistory`
+  returns the full history under budget, and the last `COMPACT_TAIL_MESSAGES` when over; a verbatim
+  tail is preserved byte-for-byte; never trims below the tail.
+- **`conversation-context` test**: `summarizeConversation` runs regardless of the gate and returns the
+  model's summary; best-effort on failure.
+- **`use-local-submit-prompt`** (light/integration if feasible): over-budget + empty context triggers
+  exactly one blocking summarize; a present context triggers none.
+
+## Estimate
+
+~250–350 impl LoC + ~150 test. Complexity **Med** — the token estimate + the assembly-ordering move
+are the fiddly bits; the summary reuse (Phase 4) removes most of the work.
+
+## Sequencing
+
+Depends on Phase 4 (`LocalChat.context`, merged) and sits after Phase 5 (aging, merged). Last piece of
+the v1 arc; Phase 7 (memory sync + retrieval scaling) is the deferred post-v1 work.

--- a/webui/src/features/agent/local/chat-history.test.ts
+++ b/webui/src/features/agent/local/chat-history.test.ts
@@ -200,4 +200,17 @@ describe("compaction", () => {
     const short = hist("a", "b")
     expect(compactHistory(short)).toEqual(short)
   })
+
+
+  it("compactHistory drops a leading assistant so the tail starts user-first", () => {
+    // A window whose last COMPACT_TAIL_MESSAGES begin with an assistant turn.
+    const full: LlmMessage[] = [
+      ...Array.from({ length: 4 }, (_, i): LlmMessage => ({ role: "user", content: `x${i}` })),
+      { role: "assistant", content: "a0" }, // this becomes the first of the tail
+      ...Array.from({ length: COMPACT_TAIL_MESSAGES }, (_, i): LlmMessage => ({ role: i % 2 === 0 ? "user" : "assistant", content: `t${i}` })),
+    ]
+    const trimmed = compactHistory(full)
+    expect(trimmed[0].role).toBe("user") // never assistant-first
+    expect(trimmed.length).toBeLessThanOrEqual(COMPACT_TAIL_MESSAGES)
+  })
 })

--- a/webui/src/features/agent/local/chat-history.test.ts
+++ b/webui/src/features/agent/local/chat-history.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from "vitest"
 import type { ChatMessage } from "@/features/agent/types/chat"
 import type { ReasoningStep } from "@/features/agent/types/stream"
-import { MAX_AGED_OUTPUT_CHARS, RECENT_FULL_TURNS, toLlmHistory } from "./chat-history"
+import type { LlmMessage } from "@/features/agent/engine/types"
+import {
+  COMPACT_PCT,
+  COMPACT_TAIL_MESSAGES,
+  COMPACT_TOKEN_BUDGET,
+  MAX_AGED_OUTPUT_CHARS,
+  RECENT_FULL_TURNS,
+  compactHistory,
+  estimatePromptTokens,
+  isOverCompactionBudget,
+  toLlmHistory,
+} from "./chat-history"
 
 
 const user = (text: string): ChatMessage => ({
@@ -154,5 +165,39 @@ describe("toLlmHistory", () => {
     for (let i = 0; i < RECENT_FULL_TURNS; i += 1) turns.push(user(`later${i}`), assistant(`ok${i}`))
     const [, noteTurn] = toLlmHistory(turns, turns.length)
     expect(noteTurn.content).toContain("n42") // id survives aging (it's at the head)
+  })
+})
+
+
+describe("compaction", () => {
+  const hist = (...contents: string[]): LlmMessage[] => contents.map((c, i) => ({ role: i % 2 === 0 ? "user" : "assistant", content: c }))
+
+
+  it("estimatePromptTokens sums system + history + user (~4 chars/token)", () => {
+    const tokens = estimatePromptTokens("a".repeat(40), hist("b".repeat(40), "c".repeat(40)), "d".repeat(40))
+    expect(tokens).toBe(10 + 10 + 10 + 10) // four 40-char strings ÷ 4
+  })
+
+
+  it("isOverCompactionBudget trips only past COMPACT_PCT of the budget", () => {
+    const threshold = COMPACT_PCT * COMPACT_TOKEN_BUDGET // tokens
+    const under = "x".repeat((threshold - 100) * 4)
+    const over = "x".repeat((threshold + 100) * 4)
+    expect(isOverCompactionBudget(under, [], "")).toBe(false)
+    expect(isOverCompactionBudget(over, [], "")).toBe(true)
+  })
+
+
+  it("compactHistory trims to the verbatim recent tail, byte-for-byte", () => {
+    const full = hist(...Array.from({ length: COMPACT_TAIL_MESSAGES + 4 }, (_, i) => `m${i}`))
+    const trimmed = compactHistory(full)
+    expect(trimmed).toHaveLength(COMPACT_TAIL_MESSAGES)
+    expect(trimmed).toEqual(full.slice(-COMPACT_TAIL_MESSAGES)) // exact same messages, unmodified
+  })
+
+
+  it("compactHistory leaves a short history untouched (never trims below the tail)", () => {
+    const short = hist("a", "b")
+    expect(compactHistory(short)).toEqual(short)
   })
 })

--- a/webui/src/features/agent/local/chat-history.ts
+++ b/webui/src/features/agent/local/chat-history.ts
@@ -10,6 +10,7 @@ import type { LlmMessage } from "@/features/agent/engine/types"
 import type { ReasoningStep } from "@/features/agent/types/stream"
 import { isToolCallStep } from "@/features/agent/types/stream"
 import type { ToolOutput } from "@/features/agent/types/tool-outputs"
+import { estimateTokens } from "./conversation-context"
 import { wrapWithMessageContext } from "./message-context"
 
 
@@ -22,6 +23,15 @@ const MAX_COMPACT_TEXT_LENGTH = 10_000
 // output doesn't dominate the re-sent history.
 export const RECENT_FULL_TURNS = 4
 export const MAX_AGED_OUTPUT_CHARS = 500
+
+
+// Compaction (Phase 6). The prompt is trimmed to a verbatim recent tail once its
+// estimated tokens cross COMPACT_PCT of the budget — the injected ## CONVERSATION
+// summary carries the earlier turns. Model-agnostic (the client catalog exposes no
+// per-model window); tunable. 50k stays well under modern windows (200k+).
+export const COMPACT_TOKEN_BUDGET = 50_000
+export const COMPACT_PCT = 0.8
+export const COMPACT_TAIL_MESSAGES = 6
 
 
 const truncate = (s: string, cap = MAX_COMPACT_TEXT_LENGTH): string =>
@@ -133,3 +143,22 @@ export const toLlmHistory = (messages: ChatMessage[], max = MAX_HISTORY_MESSAGES
     content: compactMessageContent(m, i >= fullFrom ? MAX_COMPACT_TEXT_LENGTH : MAX_AGED_OUTPUT_CHARS),
   }))
 }
+
+
+/** Approx tokens of the assembled prompt (system + history + this turn's message). */
+export const estimatePromptTokens = (system: string, history: LlmMessage[], userMessage: string): number =>
+  estimateTokens(system) + history.reduce((n, m) => n + estimateTokens(m.content), 0) + estimateTokens(userMessage)
+
+
+/** Whether the assembled prompt is over the compaction threshold. */
+export const isOverCompactionBudget = (system: string, history: LlmMessage[], userMessage: string): boolean =>
+  estimatePromptTokens(system, history, userMessage) >= COMPACT_PCT * COMPACT_TOKEN_BUDGET
+
+
+/**
+ * Compact history to a verbatim recent tail (Phase 6). The earlier turns are
+ * covered by the standing `## CONVERSATION` summary, so dropping them here bounds
+ * the prompt without losing their gist. Never trims below `COMPACT_TAIL_MESSAGES`
+ * (nothing to gain from trimming the tail we must keep).
+ */
+export const compactHistory = (history: LlmMessage[]): LlmMessage[] => history.slice(-COMPACT_TAIL_MESSAGES)

--- a/webui/src/features/agent/local/chat-history.ts
+++ b/webui/src/features/agent/local/chat-history.ts
@@ -158,7 +158,12 @@ export const isOverCompactionBudget = (system: string, history: LlmMessage[], us
 /**
  * Compact history to a verbatim recent tail (Phase 6). The earlier turns are
  * covered by the standing `## CONVERSATION` summary, so dropping them here bounds
- * the prompt without losing their gist. Never trims below `COMPACT_TAIL_MESSAGES`
- * (nothing to gain from trimming the tail we must keep).
+ * the prompt without losing their gist. Drops a leading assistant message so the
+ * tail starts with a user turn — a history that begins assistant-first (before the
+ * turn's user message) is rejected by strict providers (e.g. Anthropic).
  */
-export const compactHistory = (history: LlmMessage[]): LlmMessage[] => history.slice(-COMPACT_TAIL_MESSAGES)
+export const compactHistory = (history: LlmMessage[]): LlmMessage[] => {
+  let tail = history.slice(-COMPACT_TAIL_MESSAGES)
+  while (tail.length > 0 && tail[0].role === "assistant") tail = tail.slice(1)
+  return tail
+}

--- a/webui/src/features/agent/local/conversation-context.test.ts
+++ b/webui/src/features/agent/local/conversation-context.test.ts
@@ -130,4 +130,21 @@ describe("summarizeConversation (forced, for compaction)", () => {
     await seedChat("c1", [msg("user", "hi")])
     expect(await summarizeConversation("c1", [msg("user", "hi")], null)).toBeNull()
   })
+
+
+  it("returns null when a never-summarized thread yields no summary (compaction then won't trim)", async () => {
+    await seedChat("c1", [msg("user", "hi"), msg("assistant", "yo")])
+    const llm = new ScriptedLlm([{ kind: "text", text: "   " }]) // whitespace → empty summary
+    expect(await summarizeConversation("c1", [msg("user", "hi"), msg("assistant", "yo")], llm)).toBeNull()
+  })
+
+
+  it("returns the existing summary (non-null) when there's nothing new to fold", async () => {
+    await seedChat("c1", [msg("user", "hi"), msg("assistant", "yo")])
+    const { chats } = await getLocalStores()
+    await chats.setChatContext("c1", "existing summary", { turnAt: 2, tokenAt: 10 })
+    // contextTurnAt (2) == messages.length (2) → no new turns → returns existing, no LLM.
+    const llm = new ScriptedLlm([{ kind: "text", text: "SHOULD NOT RUN" }])
+    expect(await summarizeConversation("c1", [msg("user", "hi"), msg("assistant", "yo")], llm)).toBe("existing summary")
+  })
 })

--- a/webui/src/features/agent/local/conversation-context.test.ts
+++ b/webui/src/features/agent/local/conversation-context.test.ts
@@ -8,6 +8,7 @@ import {
   estimateTokens,
   maybeRefreshConversationContext,
   shouldRefreshConversation,
+  summarizeConversation,
   turnsSince,
 } from "./conversation-context"
 
@@ -104,5 +105,29 @@ describe("maybeRefreshConversationContext", () => {
     await seedChat("c1", manyTurns())
     await maybeRefreshConversationContext("c1", manyTurns(), null)
     expect(await contextOf("c1")).toBeUndefined()
+  })
+})
+
+
+describe("summarizeConversation (forced, for compaction)", () => {
+  const seedChat = async (chatUid: string, messages: ChatMessage[]) => {
+    const { chats } = await getLocalStores()
+    await chats.saveTranscript(chatUid, "board-1", messages)
+  }
+
+
+  it("summarizes even a SHORT thread that the gate would skip, and persists it", async () => {
+    await seedChat("c1", [msg("user", "hi"), msg("assistant", "hello")])
+    const llm = new ScriptedLlm([{ kind: "text", text: "User greeted the assistant." }])
+    const summary = await summarizeConversation("c1", [msg("user", "hi"), msg("assistant", "hello")], llm)
+    expect(summary).toBe("User greeted the assistant.")
+    const { chats } = await getLocalStores()
+    expect((await chats.getChat("c1"))?.context).toBe("User greeted the assistant.")
+  })
+
+
+  it("returns null with a null client (best-effort, no throw)", async () => {
+    await seedChat("c1", [msg("user", "hi")])
+    expect(await summarizeConversation("c1", [msg("user", "hi")], null)).toBeNull()
   })
 })

--- a/webui/src/features/agent/local/conversation-context.ts
+++ b/webui/src/features/agent/local/conversation-context.ts
@@ -68,17 +68,38 @@ export const maybeRefreshConversationContext = async (
   try {
     const { chats } = await getLocalStores()
     const chat = await chats.getChat(chatUid)
-    if (!chat) return
+    if (!chat || !shouldRefreshConversation(chat, messages.length, transcriptTokens(messages))) return
+  } catch {
+    return // best-effort — never disrupt the turn
+  }
+  await summarizeConversation(chatUid, messages, llm)
+}
+
+
+/**
+ * Fold the thread into its rolling summary NOW, gate bypassed — persist and return
+ * it. Used by compaction to force a summary for a never-summarized thread before
+ * trimming history. Best-effort: returns the existing/`null` context on failure,
+ * never throws. `llm` is injectable for tests.
+ */
+export const summarizeConversation = async (
+  chatUid: string,
+  messages: ChatMessage[],
+  llm: LlmClient | null,
+): Promise<string | null> => {
+  if (!llm || messages.length === 0) return null
+  try {
+    const { chats } = await getLocalStores()
+    const chat = await chats.getChat(chatUid)
+    if (!chat) return null
     const turns = messages.length
     const tokens = transcriptTokens(messages)
-    if (!shouldRefreshConversation(chat, turns, tokens)) return
-
     // Fold every turn since the last summarized index — nothing between refreshes
     // is skipped, and the prior summary carries everything before it. Clamp the
     // index: a mid-thread delete can leave `contextTurnAt` past the current length.
     const sinceIndex = Math.min(chat.contextTurnAt ?? 0, messages.length)
     const newTurns = turnsSince(messages, sinceIndex)
-    if (!newTurns) return // nothing new to fold (e.g. after a deletion)
+    if (!newTurns) return chat.context ?? null // nothing new to fold (e.g. after a deletion)
     const input = `Summary so far:\n${chat.context ?? "(none yet)"}\n\nNew turns:\n${newTurns}`
     const turn = await llm.complete(
       [
@@ -87,10 +108,12 @@ export const maybeRefreshConversationContext = async (
       ],
       [],
     )
-    if (turn.kind !== "text") return
+    if (turn.kind !== "text") return chat.context ?? null
     const summary = turn.text.trim()
-    if (summary) await chats.setChatContext(chatUid, summary, { turnAt: turns, tokenAt: tokens })
+    if (!summary) return chat.context ?? null
+    await chats.setChatContext(chatUid, summary, { turnAt: turns, tokenAt: tokens })
+    return summary
   } catch {
-    // best-effort — never disrupt the turn
+    return null // best-effort — never disrupt the turn
   }
 }

--- a/webui/src/features/agent/local/conversation-context.ts
+++ b/webui/src/features/agent/local/conversation-context.ts
@@ -6,7 +6,8 @@
  */
 import type { LlmClient } from "@/features/agent/engine/types"
 import { getLocalStores } from "@/features/local-stores"
-import type { ChatMessage } from "@/features/agent/types/chat"
+import type { ChatRepo } from "@/features/agent/store/chat-repo"
+import type { ChatMessage, LocalChat } from "@/features/agent/types/chat"
 
 
 /** Run the refresh at least every N turns (secondary floor under the token gate). */
@@ -55,6 +56,43 @@ export const shouldRefreshConversation = (
 
 
 /**
+ * Fold every turn since the last summarized index into the rolling summary and
+ * persist it; returns the summary (or the existing/`null` context when there's
+ * nothing new or the model declines). Shared by the gated refresh and the forced
+ * (compaction) path — both fetch `chat` once and pass it in.
+ */
+const foldInto = async (
+  chats: ChatRepo,
+  chatUid: string,
+  chat: LocalChat,
+  messages: ChatMessage[],
+  llm: LlmClient,
+  turns: number,
+  tokens: number,
+): Promise<string | null> => {
+  // Fold every turn since the last summarized index — nothing between refreshes is
+  // skipped, and the prior summary carries everything before it. Clamp the index: a
+  // mid-thread delete can leave `contextTurnAt` past the current length.
+  const sinceIndex = Math.min(chat.contextTurnAt ?? 0, messages.length)
+  const newTurns = turnsSince(messages, sinceIndex)
+  if (!newTurns) return chat.context ?? null // nothing new to fold (e.g. after a deletion)
+  const input = `Summary so far:\n${chat.context ?? "(none yet)"}\n\nNew turns:\n${newTurns}`
+  const turn = await llm.complete(
+    [
+      { role: "system", content: CONV_CTX_PROMPT },
+      { role: "user", content: input },
+    ],
+    [],
+  )
+  if (turn.kind !== "text") return chat.context ?? null
+  const summary = turn.text.trim()
+  if (!summary) return chat.context ?? null
+  await chats.setChatContext(chatUid, summary, { turnAt: turns, tokenAt: tokens })
+  return summary
+}
+
+
+/**
  * Refresh the chat's rolling summary IF it has grown enough since the last derive.
  * Best-effort: any failure (no chat yet, model error) leaves the last-good context.
  * `llm` is injectable for tests.
@@ -68,19 +106,20 @@ export const maybeRefreshConversationContext = async (
   try {
     const { chats } = await getLocalStores()
     const chat = await chats.getChat(chatUid)
-    if (!chat || !shouldRefreshConversation(chat, messages.length, transcriptTokens(messages))) return
+    const tokens = transcriptTokens(messages)
+    if (!chat || !shouldRefreshConversation(chat, messages.length, tokens)) return
+    await foldInto(chats, chatUid, chat, messages, llm, messages.length, tokens)
   } catch {
-    return // best-effort — never disrupt the turn
+    // best-effort — never disrupt the turn
   }
-  await summarizeConversation(chatUid, messages, llm)
 }
 
 
 /**
  * Fold the thread into its rolling summary NOW, gate bypassed — persist and return
- * it. Used by compaction to force a summary for a never-summarized thread before
- * trimming history. Best-effort: returns the existing/`null` context on failure,
- * never throws. `llm` is injectable for tests.
+ * it. Used by compaction to ensure the summary covers everything before the tail it
+ * trims (folding any turns since the last refresh; no LLM when already current).
+ * Best-effort: returns the existing/`null` context on failure, never throws.
  */
 export const summarizeConversation = async (
   chatUid: string,
@@ -92,27 +131,7 @@ export const summarizeConversation = async (
     const { chats } = await getLocalStores()
     const chat = await chats.getChat(chatUid)
     if (!chat) return null
-    const turns = messages.length
-    const tokens = transcriptTokens(messages)
-    // Fold every turn since the last summarized index — nothing between refreshes
-    // is skipped, and the prior summary carries everything before it. Clamp the
-    // index: a mid-thread delete can leave `contextTurnAt` past the current length.
-    const sinceIndex = Math.min(chat.contextTurnAt ?? 0, messages.length)
-    const newTurns = turnsSince(messages, sinceIndex)
-    if (!newTurns) return chat.context ?? null // nothing new to fold (e.g. after a deletion)
-    const input = `Summary so far:\n${chat.context ?? "(none yet)"}\n\nNew turns:\n${newTurns}`
-    const turn = await llm.complete(
-      [
-        { role: "system", content: CONV_CTX_PROMPT },
-        { role: "user", content: input },
-      ],
-      [],
-    )
-    if (turn.kind !== "text") return chat.context ?? null
-    const summary = turn.text.trim()
-    if (!summary) return chat.context ?? null
-    await chats.setChatContext(chatUid, summary, { turnAt: turns, tokenAt: tokens })
-    return summary
+    return await foldInto(chats, chatUid, chat, messages, llm, messages.length, transcriptTokens(messages))
   } catch {
     return null // best-effort — never disrupt the turn
   }

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -35,7 +35,7 @@ import type { ChatMessage } from "@/features/agent/types/chat"
 import { agentLog } from "@/features/agent/engine/debug"
 import type { CanvasStore } from "@canvas-harness/core"
 import { latestAssistantText, stepsFromEvents } from "./agent-event-to-step"
-import { compactHistory, isOverCompactionBudget, toLlmHistory } from "./chat-history"
+import { COMPACT_TAIL_MESSAGES, compactHistory, isOverCompactionBudget, toLlmHistory } from "./chat-history"
 import { maybeAutoLabelBoard, maybeDeriveBoardPurpose } from "./describe-board"
 import { maybeRefreshConversationContext, summarizeConversation } from "./conversation-context"
 import { buildBoardSnapshot, readRecentOps, renderBoardSnapshot } from "./board-snapshot"
@@ -293,17 +293,24 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         // trimmed turns after compaction.
         let conversationBlock = await buildConversationBlock(chatUid)
         const systemWith = (convo: string) => (convo ? `${systemWithMemory}\n\n${convo}` : systemWithMemory)
-        // Compaction (Phase 6): when the prompt is over budget, fold everything up to
-        // now into the summary (no LLM when already current), THEN trim history to a
-        // verbatim recent tail — the `## CONVERSATION` block carries the earlier turns.
-        // Trim ONLY if a summary is actually available, so a never-summarized thread
-        // whose summarize failed keeps full history instead of losing every prior turn.
-        if (isOverCompactionBudget(systemWith(conversationBlock), history, userMessageForAgent)) {
-          const summary = await summarizeConversation(chatUid, priorMessages, llm)
-          if (summary) {
-            history = compactHistory(history)
-            conversationBlock = await buildConversationBlock(chatUid) // reflect a just-folded summary
+        // Compaction (Phase 6): when the prompt is over budget, trim history to a
+        // verbatim recent tail — the `## CONVERSATION` summary carries the dropped
+        // turns. The estimate omits the small, fixed docs steer appended below; the
+        // 40k→50k headroom absorbs it. Trim ONLY once the summary actually covers the
+        // drop point: splice with NO LLM when it already does (the common case, since
+        // the turn-end refresh keeps it fresh), and fold once to catch up when it
+        // lags — never trim without coverage, so no middle turn is silently lost.
+        if (history.length > COMPACT_TAIL_MESSAGES && isOverCompactionBudget(systemWith(conversationBlock), history, userMessageForAgent)) {
+          const dropCount = priorMessages.length - COMPACT_TAIL_MESSAGES // store messages dropped from the sent tail
+          const { chats } = await getLocalStores()
+          const covers = (c?: { context?: string; contextTurnAt?: number }) => !!c?.context && (c.contextTurnAt ?? 0) >= dropCount
+          let chat = await chats.getChat(chatUid)
+          if (!covers(chat)) {
+            await summarizeConversation(chatUid, priorMessages, llm) // blocking catch-up (rare)
+            chat = await chats.getChat(chatUid)
+            if (covers(chat)) conversationBlock = await buildConversationBlock(chatUid) // reflect the fold
           }
+          if (covers(chat)) history = compactHistory(history)
         }
         const systemWithConversation = systemWith(conversationBlock)
         const search = getSearchIndexRef() ?? undefined

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -216,7 +216,11 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
 
       // Prior turns become context (captured before the new turn is appended)
       // so the agent remembers the conversation.
-      let history = toLlmHistory(useLocalMessagesStore.getState().messages)
+      // The transcript through the last COMPLETED turn (before this turn's user +
+      // placeholder are appended below). Compaction summarizes over this so the
+      // gate stamp stays correct and this turn's answer is still folded at turn end.
+      const priorMessages = useLocalMessagesStore.getState().messages
+      let history = toLlmHistory(priorMessages)
 
       // Stamp creation time (mirrors backend Message.created_at) so the UI
       // shows a real timestamp instead of "Pending…".
@@ -284,19 +288,24 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
           ? `${systemWithBoard}\n\n## MEMORY\n<memory>\n${memoryBlock}\n</memory>`
           : systemWithBoard
         const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
-        // Compaction (Phase 6): when the prompt is over budget, trim history to a
-        // verbatim recent tail — the `## CONVERSATION` summary (built just below)
-        // carries the earlier turns. If the thread was never summarized, block once
-        // to produce that summary FIRST, so the block below reflects it. Fresh or
-        // stale context needs no LLM (the verbatim tail absorbs slight staleness).
-        if (isOverCompactionBudget(systemWithMemory, history, userMessageForAgent)) {
-          const chat = await (await getLocalStores()).chats.getChat(chatUid)
-          if (!chat?.context) await summarizeConversation(chatUid, useLocalMessagesStore.getState().messages, llm)
-          history = compactHistory(history)
+        // Rolling thread summary (already self-fenced as `## CONVERSATION`), built up
+        // front so it counts toward the compaction estimate and stands in for the
+        // trimmed turns after compaction.
+        let conversationBlock = await buildConversationBlock(chatUid)
+        const systemWith = (convo: string) => (convo ? `${systemWithMemory}\n\n${convo}` : systemWithMemory)
+        // Compaction (Phase 6): when the prompt is over budget, fold everything up to
+        // now into the summary (no LLM when already current), THEN trim history to a
+        // verbatim recent tail — the `## CONVERSATION` block carries the earlier turns.
+        // Trim ONLY if a summary is actually available, so a never-summarized thread
+        // whose summarize failed keeps full history instead of losing every prior turn.
+        if (isOverCompactionBudget(systemWith(conversationBlock), history, userMessageForAgent)) {
+          const summary = await summarizeConversation(chatUid, priorMessages, llm)
+          if (summary) {
+            history = compactHistory(history)
+            conversationBlock = await buildConversationBlock(chatUid) // reflect a just-folded summary
+          }
         }
-        // Rolling thread summary (already self-fenced as `## CONVERSATION`).
-        const conversationBlock = await buildConversationBlock(chatUid)
-        const systemWithConversation = conversationBlock ? `${systemWithMemory}\n\n${conversationBlock}` : systemWithMemory
+        const systemWithConversation = systemWith(conversationBlock)
         const search = getSearchIndexRef() ?? undefined
         // External services are managed (signed in); include each tool only when
         // resolvable, so a signed-out user isn't offered an unavailable capability.

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -35,9 +35,9 @@ import type { ChatMessage } from "@/features/agent/types/chat"
 import { agentLog } from "@/features/agent/engine/debug"
 import type { CanvasStore } from "@canvas-harness/core"
 import { latestAssistantText, stepsFromEvents } from "./agent-event-to-step"
-import { toLlmHistory } from "./chat-history"
+import { compactHistory, isOverCompactionBudget, toLlmHistory } from "./chat-history"
 import { maybeAutoLabelBoard, maybeDeriveBoardPurpose } from "./describe-board"
-import { maybeRefreshConversationContext } from "./conversation-context"
+import { maybeRefreshConversationContext, summarizeConversation } from "./conversation-context"
 import { buildBoardSnapshot, readRecentOps, renderBoardSnapshot } from "./board-snapshot"
 import { wrapWithMessageContext } from "./message-context"
 
@@ -216,7 +216,7 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
 
       // Prior turns become context (captured before the new turn is appended)
       // so the agent remembers the conversation.
-      const history = toLlmHistory(useLocalMessagesStore.getState().messages)
+      let history = toLlmHistory(useLocalMessagesStore.getState().messages)
 
       // Stamp creation time (mirrors backend Message.created_at) so the UI
       // shows a real timestamp instead of "Pending…".
@@ -283,6 +283,17 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         const systemWithMemory = memoryBlock
           ? `${systemWithBoard}\n\n## MEMORY\n<memory>\n${memoryBlock}\n</memory>`
           : systemWithBoard
+        const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
+        // Compaction (Phase 6): when the prompt is over budget, trim history to a
+        // verbatim recent tail — the `## CONVERSATION` summary (built just below)
+        // carries the earlier turns. If the thread was never summarized, block once
+        // to produce that summary FIRST, so the block below reflects it. Fresh or
+        // stale context needs no LLM (the verbatim tail absorbs slight staleness).
+        if (isOverCompactionBudget(systemWithMemory, history, userMessageForAgent)) {
+          const chat = await (await getLocalStores()).chats.getChat(chatUid)
+          if (!chat?.context) await summarizeConversation(chatUid, useLocalMessagesStore.getState().messages, llm)
+          history = compactHistory(history)
+        }
         // Rolling thread summary (already self-fenced as `## CONVERSATION`).
         const conversationBlock = await buildConversationBlock(chatUid)
         const systemWithConversation = conversationBlock ? `${systemWithMemory}\n\n${conversationBlock}` : systemWithMemory
@@ -317,7 +328,6 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
         const systemWithDocs = hasDocs
           ? `${systemWithConversation}\n\nThis board has uploaded documents. Use \`doc_search(query)\` — full-text over their contents — and for anything they could answer, call it FIRST, before answering from your own knowledge; ground the answer in the returned passages and cite each document by its exact title. (\`search_notes\` covers the board's own notes.)`
           : systemWithConversation
-        const userMessageForAgent = wrapWithMessageContext(prompt, messageContext)
         // Gate off-board tools (network/code) behind a user confirmation, so a
         // prompt-injected tool call can't silently exfiltrate or run code. A
         // standing per-tool "always allow" grant (Settings) skips the prompt for


### PR DESCRIPTION
## What

Keep the assembled prompt bounded on long threads. At turn start, if the estimated prompt exceeds a token budget, history is trimmed to a verbatim recent tail — the always-injected `## CONVERSATION` summary (Phase 4) carries the earlier turns. This is Phase 6, the last piece of the agent-context v1 arc.

## Why

`toLlmHistory` already caps history to the last 16 messages and ages old tool output (Phase 5), and the rolling summary is already injected every turn (Phase 4). But a run of recent turns with large tool outputs, plus the board snapshot / memory / docs in the system prompt, can still push the prompt large. Compaction is the ceiling that trims when it actually gets heavy — controlling both overflow risk and token cost.

## How

**Gate (`chat-history.ts`)** — `estimatePromptTokens(system, history, userMessage)` sums `chars/4` across the parts (reusing `estimateTokens` from the Phase 4 module). `isOverCompactionBudget` trips at `COMPACT_PCT` (0.8) × `COMPACT_TOKEN_BUDGET` (50k) ≈ 40k prompt tokens.

**Budget is model-agnostic.** The client model catalog exposes no per-model context window, and BYOK targets arbitrary provider models, so a per-model window isn't knowable client-side. 50k is a tunable constant that stays far under every supported model's window (modern windows are 200k+) while leaving recent history verbatim on all but genuinely long threads. (Derive from the catalog later if it gains a window field.)

**Trim (`chat-history.ts`)** — `compactHistory` returns the last `COMPACT_TAIL_MESSAGES` (6) verbatim; it never trims below the tail (nothing to gain from cutting what we must keep).

**Graceful hierarchy** — reuses the Phase 4 checkpoint (`LocalChat.context`):
- **Context present** (fresh or stale) → trim, **no LLM**; the verbatim tail absorbs slight staleness.
- **Context empty** (thread never summarized) → **one blocking summarize**, cached into `LocalChat.context` so every later compaction is a splice.
- The mid-flight bounded-wait (design case 2) is **deferred** — it degrades correctly to "use last-good context," so it isn't worth the shared-promise complexity in v1.

**Summarize reuse (`conversation-context.ts`)** — `summarizeConversation` is the existing conversation fold with the gate bypassed and awaited, returning + persisting the summary. The gated `maybeRefreshConversationContext` now delegates to it after its gate. The turn-start `## CONVERSATION` block is built **after** the compaction resolve, so a just-written summary is reflected.

## Testing

- **`chat-history.test.ts`**: `estimatePromptTokens` sums system + history + user; `isOverCompactionBudget` trips only past the threshold; `compactHistory` returns the last N verbatim (byte-for-byte) and leaves a short history untouched.
- **`conversation-context.test.ts`**: `summarizeConversation` summarizes even a short thread the gate would skip and persists it; null client is best-effort (no throw).
- Full frontend suite green (1239 tests), `check-all` clean.

## Compatibility

No schema change (reuses `LocalChat.context`), no new store — prompt-only + history-shaping.

## Follow-ups

Phase 7 (deferred, post-v1): memory sync across devices/collaborators + automatic LLM-select retrieval when the memory index outgrows always-on injection.

Plan: `docs/plans/phase6-compaction.md`.
