### PR TITLE
fix(webui): make browser-agent note search work (build the index; index titles)

### DIFF
--- a/webui/src/features/agent/local/local-agent-flag.ts
+++ b/webui/src/features/agent/local/local-agent-flag.ts
@@ -20,6 +20,15 @@ export const isLocalAgentOnSynced = (): boolean => {
 }
 
 
+/**
+ * Whether the browser agent is the active engine for a given board — true on
+ * local-only boards (`local`) OR on synced boards in browser-agent mode. The one
+ * predicate that gates browser-agent-only infra (local search / doc indexes), so
+ * callers don't re-derive `local || isLocalAgentOnSynced()` and drift apart.
+ */
+export const isBrowserAgentActive = (local: boolean): boolean => local || isLocalAgentOnSynced()
+
+
 const set = (on: boolean): void => {
   try {
     if (on) localStorage.setItem(KEY, "1")

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -65,6 +65,7 @@ import { useBlockFolderCopy } from "./use-block-folder-copy"
 import { resolveStoredEdgeColors, useStampNewEdges } from "./use-stamp-new-edges"
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useLocalSearchIndex } from "@/features/board/search/use-search-index"
+import { isLocalAgentOnSynced } from "@/features/agent/local/local-agent-flag"
 import { useLocalDocIndex } from "@/features/board/search/use-doc-index"
 import { useDocNodeCascade } from "@/features/board/harness/agent/use-doc-node-cascade"
 import { useStyleMemory } from "./use-style-memory"
@@ -170,9 +171,15 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
   useStampNewEdges(store, boardId, rootId)
   useStampNewNodes(store, boardId, rootId)
   useSidebarContentsSync(store, boardId)
-  useLocalSearchIndex(store, local)
-  useLocalDocIndex(boardId ?? "", local)
-  useDocNodeCascade(store, boardId ?? "", local)
+  // The browser agent's local indexes (note search + doc Q&A) must exist whenever
+  // the browser agent is the active engine — on local-only boards AND on synced
+  // boards in browser-agent mode. Gating on `local` alone left `search_notes` with
+  // a null index (empty results for EVERY query) on synced browser-agent boards.
+  // Persistence/hydrate below stays gated on `local` — synced boards still sync.
+  const agentLocalIndexes = local || isLocalAgentOnSynced()
+  useLocalSearchIndex(store, agentLocalIndexes)
+  useLocalDocIndex(boardId ?? "", agentLocalIndexes)
+  useDocNodeCascade(store, boardId ?? "", agentLocalIndexes)
   useBlockFolderCopy(store)
   useHarnessApplyMindMap(store, boardId, rootId)
   useHydrateIconNodes(store, boardId, rootId, ready)

--- a/webui/src/features/board/harness/canvas/harness-canvas.tsx
+++ b/webui/src/features/board/harness/canvas/harness-canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { LocalBoardUrl } from "@/routes"
 import { isTauri } from "@/platform"
@@ -65,7 +65,7 @@ import { useBlockFolderCopy } from "./use-block-folder-copy"
 import { resolveStoredEdgeColors, useStampNewEdges } from "./use-stamp-new-edges"
 import { useStampNewNodes } from "./use-stamp-new-nodes"
 import { useLocalSearchIndex } from "@/features/board/search/use-search-index"
-import { isLocalAgentOnSynced } from "@/features/agent/local/local-agent-flag"
+import { isBrowserAgentActive } from "@/features/agent/local/local-agent-flag"
 import { useLocalDocIndex } from "@/features/board/search/use-doc-index"
 import { useDocNodeCascade } from "@/features/board/harness/agent/use-doc-node-cascade"
 import { useStyleMemory } from "./use-style-memory"
@@ -176,7 +176,9 @@ export function HarnessCanvas({ local = false }: { local?: boolean } = {}) {
   // boards in browser-agent mode. Gating on `local` alone left `search_notes` with
   // a null index (empty results for EVERY query) on synced browser-agent boards.
   // Persistence/hydrate below stays gated on `local` — synced boards still sync.
-  const agentLocalIndexes = local || isLocalAgentOnSynced()
+  // Memoized: the flag is reload-stable, so don't read localStorage every render
+  // of this hot canvas component.
+  const agentLocalIndexes = useMemo(() => isBrowserAgentActive(local), [local])
   useLocalSearchIndex(store, agentLocalIndexes)
   useLocalDocIndex(boardId ?? "", agentLocalIndexes)
   useDocNodeCascade(store, boardId ?? "", agentLocalIndexes)

--- a/webui/src/features/board/search/local-index.test.ts
+++ b/webui/src/features/board/search/local-index.test.ts
@@ -19,7 +19,24 @@ describe("LocalSearchIndex", () => {
   })
 
 
-  it("does not crash when a node's label is not a string", async () => {
+  it("indexes the PRODUCTION title shape (data.label is a RichText object)", async () => {
+    // Regression: production stores `data.label` as `{ markdown }`, not a string,
+    // so the index used to read every title as empty — titles were unsearchable.
+    const store = freshStore("c")
+    const index = new LocalSearchIndex()
+    index.attach(store)
+
+    addNode(store, "n1")
+    store.updateNode(asNodeId("n1"), {
+      data: { label: { markdown: "Napoleon" } as unknown as string, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+    })
+    await index.idle()
+
+    expect(await index.query("Napoleon")).toContain("n1") // title is searchable
+  })
+
+
+  it("does not crash when a node's label is neither string nor RichText", async () => {
     const store = freshStore("c")
     const index = new LocalSearchIndex()
     index.attach(store)
@@ -28,14 +45,14 @@ describe("LocalSearchIndex", () => {
     await index.idle()
     expect(await index.query("ok")).toContain("n1")
 
-    // A node type puts a non-string in data.label — must not reject the insert
-    // (which would otherwise poison the whole update queue).
+    // A stray non-string, non-RichText label must not reject the insert (which
+    // would otherwise poison the whole update queue).
     store.updateNode(asNodeId("n1"), {
-      data: { label: { markdown: "x" } as unknown as string, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+      data: { label: 42 as unknown as string, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
     })
     await index.idle()
 
-    expect(index.count()).toBe(1) // still indexed, just no title text
+    expect(index.count()).toBe(1) // still indexed, just no usable title text
     expect(await index.query("ok")).toHaveLength(0) // old title dropped on upsert
 
     // The queue still works for later nodes.

--- a/webui/src/features/board/search/local-index.ts
+++ b/webui/src/features/board/search/local-index.ts
@@ -13,24 +13,35 @@
  */
 import { count, create, getByID, insert, remove, search } from "@orama/orama"
 import type { CanvasStore, Node, NodeId } from "@canvas-harness/core"
-import type { DimNodeData } from "@/features/board/model"
 
 
 const SCHEMA = { title: "string", body: "string" } as const
 
 
 /**
- * Coerce a value to a plain string for the index. `data.label` / `content` are
- * typed `string`, but the store types `data` as generic and some node types put
- * a non-string there — Orama's `"string"` schema then rejects the whole insert.
- * A non-string just isn't full-text-indexed, which is correct.
+ * Coerce a value to a plain string for the index. `content` is typed `string`,
+ * but the store types `data` as generic; a non-string just isn't full-text
+ * indexed (Orama's `"string"` schema would otherwise reject the whole insert).
  */
 const asText = (value: unknown): string => (typeof value === "string" ? value : "")
 
 
+/**
+ * A node's title text. Production stores `data.label` as a `RichText` object
+ * (`{ markdown }`) — the same shape `board-snapshot` reads — so a naive
+ * `asText(label)` indexed EVERY title as empty (titles were unsearchable). Read
+ * `.markdown`, tolerating a plain-string label (older/test nodes) too.
+ */
+const titleText = (data: unknown): string => {
+  const label = (data as { label?: unknown } | undefined)?.label
+  if (typeof label === "string") return label
+  return asText((label as { markdown?: unknown } | undefined)?.markdown)
+}
+
+
 const docOf = (node: Node) => ({
   id: node.id,
-  title: asText((node.data as DimNodeData | undefined)?.label),
+  title: titleText(node.data),
   body: asText(node.content),
 })
 


### PR DESCRIPTION
## Summary

Note search (`search_notes`) was broken for the browser agent in two independent ways. Both are fixed here.

Search is fully local — an in-memory **Orama BM25** index (`LocalSearchIndex`) over each node's `title` + `body`. There is **no server relay**: the browser agent's `search_notes` reads `ctx.search` (the local index) only.

## Bug 1 (the big one): the index was never built on synced browser-agent boards

The local index was gated on `local` — the board being **local-only**:

```ts
useLocalSearchIndex(store, local)
```

But the browser agent also runs on **synced** boards (`isLocalAgentOnSynced()`), where `board-view` mounts the canvas with `local=false`. So on a synced board in browser-agent mode, **no index was ever created**, and `search_notes` read a null index and returned `[]` for **every** query regardless of content. (The doc index / doc Q&A had the same gap.)

The `local` flag was overloaded: it means "board is local-only" (which drives the persistence path), but the search index needs to exist whenever the browser agent is the active engine.

**Fix:** gate the browser agent's local indexes on `local || isLocalAgentOnSynced()`. Persistence/hydrate stays gated on `local`, so synced boards still sync normally — only the read-only local indexes are additionally enabled.

## Bug 2: titles were never indexed

Even where the index existed, it never matched a note's **title**:

```ts
title: asText((node.data as DimNodeData | undefined)?.label),  // always ""
```

At runtime `data.label` is a `RichText` object `{ markdown }` (what the convert layer sets, what `board-snapshot` reads), so `asText` returned `""` — every title indexed empty. Title-only notes (the common case) were unsearchable. Masked by a mistyped `DimNodeData.label: string` and a test that used string labels and even asserted the `{ markdown }` shape meant "no title text."

**Fix:** read `label.markdown` (tolerating a plain-string or non-string label).

## What was NOT broken

- **Body indexing** is correct: the harness `node.content` is a plain `string` (the convert unwraps `Note.content.markdown`), so body was always indexed once the index existed.
- **Orama query semantics** are fine: single/multi-word, stemming, prefix, and case-insensitive matching all work (verified empirically).

## Testing

- New regression test: a node with the production `data.label = { markdown: "…" }` is searchable by its title (failed before Bug 2's fix).
- Reworked the "non-string label" test to use a genuinely unusable label for the crash-tolerance guarantee.
- Full search suite green; `check-all` clean.

## Follow-ups (not in this PR)

- **Layer scoping:** the store (and thus the index) only holds the *current* layer (`applyContentToStore(store, content, rootId)`), so notes in other folders/sub-boards aren't searchable from a different layer. That's a design decision to revisit (should agent search span the whole board?), separate from these correctness fixes.
- **`DimNodeData.label` is typed `string` but is a `RichText` at runtime** — a broader type-correctness gap worth an audit; other `as DimNodeData` casts read the wrong shape. This fix is robust regardless of the declared type.
