### PR TITLE
fix(webui): agent link labels use edge.content (the rendered field)

### DIFF
--- a/webui/src/features/agent/engine/tools.test.ts
+++ b/webui/src/features/agent/engine/tools.test.ts
@@ -177,14 +177,14 @@ describe("linkNotes", () => {
     expect(String(tgt.nodeId)).toBe("b")
     // seeded nodes are 100x50 → center offset 50,25
     expect(src.localOffset).toEqual({ x: 50, y: 25 })
-    expect((e.data as { label?: string }).label).toBe("then")
+    expect(e.content).toBe("then") // the label lives in edge.content (what the harness renders)
   })
 
   it("omits the edge label when none is given", async () => {
     seed(store, "a")
     seed(store, "b")
     await linkNotes.run({ sourceId: "a", targetId: "b" }, ctx)
-    expect((store.getAllEdges()[0].data as { label?: string }).label).toBeUndefined()
+    expect(store.getAllEdges()[0].content).toBeUndefined()
   })
 
   it("stamps the current rootId as the edge parentId", async () => {

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -224,9 +224,12 @@ export const linkNotes = defineTool({
         target: { nodeId: tgt, localOffset: center(tgt) },
         pathStyle: "bezier",
         groups: [],
+        // The edge label is `content` — the field the harness renders and the
+        // convert layer round-trips to `Link.label` (previously written to a
+        // never-rendered `data.label`, so agent link labels were invisible).
+        content: label || undefined,
         style,
         data: {
-          label: label || undefined,
           parentId: ctx.rootId ?? undefined,
           meta: meta(),
           _storedColors: storedColors,

--- a/webui/src/features/board/harness/sync/board-sync.test.ts
+++ b/webui/src/features/board/harness/sync/board-sync.test.ts
@@ -394,7 +394,8 @@ describe("E1.4 conflict resolution", () => {
     // land on BBB too (not A's local-append order, which would give AAA).
     const reloaded = new BoardPersistence(BOARD, { engine: a.engine })
     const content = await reloaded.load()
-    expect(content.nodes.find((n) => n.id === "n1")?.data?.label).toBe("BBB")
+    // load() normalizes labels to RichText, so read via labelText.
+    expect(labelText(content.nodes.find((n) => n.id === "n1")?.data?.label)).toBe("BBB")
     a.sync.detach()
     b.sync.detach()
   })

--- a/webui/src/features/board/model/index.ts
+++ b/webui/src/features/board/model/index.ts
@@ -159,6 +159,36 @@ export type BoardContent = {
 }
 
 
+/**
+ * Normalize board content to the canonical label shape at the READ source (called
+ * from `BoardPersistence.materialize`, so display hydrate, whole-board search, and
+ * the enable-sync `capture()` all get migrated content — a legacy label isn't lost
+ * when a local board is promoted to synced). Idempotent and churn-free: unchanged
+ * nodes/edges keep their identity.
+ *   - node `data.label`: coerce a legacy bare string → RichText.
+ *   - edge label: the harness renders `edge.content`; migrate a legacy
+ *     `data.label` (string OR RichText, from an older link tool) → `content` and
+ *     strip the dead field. Existing `content` wins.
+ */
+export const normalizeBoardContent = (content: BoardContent): BoardContent => {
+  const nodes = content.nodes.map((n) => {
+    if (!n.data) return n
+    const label = asRichLabel(n.data.label)
+    return label === n.data.label ? n : { ...n, data: { ...n.data, label } }
+  })
+  const edges = content.edges.map((e) => {
+    const data = e.data as (DimEdgeData & { label?: unknown }) | undefined
+    const hasLegacy = !!data && "label" in data
+    const migrated = e.content || labelText(data?.label as string | { markdown?: string } | undefined) || undefined
+    if (!hasLegacy) return e.content === migrated ? e : { ...e, content: migrated }
+    const rest = { ...data } as DimEdgeData & { label?: unknown }
+    delete rest.label // drop the dead field (edge label lives in `content`)
+    return { ...e, content: migrated, data: rest }
+  })
+  return { ...content, nodes, edges }
+}
+
+
 /** How a board is hosted. `local-only` = IndexedDB only, no account, no relay. */
 export type BoardKind = "local-only" | "synced"
 

--- a/webui/src/features/board/model/index.ts
+++ b/webui/src/features/board/model/index.ts
@@ -178,9 +178,10 @@ export const normalizeBoardContent = (content: BoardContent): BoardContent => {
   })
   const edges = content.edges.map((e) => {
     const data = e.data as (DimEdgeData & { label?: unknown }) | undefined
-    const hasLegacy = !!data && "label" in data
-    const migrated = e.content || labelText(data?.label as string | { markdown?: string } | undefined) || undefined
-    if (!hasLegacy) return e.content === migrated ? e : { ...e, content: migrated }
+    // No legacy label → nothing to migrate; keep the edge as-is (identity, so a
+    // label-less edge with content:"" isn't rewritten to undefined every load).
+    if (!data || !("label" in data)) return e
+    const migrated = e.content || labelText(data.label as string | { markdown?: string } | undefined) || undefined
     const rest = { ...data } as DimEdgeData & { label?: unknown }
     delete rest.label // drop the dead field (edge label lives in `content`)
     return { ...e, content: migrated, data: rest }

--- a/webui/src/features/board/model/index.ts
+++ b/webui/src/features/board/model/index.ts
@@ -120,7 +120,9 @@ export type DimNodeData = {
 
 /** dim0 payload carried in a canvas-harness `edge.data`. */
 export type DimEdgeData = {
-  label?: string
+  // NOTE: the edge label is `edge.content` (what the harness renders + the convert
+  // layer round-trips to `Link.label`), NOT a `data.label`. A legacy `data.label`
+  // written by an older link tool is migrated to `content` on load.
   parentId?: Id | null
   props?: Record<string, DataProperty>
   meta: SyncMeta

--- a/webui/src/features/board/model/normalize-content.test.ts
+++ b/webui/src/features/board/model/normalize-content.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import type { BoardContent, DimEdge, DimNode } from "."
+import { labelText, normalizeBoardContent } from "."
+
+
+const node = (id: string, label: unknown): DimNode =>
+  ({ id, type: "rect", x: 0, y: 0, w: 1, h: 1, angle: 0, z: 0, groups: [], data: { label, meta: { v: 1, createdAt: 0, updatedAt: 0 } } }) as unknown as DimNode
+
+
+const edge = (id: string, opts: { label?: unknown; content?: string }): DimEdge =>
+  ({ id, source: { nodeId: "a" }, target: { nodeId: "b" }, pathStyle: "bezier", z: 0, groups: [], content: opts.content, data: { label: opts.label, meta: { v: 1, createdAt: 0, updatedAt: 0 } } }) as unknown as DimEdge
+
+
+const content = (nodes: DimNode[], edges: DimEdge[] = []): BoardContent =>
+  ({ schemaVersion: 1, nodes, edges, groups: [] }) as unknown as BoardContent
+
+
+describe("normalizeBoardContent", () => {
+  it("coerces a legacy bare-string node label to RichText", () => {
+    const out = normalizeBoardContent(content([node("n", "Legacy Title")]))
+    expect(out.nodes[0].data?.label).toEqual({ markdown: "Legacy Title" })
+  })
+
+
+  it("leaves a RichText node label untouched (keeps identity — no churn)", () => {
+    const n = node("n", { markdown: "Already Rich" })
+    const out = normalizeBoardContent(content([n]))
+    expect(out.nodes[0]).toBe(n) // unchanged node keeps its reference
+  })
+
+
+  it("migrates a legacy string edge label to content and strips the dead field", () => {
+    const out = normalizeBoardContent(content([], [edge("e", { label: "causes" })]))
+    expect(out.edges[0].content).toBe("causes") // the field the harness renders
+    expect((out.edges[0].data as { label?: unknown })?.label).toBeUndefined()
+  })
+
+
+  it("migrates a legacy RichText edge label to content", () => {
+    const out = normalizeBoardContent(content([], [edge("e", { label: { markdown: "leads to" } })]))
+    expect(out.edges[0].content).toBe("leads to")
+  })
+
+
+  it("keeps existing edge.content over a stale data.label", () => {
+    const out = normalizeBoardContent(content([], [edge("e", { label: "stale", content: "real" })]))
+    expect(out.edges[0].content).toBe("real")
+  })
+
+
+  it("is idempotent — a normalized content re-normalizes to the same labels", () => {
+    const once = normalizeBoardContent(content([node("n", "T")], [edge("e", { label: "causes" })]))
+    const twice = normalizeBoardContent(once)
+    expect(labelText(twice.nodes[0].data?.label)).toBe("T")
+    expect(twice.edges[0].content).toBe("causes")
+    expect((twice.edges[0].data as { label?: unknown })?.label).toBeUndefined()
+  })
+})

--- a/webui/src/features/board/persist/local/apply-content.test.ts
+++ b/webui/src/features/board/persist/local/apply-content.test.ts
@@ -50,7 +50,31 @@ describe("applyContentToStore", () => {
     }
     const c = { schemaVersion: 1, nodes: [a, b], edges: [edge], groups: [] } as unknown as BoardContent
     applyContentToStore(store, c, null)
-    expect(store.getAllEdges()[0]?.content).toBe("causes") // now the harness will render it
+    const migrated = store.getAllEdges()[0]
+    expect(migrated?.content).toBe("causes") // now the harness will render it
+    expect((migrated?.data as { label?: unknown })?.label).toBeUndefined() // dead field stripped
+  })
+
+
+  it("migrates a legacy RichText edge label and lets existing content win", () => {
+    const store = freshStore("c")
+    const [a, b] = [rectNode("a"), rectNode("b")]
+    const edgeAt = (id: string, ends: [string, string], data: object, content?: string) => ({
+      id, source: { nodeId: asNodeId(ends[0]), localOffset: { x: 0, y: 0 } },
+      target: { nodeId: asNodeId(ends[1]), localOffset: { x: 0, y: 0 } },
+      pathStyle: "bezier", z: 0, groups: [], content, data,
+    })
+    const c = {
+      schemaVersion: 1, nodes: [a, b], groups: [],
+      edges: [
+        edgeAt("rich", ["a", "b"], { label: { markdown: "leads to" }, meta: { v: 1, createdAt: 0, updatedAt: 0 } }),
+        edgeAt("both", ["b", "a"], { label: "stale", meta: { v: 1, createdAt: 0, updatedAt: 0 } }, "real"),
+      ],
+    } as unknown as BoardContent
+    applyContentToStore(store, c, null)
+    const byId = new Map(store.getAllEdges().map((e) => [String(e.id), e]))
+    expect(byId.get("rich")?.content).toBe("leads to") // RichText legacy label migrated
+    expect(byId.get("both")?.content).toBe("real") // present content wins over data.label
   })
 
 

--- a/webui/src/features/board/persist/local/apply-content.test.ts
+++ b/webui/src/features/board/persist/local/apply-content.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from "vitest"
 import { asNodeId } from "@canvas-harness/core"
 import { freshStore } from "@/test/canvas"
 import type { BoardContent, DimNode } from "@/features/board/model"
-import { labelText } from "@/features/board/model"
-import type { DimNodeData } from "@/features/board/model"
 import { applyContentToStore } from "./apply-content"
 
 
@@ -25,56 +23,6 @@ describe("applyContentToStore", () => {
     const store = freshStore("c")
     applyContentToStore(store, content([rectNode("a"), rectNode("child", "f1")]), null)
     expect(store.getAllNodes().map((n) => n.id)).toEqual(["a"])
-  })
-
-
-  it("normalizes a legacy bare-string label to RichText on load", () => {
-    const store = freshStore("c")
-    const legacy = rectNode("a")
-    ;(legacy.data as { label?: unknown }).label = "Legacy Title" // older boards persisted a string
-    applyContentToStore(store, content([legacy]), null)
-    const stored = (store.getAllNodes()[0]?.data as DimNodeData | undefined)?.label
-    expect(stored).toEqual({ markdown: "Legacy Title" }) // coerced to the canonical shape
-    expect(labelText(stored)).toBe("Legacy Title")
-  })
-
-
-  it("migrates a legacy edge label from data.label to content (the rendered field)", () => {
-    const store = freshStore("c")
-    const [a, b] = [rectNode("a"), rectNode("b")]
-    const edge = {
-      id: "e1",
-      source: { nodeId: asNodeId("a"), localOffset: { x: 0, y: 0 } },
-      target: { nodeId: asNodeId("b"), localOffset: { x: 0, y: 0 } },
-      pathStyle: "bezier", z: 0, groups: [], data: { label: "causes", meta: { v: 1, createdAt: 0, updatedAt: 0 } },
-    }
-    const c = { schemaVersion: 1, nodes: [a, b], edges: [edge], groups: [] } as unknown as BoardContent
-    applyContentToStore(store, c, null)
-    const migrated = store.getAllEdges()[0]
-    expect(migrated?.content).toBe("causes") // now the harness will render it
-    expect((migrated?.data as { label?: unknown })?.label).toBeUndefined() // dead field stripped
-  })
-
-
-  it("migrates a legacy RichText edge label and lets existing content win", () => {
-    const store = freshStore("c")
-    const [a, b] = [rectNode("a"), rectNode("b")]
-    const edgeAt = (id: string, ends: [string, string], data: object, content?: string) => ({
-      id, source: { nodeId: asNodeId(ends[0]), localOffset: { x: 0, y: 0 } },
-      target: { nodeId: asNodeId(ends[1]), localOffset: { x: 0, y: 0 } },
-      pathStyle: "bezier", z: 0, groups: [], content, data,
-    })
-    const c = {
-      schemaVersion: 1, nodes: [a, b], groups: [],
-      edges: [
-        edgeAt("rich", ["a", "b"], { label: { markdown: "leads to" }, meta: { v: 1, createdAt: 0, updatedAt: 0 } }),
-        edgeAt("both", ["b", "a"], { label: "stale", meta: { v: 1, createdAt: 0, updatedAt: 0 } }, "real"),
-      ],
-    } as unknown as BoardContent
-    applyContentToStore(store, c, null)
-    const byId = new Map(store.getAllEdges().map((e) => [String(e.id), e]))
-    expect(byId.get("rich")?.content).toBe("leads to") // RichText legacy label migrated
-    expect(byId.get("both")?.content).toBe("real") // present content wins over data.label
   })
 
 

--- a/webui/src/features/board/persist/local/apply-content.test.ts
+++ b/webui/src/features/board/persist/local/apply-content.test.ts
@@ -39,6 +39,21 @@ describe("applyContentToStore", () => {
   })
 
 
+  it("migrates a legacy edge label from data.label to content (the rendered field)", () => {
+    const store = freshStore("c")
+    const [a, b] = [rectNode("a"), rectNode("b")]
+    const edge = {
+      id: "e1",
+      source: { nodeId: asNodeId("a"), localOffset: { x: 0, y: 0 } },
+      target: { nodeId: asNodeId("b"), localOffset: { x: 0, y: 0 } },
+      pathStyle: "bezier", z: 0, groups: [], data: { label: "causes", meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+    }
+    const c = { schemaVersion: 1, nodes: [a, b], edges: [edge], groups: [] } as unknown as BoardContent
+    applyContentToStore(store, c, null)
+    expect(store.getAllEdges()[0]?.content).toBe("causes") // now the harness will render it
+  })
+
+
   it("replaces the previous layer on switch — no accumulation across layers", () => {
     const store = freshStore("c")
     const c = content([rectNode("root1"), rectNode("c1", "folder"), rectNode("c2", "folder")])

--- a/webui/src/features/board/persist/local/apply-content.ts
+++ b/webui/src/features/board/persist/local/apply-content.ts
@@ -1,7 +1,6 @@
 import { asBatchId } from "@canvas-harness/core"
 import type { CanvasStore, Node, Op } from "@canvas-harness/core"
-import type { BoardContent, DimEdgeData } from "@/features/board/model"
-import { asRichLabel, labelText } from "@/features/board/model"
+import type { BoardContent } from "@/features/board/model"
 import { filterContentByLayer } from "@/features/board/model/layer"
 import {
   adaptEdgeColors,
@@ -49,31 +48,21 @@ export const applyContentToStore = (
 
   for (const group of scoped.groups) ops.push({ type: "group.upsert", group })
 
+  // Label shape is already normalized upstream (BoardPersistence.materialize →
+  // normalizeBoardContent), so this only re-projects theme colors.
   for (const node of scoped.nodes) {
     const stored = storedNodeColorsOf(node as unknown as Node)
     const display = mode === "dark" ? adaptNodeColors(stored, "dark") : stored
     const style = applyColorsToStyle(node.style ?? {}, display)
-    // Normalize a legacy bare-string label to RichText so the store invariant
-    // (data.label is RichText) holds — older local boards persisted strings.
-    const data = node.data ? { ...node.data, label: asRichLabel(node.data.label) } : node.data
-    ops.push({ type: "node.add", node: { ...node, style, data } })
+    ops.push({ type: "node.add", node: { ...node, style } })
   }
 
   for (const edge of scoped.edges) {
-    const data = edge.data as (DimEdgeData & { label?: unknown }) | undefined
+    const data = edge.data as { _storedColors?: { strokeColor?: string; textColor?: string } } | undefined
     const stored = data?._storedColors ?? { strokeColor: edge.style?.strokeColor, textColor: edge.style?.textColor }
     const display = mode === "dark" ? adaptEdgeColors(stored, "dark") : stored
     const style = applyColorsToEdgeStyle(edge.style ?? {}, display)
-    // Migrate a legacy edge label from the never-rendered `data.label` (string OR
-    // RichText) to `content`, the field the harness draws — existing content wins.
-    // Strip the dead field so it doesn't persist and re-migrate on every load.
-    const content = edge.content || labelText(data?.label as string | { markdown?: string } | undefined) || undefined
-    let nextData = edge.data
-    if (data && "label" in data) {
-      const { label: _legacy, ...rest } = data
-      nextData = rest
-    }
-    ops.push({ type: "edge.add", edge: { ...edge, style, content, data: nextData } })
+    ops.push({ type: "edge.add", edge: { ...edge, style } })
   }
 
   if (ops.length > 0) {

--- a/webui/src/features/board/persist/local/apply-content.ts
+++ b/webui/src/features/board/persist/local/apply-content.ts
@@ -60,11 +60,14 @@ export const applyContentToStore = (
   }
 
   for (const edge of scoped.edges) {
-    const data = edge.data as { _storedColors?: { strokeColor?: string; textColor?: string } } | undefined
+    const data = edge.data as { _storedColors?: { strokeColor?: string; textColor?: string }; label?: string } | undefined
     const stored = data?._storedColors ?? { strokeColor: edge.style?.strokeColor, textColor: edge.style?.textColor }
     const display = mode === "dark" ? adaptEdgeColors(stored, "dark") : stored
     const style = applyColorsToEdgeStyle(edge.style ?? {}, display)
-    ops.push({ type: "edge.add", edge: { ...edge, style } })
+    // Migrate a legacy edge label from the never-rendered `data.label` to
+    // `content` (the field the harness draws), so old agent links show their label.
+    const content = edge.content || (typeof data?.label === "string" ? data.label : undefined)
+    ops.push({ type: "edge.add", edge: { ...edge, style, content } })
   }
 
   if (ops.length > 0) {

--- a/webui/src/features/board/persist/local/apply-content.ts
+++ b/webui/src/features/board/persist/local/apply-content.ts
@@ -1,6 +1,7 @@
 import { asBatchId } from "@canvas-harness/core"
 import type { CanvasStore, Node, Op } from "@canvas-harness/core"
 import type { BoardContent } from "@/features/board/model"
+import { normalizeBoardContent } from "@/features/board/model"
 import { filterContentByLayer } from "@/features/board/model/layer"
 import {
   adaptEdgeColors,
@@ -37,7 +38,11 @@ export const applyContentToStore = (
   content: BoardContent,
   rootId?: string | null,
 ): void => {
-  const scoped = rootId === undefined ? content : filterContentByLayer(content, rootId)
+  // Defensive: callers normally pass `persistence.load()` output (already
+  // normalized), but this is exported — normalize here too so the store's
+  // canonical-label invariant holds regardless of the source. Idempotent + cheap.
+  const normalized = normalizeBoardContent(content)
+  const scoped = rootId === undefined ? normalized : filterContentByLayer(normalized, rootId)
   const mode = getBoardThemeMode()
   const ops: Op[] = []
 

--- a/webui/src/features/board/persist/local/apply-content.ts
+++ b/webui/src/features/board/persist/local/apply-content.ts
@@ -1,7 +1,7 @@
 import { asBatchId } from "@canvas-harness/core"
 import type { CanvasStore, Node, Op } from "@canvas-harness/core"
-import type { BoardContent } from "@/features/board/model"
-import { asRichLabel } from "@/features/board/model"
+import type { BoardContent, DimEdgeData } from "@/features/board/model"
+import { asRichLabel, labelText } from "@/features/board/model"
 import { filterContentByLayer } from "@/features/board/model/layer"
 import {
   adaptEdgeColors,
@@ -60,14 +60,20 @@ export const applyContentToStore = (
   }
 
   for (const edge of scoped.edges) {
-    const data = edge.data as { _storedColors?: { strokeColor?: string; textColor?: string }; label?: string } | undefined
+    const data = edge.data as (DimEdgeData & { label?: unknown }) | undefined
     const stored = data?._storedColors ?? { strokeColor: edge.style?.strokeColor, textColor: edge.style?.textColor }
     const display = mode === "dark" ? adaptEdgeColors(stored, "dark") : stored
     const style = applyColorsToEdgeStyle(edge.style ?? {}, display)
-    // Migrate a legacy edge label from the never-rendered `data.label` to
-    // `content` (the field the harness draws), so old agent links show their label.
-    const content = edge.content || (typeof data?.label === "string" ? data.label : undefined)
-    ops.push({ type: "edge.add", edge: { ...edge, style, content } })
+    // Migrate a legacy edge label from the never-rendered `data.label` (string OR
+    // RichText) to `content`, the field the harness draws — existing content wins.
+    // Strip the dead field so it doesn't persist and re-migrate on every load.
+    const content = edge.content || labelText(data?.label as string | { markdown?: string } | undefined) || undefined
+    let nextData = edge.data
+    if (data && "label" in data) {
+      const { label: _legacy, ...rest } = data
+      nextData = rest
+    }
+    ops.push({ type: "edge.add", edge: { ...edge, style, content, data: nextData } })
   }
 
   if (ops.length > 0) {

--- a/webui/src/features/board/persist/local/board-persistence.ts
+++ b/webui/src/features/board/persist/local/board-persistence.ts
@@ -18,6 +18,7 @@
 import { createCanvasStore } from "@canvas-harness/core"
 import type { CanvasStore, OpBatch } from "@canvas-harness/core"
 import type { BoardContent } from "@/features/board/model"
+import { normalizeBoardContent } from "@/features/board/model"
 import { contentToScene, emptyContent, readContent } from "./codec"
 import { pruneDanglingEdges } from "./integrity"
 import { IndexedDbEngine } from "./indexeddb-engine"
@@ -229,7 +230,7 @@ export class BoardPersistence {
       range: { lower: [this.boardId, baseSeq], upper: [this.boardId, Number.MAX_SAFE_INTEGER], lowerOpen: true },
     })
     const seq = records.length > 0 ? records[records.length - 1].seq : baseSeq
-    if (records.length === 0) return { content: base, seq }
+    if (records.length === 0) return { content: normalizeBoardContent(base), seq }
     // Replay in relay (`serverSeq`) order so a reload converges the same way live
     // sync did; unacked-local ops (no `serverSeq`) sort last, then by local seq.
     // Stable within a serverSeq bucket, so all-local logs keep append order.
@@ -244,7 +245,7 @@ export class BoardPersistence {
       store.applyBatch({ ...r.batch, origin: "remote" })
     }
     pruneDanglingEdges(store)
-    return { content: readContent(store), seq }
+    return { content: normalizeBoardContent(readContent(store)), seq }
   }
 
 


### PR DESCRIPTION
## What

Fix agent-drawn link labels, which were **invisible**. `link_notes` wrote the label to `edge.data.label` — a field nothing renders or syncs — instead of `edge.content`, the field the harness actually draws.

**Stacked on #235** (touches the same `tools.ts` / `apply-content.ts` / model as the label work). Retarget to `main` as the stack merges.

## Why

The audit flagged `DimEdgeData.label` as a string-vs-RichText mismatch parallel to node labels. Investigating showed it's worse than a type issue:

- The harness renders the edge label from **`edge.content`** (per `@canvas-harness/core`: *"Position of `edge.content` (the edge label)…"*).
- The convert layer round-trips it correctly: `link-to-edge` sets `edge.content` from `Link.label.markdown`; `edge-to-link` reads `edge.content` back to `Link.label`.
- But `link_notes` set `data.label` (a string) and never set `edge.content`. Nothing renders `data.label`, so agent link labels ("causes", "then", …) never showed and never synced to the server. `DimEdgeData.label` was effectively dead (only this tool wrote it; one test asserted it).

So there was no real string-vs-RichText divergence for edges — the canonical label is `edge.content` (string) ↔ `Link.label` (RichText), consistent. The bug was `link_notes` writing the wrong field.

## How

- **`link_notes`** now sets `content: label` (the rendered field) and drops the `data.label` write.
- **`applyContentToStore`** migrates a legacy edge `data.label` → `content` on load (when `content` is empty), so links created before this fix show their label after it ships — no manual migration.
- **Remove `DimEdgeData.label`** from the type (it was never the edge label).

## Testing

- `link_notes` sets `edge.content` to the label; omitting a label leaves `content` unset.
- `applyContentToStore` migrates a legacy edge `data.label` → `content`.
- Full suite green (1249), `check-all` clean.

## Model consistency

For both nodes and edges, the label text now lives in the harness-native field — `node.content` / `edge.content` for body + edge label (plain string), and `data.label` (RichText) only for a node **title** — matching the backend `Resource.label` / `Link.label`.
