### PR TITLE
refactor(webui): unify node label to RichText, matching backend

### DIFF
--- a/webui/src/features/agent/engine/agent-loop.test.ts
+++ b/webui/src/features/agent/engine/agent-loop.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { asNodeId } from "@canvas-harness/core"
 import type { Edge } from "@canvas-harness/core"
 import type { DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 import { BoardRegistry, newLocalBoard } from "@/features/board/persist/local/board-registry"
 import { LocalSearchIndex } from "@/features/board/search/local-index"
 import { addNode, freshStore, resetIdb } from "@/test/canvas"
@@ -26,7 +27,7 @@ const drain = async (gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> => 
 const endNode = (end: Edge["source"]): string => ("nodeId" in end ? String(end.nodeId) : "free")
 
 
-const titleOf = (data: unknown): string => (data as DimNodeData | undefined)?.label ?? ""
+const titleOf = (data: unknown): string => labelText((data as DimNodeData | undefined)?.label)
 
 
 beforeEach(() => {

--- a/webui/src/features/agent/engine/tools.test.ts
+++ b/webui/src/features/agent/engine/tools.test.ts
@@ -3,6 +3,7 @@ import { asNodeId } from "@canvas-harness/core"
 import type { CanvasStore } from "@canvas-harness/core"
 import { freshStore, resetIdb } from "@/test/canvas"
 import type { DimEdgeData, DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 import { setBoardThemeMode } from "@/features/board/harness/theme/theme-mode-ref"
 import { LocalSearchIndex } from "@/features/board/search/local-index"
 import type { BoardRegistry } from "@/features/board/persist/local/board-registry"
@@ -36,8 +37,8 @@ const fakeRegistry = (boards: { id: string; title: string }[]): BoardRegistry =>
 
 
 // Read helpers over the real store.
-const label = (store: CanvasStore, id: string): unknown =>
-  (store.getNode(asNodeId(id))?.data as DimNodeData | undefined)?.label
+const label = (store: CanvasStore, id: string): string =>
+  labelText((store.getNode(asNodeId(id))?.data as DimNodeData | undefined)?.label)
 const parentOf = (store: CanvasStore, id: string): unknown =>
   (store.getNode(asNodeId(id))?.data as DimNodeData | undefined)?.parentId
 const body = (store: CanvasStore, id: string): string | undefined => store.getNode(asNodeId(id))?.content
@@ -50,7 +51,7 @@ const seed = (store: CanvasStore, id: string, opts: { label?: string; content?: 
     type: "rect",
     x: 0, y: 0, w: 100, h: 50, angle: 0, groups: [],
     content: opts.content ?? "",
-    data: { label: opts.label ?? "", meta: { v: 1, createdAt: 0, updatedAt: 0 } } satisfies DimNodeData,
+    data: { label: { markdown: opts.label ?? "" }, meta: { v: 1, createdAt: 0, updatedAt: 0 } } satisfies DimNodeData,
   })
 }
 
@@ -313,6 +314,18 @@ describe("getNote", () => {
 
   it("returns an error for a missing note", async () => {
     expect(await getNote.run({ note_id: "ghost" }, ctx)).toEqual({ error: "note not found" })
+  })
+
+  it("returns the label as a plain string for both RichText and legacy-string labels", async () => {
+    // RichText (production shape) — must be unwrapped to a string, not the object.
+    seed(store, "rich", { label: "Rich Title", content: "b" })
+    expect((await getNote.run({ note_id: "rich" }, ctx) as { label: string }).label).toBe("Rich Title")
+    // Legacy bare-string label (older local board) — tolerated by labelText.
+    store.addNode({
+      id: asNodeId("legacy"), type: "rect", x: 0, y: 0, w: 100, h: 50, angle: 0, groups: [],
+      data: { label: "Legacy Title" as unknown as { markdown: string }, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+    })
+    expect((await getNote.run({ note_id: "legacy" }, ctx) as { label: string }).label).toBe("Legacy Title")
   })
 })
 

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -12,6 +12,7 @@ import { z } from "zod"
 import { asEdgeId, asNodeId } from "@canvas-harness/core"
 import type { Node } from "@canvas-harness/core"
 import type { DimEdgeData, DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 import { pickRandomColorOfShade } from "@/features/board/lib/colors/tailwind"
 import { AUTOFIT_DISABLED_TYPES } from "@/features/board/harness/convert/note-to-node"
 import { dim0LinkStyleToCanvas, dim0StyleToCanvas } from "@/features/board/harness/convert/style"
@@ -150,7 +151,7 @@ export const createNote = defineTool({
         groups: [],
         content: body,
         style: canonicalNodeStyle(storedColors),
-        data: { label: title, parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
+        data: { label: { markdown: title }, parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
       })
     })
     return { id: String(nodeId), created: true }
@@ -174,7 +175,7 @@ export const updateNote = defineTool({
     const patch: Partial<Node> = {}
     if (typeof body === "string") patch.content = body
     if (typeof title === "string") {
-      patch.data = { ...(node.data as DimNodeData | undefined), label: title, meta: meta() }
+      patch.data = { ...(node.data as DimNodeData | undefined), label: { markdown: title }, meta: meta() }
     }
     ctx.store.batch(() => ctx.store.updateNode(nid, patch))
     return { id: String(nid) }
@@ -263,7 +264,7 @@ export const writeNote = defineTool({
           ctx.store.updateNode(id, {
             type: nodeType,
             content,
-            data: { ...prev, label: label || prev?.label || "", meta: meta() },
+            data: { ...prev, label: label ? { markdown: label } : (prev?.label ?? { markdown: "" }), meta: meta() },
             ...(autoFitStyle ? { style: { ...(node.style ?? {}), ...autoFitStyle } } : {}),
           }),
         )
@@ -298,7 +299,7 @@ export const writeNote = defineTool({
         groups: [],
         content,
         ...(style ? { style } : {}),
-        data: { label: label ?? "", parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
+        data: { label: { markdown: label ?? "" }, parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
       })
     })
     return { id: String(id), created: true }
@@ -318,7 +319,7 @@ export const getNote = defineTool({
     if (!node) return { error: "note not found" }
     return {
       id: String(id),
-      label: (node.data as DimNodeData | undefined)?.label ?? "",
+      label: labelText((node.data as DimNodeData | undefined)?.label),
       content: node.content ?? "",
       note_type: node.type,
     }
@@ -342,7 +343,7 @@ export const editNote = defineTool({
     if (!node) return { error: "note not found" }
 
     const prev = node.data as DimNodeData | undefined
-    const current = field === "label" ? prev?.label ?? "" : node.content ?? ""
+    const current = field === "label" ? labelText(prev?.label) : node.content ?? ""
 
     const occurrences = old ? current.split(old).length - 1 : 0
     if (occurrences === 0) return { error: "`old` not found in field" }
@@ -353,7 +354,7 @@ export const editNote = defineTool({
 
     ctx.store.batch(() =>
       field === "label"
-        ? ctx.store.updateNode(id, { data: { ...prev, label: updated, meta: meta() } })
+        ? ctx.store.updateNode(id, { data: { ...prev, label: { markdown: updated }, meta: meta() } })
         : ctx.store.updateNode(id, { content: updated }),
     )
     return { id: String(id) }
@@ -385,7 +386,7 @@ export const searchNotes = defineTool({
     const results = ids.map((id) => {
       const node = ctx.store.getNode(asNodeId(id))
       // Title is `data.label`; the body lives in the native `node.content`.
-      const title = asText((node?.data as DimNodeData | undefined)?.label)
+      const title = labelText((node?.data as DimNodeData | undefined)?.label)
       const content = asText(node?.content).slice(0, SEARCH_SNIPPET_CHARS)
       return { id, title, content }
     })

--- a/webui/src/features/agent/local/board-snapshot.test.ts
+++ b/webui/src/features/agent/local/board-snapshot.test.ts
@@ -147,6 +147,16 @@ describe("recent-changes collapse", () => {
   })
 
 
+  it("renders a recent change's title from a LEGACY bare-string label in the oplog", () => {
+    // Oplog ops aren't normalized-on-load; a pre-upgrade agent add carries a
+    // string label. It must still render the title, not "(untitled)".
+    const legacy = mkNode("a", { label: "A" })
+    ;(legacy.data as { label?: unknown }).label = "Legacy Title"
+    const snap = buildBoardSnapshot(fakeStore([legacy]), null, [opRec(board, 1, [{ type: "node.add", node: legacy }])])
+    expect(snap.recent).toEqual([{ id: "a", op: "add", label: "Legacy Title" }])
+  })
+
+
   it("edit+remove becomes a delete, with the label from the remove op payload", () => {
     const ops: OplogRecord[] = [
       opRec(board, 1, [{ type: "node.update", id: "x" as NodeId, patch: {}, prev: {} }]),

--- a/webui/src/features/agent/local/board-snapshot.ts
+++ b/webui/src/features/agent/local/board-snapshot.ts
@@ -13,6 +13,7 @@
  */
 import type { CanvasStore, Node } from "@canvas-harness/core"
 import type { NoteNodeData } from "@/features/board/harness/convert/note-to-node"
+import { labelText } from "@/features/board/model"
 import type { OplogRecord } from "@/features/board/persist/local/idb"
 import type { StorageEngine } from "@/features/board/persist/local/engine"
 
@@ -102,7 +103,9 @@ const truncate = (s: string, max: number): string =>
 /** Title: `data.label` → first non-blank line of content → `"(untitled)"`, truncated. */
 const nodeTitle = (n: Node): string => {
   const data = nodeData(n)
-  const label = data.label?.markdown?.trim()
+  // labelText tolerates a legacy bare-string label — raw oplog ops read here
+  // aren't normalized-on-load the way the live store is.
+  const label = labelText(data.label).trim()
   return truncate(label || firstLine(n.content) || "(untitled)", TITLE_MAX_CHARS)
 }
 

--- a/webui/src/features/board/harness/convert/node-to-note.ts
+++ b/webui/src/features/board/harness/convert/node-to-note.ts
@@ -2,6 +2,7 @@ import type { Node } from "@canvas-harness/core"
 import type { Note, NoteProperties } from "@/features/board/types/note"
 import { applyColorsToStyle } from "../theme/color-adapter"
 import type { NoteNodeData } from "./note-to-node"
+import { asRichLabel } from "@/features/board/model"
 import { canvasTypeToDim0 } from "./node-type"
 import { canvasStyleToDim0 } from "./style"
 
@@ -48,7 +49,7 @@ export const nodeToNote = (node: Node): Note => {
     minWidth: data.minWidth,
     minHeight: data.minHeight,
     roughSeed: data.roughSeed,
-    label: data.label,
+    label: asRichLabel(data.label),
     content: node.content ? { markdown: node.content } : undefined,
     // `node.style.{bg,stroke,text}` may carry dark-mode display values;
     // `_storedColors` holds what the user actually picked. Prefer stored

--- a/webui/src/features/board/harness/convert/note-to-node.ts
+++ b/webui/src/features/board/harness/convert/note-to-node.ts
@@ -1,6 +1,7 @@
 import { asGroupId, asNodeId } from "@canvas-harness/core"
 import type { Node } from "@canvas-harness/core"
 import type { Note, NoteProperties, RichText } from "@/features/board/types/note"
+import { asRichLabel } from "@/features/board/model"
 import type { Document } from "@/features/board/types/document"
 import type { NodeType as Dim0NodeType } from "@/features/board/types/style"
 import {
@@ -98,7 +99,7 @@ export const noteToNode = (note: Note | Document): Node => {
     minWidth: note.minWidth,
     minHeight: note.minHeight,
     roughSeed: note.roughSeed,
-    label: note.label,
+    label: asRichLabel(note.label),
     properties: rest,
   }
 

--- a/webui/src/features/board/harness/sync/board-sync.test.ts
+++ b/webui/src/features/board/harness/sync/board-sync.test.ts
@@ -3,6 +3,7 @@ import { asBatchId, asClientId, asNodeId, type OpBatch } from "@canvas-harness/c
 import type { CanvasStore } from "@canvas-harness/core"
 import { addEdge, addNode, freshStore } from "@/test/canvas"
 import type { DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 import { MemoryRelay } from "@/test/sync-relay"
 import { InMemoryEngine } from "@/features/board/persist/local/in-memory-engine"
 import { BoardOutbox } from "@/features/board/persist/local/board-outbox"
@@ -89,8 +90,8 @@ const edgeIds = (store: CanvasStore): string[] =>
   store.getAllEdges().map((e) => e.id).sort()
 
 
-const labelOf = (store: CanvasStore, id: string): string | undefined =>
-  (store.getAllNodes().find((n) => n.id === id)?.data as DimNodeData | undefined)?.label
+const labelOf = (store: CanvasStore, id: string): string =>
+  labelText((store.getAllNodes().find((n) => n.id === id)?.data as DimNodeData | undefined)?.label)
 
 
 const xOf = (store: CanvasStore, id: string): number | undefined =>
@@ -640,7 +641,7 @@ describe("E1.5 protocol handlers", () => {
         for (const op of b.ops) {
           if (op.type === "node.add") {
             const data = op.node.data as DimNodeData
-            data.label = `${data.label} (themed)`
+            data.label = { markdown: `${labelText(data.label)} (themed)` }
           }
         }
       },
@@ -654,16 +655,15 @@ describe("E1.5 protocol handlers", () => {
         type: "node.add",
         node: {
           id: asNodeId("n1"), type: "rect", x: 0, y: 0, z: 0, w: 100, h: 50, angle: 0,
-          groups: [], data: { label: "raw", meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+          groups: [], data: { label: { markdown: "raw" }, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
         },
       }],
     }
     c.push({ kind: "peer-op", seq: 1, batch: raw })
     await c.sync.settle()
 
-    const label = (c.store.getAllNodes().find((n) => n.id === "n1")?.data as DimNodeData | undefined)?.label
-    expect(label).toBe("raw (themed)") // store got the normalized copy
-    expect((raw.ops[0] as { node: { data: DimNodeData } }).node.data.label).toBe("raw") // input untouched
+    expect(labelOf(c.store, "n1")).toBe("raw (themed)") // store got the normalized copy
+    expect(labelText((raw.ops[0] as { node: { data: DimNodeData } }).node.data.label)).toBe("raw") // input untouched
     c.sync.detach()
   })
 })

--- a/webui/src/features/board/model/index.ts
+++ b/webui/src/features/board/model/index.ts
@@ -23,10 +23,26 @@ import type {
   Edge as ChEdge,
   Node as ChNode,
 } from "@canvas-harness/core"
+import type { RichText } from "@/features/board/types/note"
 
 
 /** App-level id. canvas-harness brands node/edge ids; this is the unbranded form. */
 export type Id = string
+
+
+/**
+ * The string form of a node/edge `label`. The canonical shape is `RichText`
+ * (`{ markdown }`, matching the backend `Resource.label` and the convert layer),
+ * but boards persisted before unification may still hold a bare string — tolerate
+ * both so legacy local boards keep reading. Prefer this over `label.markdown`.
+ */
+export const labelText = (label: RichText | string | undefined): string =>
+  typeof label === "string" ? label : (label?.markdown ?? "")
+
+
+/** Coerce a label (possibly a legacy bare string) to the canonical `RichText`. */
+export const asRichLabel = (label: RichText | string | undefined): RichText | undefined =>
+  label === undefined ? undefined : typeof label === "string" ? { markdown: label } : label
 
 
 /**
@@ -71,8 +87,9 @@ export type DataProperty =
  * library reads e.g. `data.src` directly for built-in image/icon nodes.
  */
 export type DimNodeData = {
-  /** Title. The body lives in the native `node.content`. */
-  label?: string
+  /** Title (RichText, matching the backend `Resource.label`). Body → `node.content`.
+   *  Read via `labelText()` — legacy local boards may hold a bare string. */
+  label?: RichText
   /** Containment / subspace parent (recursive boards). */
   parentId?: Id | null
   pinned?: boolean

--- a/webui/src/features/board/model/index.ts
+++ b/webui/src/features/board/model/index.ts
@@ -36,7 +36,7 @@ export type Id = string
  * but boards persisted before unification may still hold a bare string — tolerate
  * both so legacy local boards keep reading. Prefer this over `label.markdown`.
  */
-export const labelText = (label: RichText | string | undefined): string =>
+export const labelText = (label: { markdown?: string } | string | undefined): string =>
   typeof label === "string" ? label : (label?.markdown ?? "")
 
 

--- a/webui/src/features/board/model/layer.ts
+++ b/webui/src/features/board/model/layer.ts
@@ -10,6 +10,7 @@
  * drop other layers.
  */
 import type { BoardContent, DimNode } from "."
+import { labelText } from "."
 
 
 /** Normalise a parentId to its layer key (null = root layer). */
@@ -50,7 +51,7 @@ export const buildLayerPath = (nodes: DimNode[], rootId: string | null): LayerCr
     seen.add(current)
     const node = byId.get(current)
     if (!node) break
-    path.push({ id: current, label: node.data?.label?.trim() || "Folder" })
+    path.push({ id: current, label: labelText(node.data?.label).trim() || "Folder" })
     current = node.data?.parentId ?? null
   }
   return path.reverse()

--- a/webui/src/features/board/persist/local/apply-content.test.ts
+++ b/webui/src/features/board/persist/local/apply-content.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 import { asNodeId } from "@canvas-harness/core"
 import { freshStore } from "@/test/canvas"
 import type { BoardContent, DimNode } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
+import type { DimNodeData } from "@/features/board/model"
 import { applyContentToStore } from "./apply-content"
 
 
@@ -23,6 +25,17 @@ describe("applyContentToStore", () => {
     const store = freshStore("c")
     applyContentToStore(store, content([rectNode("a"), rectNode("child", "f1")]), null)
     expect(store.getAllNodes().map((n) => n.id)).toEqual(["a"])
+  })
+
+
+  it("normalizes a legacy bare-string label to RichText on load", () => {
+    const store = freshStore("c")
+    const legacy = rectNode("a")
+    ;(legacy.data as { label?: unknown }).label = "Legacy Title" // older boards persisted a string
+    applyContentToStore(store, content([legacy]), null)
+    const stored = (store.getAllNodes()[0]?.data as DimNodeData | undefined)?.label
+    expect(stored).toEqual({ markdown: "Legacy Title" }) // coerced to the canonical shape
+    expect(labelText(stored)).toBe("Legacy Title")
   })
 
 

--- a/webui/src/features/board/persist/local/apply-content.ts
+++ b/webui/src/features/board/persist/local/apply-content.ts
@@ -1,6 +1,7 @@
 import { asBatchId } from "@canvas-harness/core"
 import type { CanvasStore, Node, Op } from "@canvas-harness/core"
 import type { BoardContent } from "@/features/board/model"
+import { asRichLabel } from "@/features/board/model"
 import { filterContentByLayer } from "@/features/board/model/layer"
 import {
   adaptEdgeColors,
@@ -52,7 +53,10 @@ export const applyContentToStore = (
     const stored = storedNodeColorsOf(node as unknown as Node)
     const display = mode === "dark" ? adaptNodeColors(stored, "dark") : stored
     const style = applyColorsToStyle(node.style ?? {}, display)
-    ops.push({ type: "node.add", node: { ...node, style } })
+    // Normalize a legacy bare-string label to RichText so the store invariant
+    // (data.label is RichText) holds — older local boards persisted strings.
+    const data = node.data ? { ...node.data, label: asRichLabel(node.data.label) } : node.data
+    ops.push({ type: "node.add", node: { ...node, style, data } })
   }
 
   for (const edge of scoped.edges) {

--- a/webui/src/features/board/persist/local/board-persistence.test.ts
+++ b/webui/src/features/board/persist/local/board-persistence.test.ts
@@ -46,7 +46,7 @@ describe("BoardPersistence", () => {
 
     const content = await p.load()
     expect(content.nodes.map((n) => n.id)).toContain("n1")
-    expect((content.nodes[0]?.data)?.label).toBe("hello")
+    expect((content.nodes[0]?.data)?.label).toEqual({ markdown: "hello" })
     p.close()
   })
 

--- a/webui/src/features/board/search/local-index.ts
+++ b/webui/src/features/board/search/local-index.ts
@@ -13,6 +13,8 @@
  */
 import { count, create, getByID, insert, remove, search } from "@orama/orama"
 import type { CanvasStore, Node, NodeId } from "@canvas-harness/core"
+import type { DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 
 
 const SCHEMA = { title: "string", body: "string" } as const
@@ -26,22 +28,11 @@ const SCHEMA = { title: "string", body: "string" } as const
 const asText = (value: unknown): string => (typeof value === "string" ? value : "")
 
 
-/**
- * A node's title text. Production stores `data.label` as a `RichText` object
- * (`{ markdown }`) — the same shape `board-snapshot` reads — so a naive
- * `asText(label)` indexed EVERY title as empty (titles were unsearchable). Read
- * `.markdown`, tolerating a plain-string label (older/test nodes) too.
- */
-const titleText = (data: unknown): string => {
-  const label = (data as { label?: unknown } | undefined)?.label
-  if (typeof label === "string") return label
-  return asText((label as { markdown?: unknown } | undefined)?.markdown)
-}
-
-
 const docOf = (node: Node) => ({
   id: node.id,
-  title: titleText(node.data),
+  // `data.label` is RichText (`{ markdown }`); `labelText` also tolerates a legacy
+  // bare string. A naive string read indexed every title as empty (unsearchable).
+  title: labelText((node.data as DimNodeData | undefined)?.label),
   body: asText(node.content),
 })
 

--- a/webui/src/features/board/search/notes-search.ts
+++ b/webui/src/features/board/search/notes-search.ts
@@ -5,6 +5,7 @@
  * layer (`parentId`) + folder breadcrumb so a result can jump across layers.
  */
 import type { DimNode } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
 import { buildLayerPath } from "@/features/board/model/layer"
 
 
@@ -22,7 +23,7 @@ export type SearchRow = {
 
 /** A note's display title: its label, else a body snippet, else "Untitled". */
 const titleOf = (node: DimNode): string => {
-  const label = node.data?.label?.trim() ?? ""
+  const label = labelText(node.data?.label).trim()
   if (label) return label
   const body = (node.content ?? "").trim().replace(/\s+/g, " ")
   return body.slice(0, 60) || "Untitled"

--- a/webui/src/features/board/utils/context-text.ts
+++ b/webui/src/features/board/utils/context-text.ts
@@ -1,8 +1,10 @@
 import type { NoteNode } from "../types/flow"
+import { labelText } from "@/features/board/model"
 
 type NoteLike = {
   id?: string
-  label?: { markdown?: string }
+  // Canonical shape is RichText; a legacy local board may hold a bare string.
+  label?: { markdown?: string } | string
   content?: { markdown?: string }
   properties?: { summary?: { text?: string } }
   style?: { type?: string }
@@ -18,7 +20,7 @@ const trimOrEmpty = (value?: string) => (value ?? "").trim()
  */
 const buildPlainNodeText = (node: NoteNode) => {
   const data = node.data as NoteLike | undefined
-  const label = trimOrEmpty(data?.label?.markdown)
+  const label = trimOrEmpty(labelText(data?.label))
   const content = trimOrEmpty(data?.content?.markdown)
   const summary = trimOrEmpty(data?.properties?.summary?.text)
 

--- a/webui/src/test/canvas.ts
+++ b/webui/src/test/canvas.ts
@@ -43,7 +43,7 @@ export const addNode = (store: CanvasStore, id: string, label = ""): void => {
     h: 50,
     angle: 0,
     groups: [],
-    data: { label, meta: META } satisfies DimNodeData,
+    data: { label: { markdown: label }, meta: META } satisfies DimNodeData,
   })
 }
 


### PR DESCRIPTION
## What

Unify the node `label` field on a single shape — `RichText` `{ markdown }` — matching the backend. This is the type-correctness audit follow-up to the note-search fixes (#233), and it removes the root cause behind unsearchable titles.

**Stacked on #233** (it builds on that branch's `local-index` change). Retarget to `main` once #233 merges.

## Why

`data.label` had **two runtime shapes**:
- The **convert layer** (loading notes) wrote `RichText` `{ markdown }` — matching the backend `Resource.label` (`backend/topix/datatypes/resource.py`) and the frontend `Note.label`.
- The **agent's note tools** (`create/write/update/edit_note`) wrote a plain **string**.

`DimNodeData.label` was typed `string`, so the wrong casts compiled cleanly and the mismatch stayed hidden. Readers that assumed one shape silently broke on the other:

- `get_note` returned the `{markdown}` **object** as `label` to the model.
- `edit_note` ran string ops (`.split`/`.replace`) on an object → wrong/crash.
- Board **breadcrumb / layer** labels called `.trim()` on an object.
- `board-snapshot` read `.markdown` off a **string** → agent saw `(untitled)` for its own notes on local boards.
- Agent-created notes **synced to the server as a malformed string `Note.label`**, which the backend then reads as `self.label.markdown` — broken server-side.

The audit confirmed the backend canonically stores `RichText`, so unifying on it (rather than string) is the aligned choice.

## How

- **Type:** `DimNodeData.label: string` → `RichText`. Add two model helpers:
  - `labelText(label): string` — tolerant read (handles a legacy bare string OR `{markdown}`).
  - `asRichLabel(label): RichText | undefined` — coerce a possibly-legacy string to the canonical shape.
- **Writers:** the agent note tools now write `{ markdown }`.
- **Readers:** `get_note` / `edit_note` / `search_notes` / `notes-search` / `layer` / `local-index` read via `labelText`.
- **Normalize-on-load:** `applyContentToStore` (local boards) and `noteToNode` (server hydrate) coerce a legacy bare-string label to `{ markdown }`, so the store invariant (`data.label` is RichText) holds and **existing local boards keep working with no migration** — they re-persist as RichText over time.

## Testing

- `get_note` returns the label as a plain string for **both** a RichText and a legacy bare-string label (regression for the "returned an object" bug).
- `applyContentToStore` coerces a legacy string label to `{ markdown }` on load.
- Existing note-tool tests updated (helpers read via `labelText`; the persistence round-trip asserts the RichText shape).
- Full suite green (**1245 tests**), `check-all` clean.

## Scope note

Edge labels (`DimEdgeData.label`) have the **same** latent string-vs-RichText mismatch against `Link.label`. Left for a focused follow-up to keep this PR to node labels.
