### PR TITLE
feat(webui): escape returns to select tool, else closes open dialog

### DIFF
--- a/webui/src/features/board/harness/canvas/use-board-keyboard.ts
+++ b/webui/src/features/board/harness/canvas/use-board-keyboard.ts
@@ -48,6 +48,7 @@ const TOOL_SHORTCUTS: Record<string, string> = {
  *  - M                            → toggle Slides panel
  *  - G                            → open Icons search dialog
  *  - I                            → open Images search dialog
+ *  - Escape                       → close open dialog, else drop to select tool
  *
  * Skipped when focus is in an input / textarea / contentEditable so
  * inline editing keeps the native shortcuts. canvas-harness already
@@ -57,6 +58,17 @@ export const useBoardKeyboard = (store: CanvasStore): void => {
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (isTypingTarget(e.target)) return
+
+      // Escape peels back to a neutral state: close an open chrome dialog
+      // first, otherwise drop any active create tool back to `select`. Left
+      // un-prevented so canvas-harness's own Escape handler still runs to
+      // clear the selection + abort an in-progress drag / marquee / draft edge.
+      if (e.key === "Escape") {
+        const app = useBoardAppStore.getState()
+        if (app.chromeDialog) app.setChromeDialog(null)
+        else app.setTool("select")
+        return
+      }
 
       // Reserve Space for hold-to-pan: stop a focused button from
       // re-firing its click on each Space press (e.g. the sidebar

--- a/webui/src/features/board/harness/canvas/use-board-keyboard.ts
+++ b/webui/src/features/board/harness/canvas/use-board-keyboard.ts
@@ -131,16 +131,37 @@ export const useBoardKeyboard = (store: CanvasStore): void => {
     // race all of them. When an overlay owns the Escape we defer to its close and
     // leave the tool untouched; canvas-harness's own Escape handler still clears
     // the selection + aborts an in-progress drag / marquee / draft edge.
+    //
+    // "Is an overlay open?" is a hand-maintained enumeration (store flags below +
+    // the focused-overlay DOM guard). A shared open-overlay signal would be less
+    // fragile — new overlays must remember to opt in here — but that's a broader
+    // refactor; this list covers every dismissable the board mounts today.
     const onEscape = (e: KeyboardEvent): void => {
       if (e.key !== "Escape") return
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
       if (isTypingTarget(e.target)) return
       const app = useBoardAppStore.getState()
-      if (app.chromeDialog || app.activeNodeSurface || app.presentationMode) return
-      // Store-less Radix overlays (view menu, context menu, chat sheet) keep their
-      // open-state locally — skip when the Escape is focused inside one.
+      // The tool only exists on the board canvas — no-op in files / list views.
+      if (app.viewMode !== "board") return
+      // Overlays whose open-state lives in the store own the Escape; their own
+      // handlers close them, so don't also steal the tool switch. `chatSheetOpen`
+      // needs the explicit flag because the CopilotSheet is non-modal — focus
+      // stays on the canvas, so the focused-overlay DOM guard below misses it.
+      if (
+        app.chromeDialog ||
+        app.activeNodeSurface ||
+        app.presentationMode ||
+        app.chatSheetOpen
+      )
+        return
+      // Store-less Radix overlays (view menu, context menu, delete-confirm alert)
+      // keep open-state locally — skip when the Escape is focused inside one.
       const target = e.target
-      if (target instanceof HTMLElement && target.closest("[role='menu'],[role='dialog']")) return
+      if (
+        target instanceof HTMLElement &&
+        target.closest("[role='menu'],[role='dialog'],[role='alertdialog']")
+      )
+        return
       if (app.tool !== "select") app.setTool("select")
     }
 

--- a/webui/src/features/board/harness/canvas/use-board-keyboard.ts
+++ b/webui/src/features/board/harness/canvas/use-board-keyboard.ts
@@ -48,7 +48,7 @@ const TOOL_SHORTCUTS: Record<string, string> = {
  *  - M                            → toggle Slides panel
  *  - G                            → open Icons search dialog
  *  - I                            → open Images search dialog
- *  - Escape                       → close open dialog, else drop to select tool
+ *  - Escape                       → return to select tool (unless an overlay owns it)
  *
  * Skipped when focus is in an input / textarea / contentEditable so
  * inline editing keeps the native shortcuts. canvas-harness already
@@ -58,17 +58,6 @@ export const useBoardKeyboard = (store: CanvasStore): void => {
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       if (isTypingTarget(e.target)) return
-
-      // Escape peels back to a neutral state: close an open chrome dialog
-      // first, otherwise drop any active create tool back to `select`. Left
-      // un-prevented so canvas-harness's own Escape handler still runs to
-      // clear the selection + abort an in-progress drag / marquee / draft edge.
-      if (e.key === "Escape") {
-        const app = useBoardAppStore.getState()
-        if (app.chromeDialog) app.setChromeDialog(null)
-        else app.setTool("select")
-        return
-      }
 
       // Reserve Space for hold-to-pan: stop a focused button from
       // re-firing its click on each Space press (e.g. the sidebar
@@ -132,7 +121,34 @@ export const useBoardKeyboard = (store: CanvasStore): void => {
       }
     }
 
+    // Escape returns the canvas to the `select` tool (matches tldraw/excalidraw),
+    // so a create tool (rect / note / arrow / …) isn't left stuck after one shape.
+    // Registered in the CAPTURE phase on purpose: it must read overlay state
+    // BEFORE the same Escape is consumed by a handler that clears it — Radix
+    // dialogs/menus close on a document-level capture handler (clearing
+    // `chromeDialog`), and the presentation / node-surface handlers are window
+    // bubble listeners that clear their own flags. Reading in bubble phase would
+    // race all of them. When an overlay owns the Escape we defer to its close and
+    // leave the tool untouched; canvas-harness's own Escape handler still clears
+    // the selection + aborts an in-progress drag / marquee / draft edge.
+    const onEscape = (e: KeyboardEvent): void => {
+      if (e.key !== "Escape") return
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+      if (isTypingTarget(e.target)) return
+      const app = useBoardAppStore.getState()
+      if (app.chromeDialog || app.activeNodeSurface || app.presentationMode) return
+      // Store-less Radix overlays (view menu, context menu, chat sheet) keep their
+      // open-state locally — skip when the Escape is focused inside one.
+      const target = e.target
+      if (target instanceof HTMLElement && target.closest("[role='menu'],[role='dialog']")) return
+      if (app.tool !== "select") app.setTool("select")
+    }
+
     window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
+    window.addEventListener("keydown", onEscape, true)
+    return () => {
+      window.removeEventListener("keydown", onKey)
+      window.removeEventListener("keydown", onEscape, true)
+    }
   }, [store])
 }


### PR DESCRIPTION
## What

Add an **Escape → select tool** binding to the canvas keymap (`use-board-keyboard.ts`). When a create tool (rect / note / arrow / …) is active, Escape drops back to `select` — matching the tldraw/excalidraw default, so a tool isn't left stuck after drawing one shape.

## Why

The canvas had no Escape binding. Pressing Escape while a create tool was active did **nothing** — you were stuck until you clicked Select or pressed `v`.

## Design — why it's a capture-phase listener

Escape is a shared key: Radix dialogs/menus close on it, and presentation-mode / node-surface handlers close their surfaces on it. Resetting the tool in a window **bubble** handler is racy: Radix closes its overlays in a **document-level capture** handler that clears `chromeDialog` *before* a bubble handler runs, and the presentation / node-surface handlers are themselves window bubble listeners that clear their own flags. A bubble-phase guard would read already-cleared state and silently reset the tool on every overlay dismiss.

Fix: a dedicated **capture-phase** window listener for Escape that reads overlay state *before* any other handler consumes the key, and only resets the tool when no overlay owns the Escape:

- No-op outside the board canvas (`viewMode !== "board"`).
- Defer when a **store-tracked** overlay is open: `chromeDialog`, `activeNodeSurface`, `presentationMode`, `chatSheetOpen` (the CopilotSheet is non-modal, so focus stays on the canvas — it needs the explicit flag).
- Defer when the Escape is focused inside a **store-less Radix overlay** — `[role=menu] / [role=dialog] / [role=alertdialog]` (view menu, context menu, node delete-confirm).
- Otherwise reset the tool to `select`. Ignore modified Escape (Cmd/Ctrl/Alt/Shift), consistent with the other single-key shortcuts.

Left un-`preventDefault`ed so canvas-harness's own Escape handler still clears the selection + aborts an in-progress drag / marquee / draft edge. No `@canvas-harness` changes required.

**Known limitation:** "is an overlay open?" is a hand-maintained enumeration (store flags + the DOM guard); a shared open-overlay signal would be less fragile, but that's a broader refactor. The current list covers every dismissable the board mounts today.

## Scope notes

- Create tools remain **sticky** (you stay in the tool after drawing a shape); auto-revert-after-create is a separate UX decision, not included here.

## Testing

- `npm run check-all` (type-check + eslint) passes clean.
- Manual: create tool active + Escape → back to select; dialog / menu / context-menu / alert / node-surface / non-modal chat sheet open + Escape → that closes and the tool is left alone; elements selected + Escape → deselects (library) and tool resets.
- No unit test added: `use-board-keyboard.ts` is untested and there's no `@testing-library/react` / `renderHook` precedent in the harness for this `useEffect`-based hook.

## Review

Two rounds of `/code-review high`. Round 1 caught the capture-phase race (dialog dismiss clobbering the tool); round 2 caught overlay-enumeration gaps (chat sheet, alert dialog, non-board views). Both addressed in follow-up commits.