### PR TITLE
fix(webui): note-card/board links use `center` (the consumed nav param)

### DIFF
--- a/webui/src/components/markdown/markdown-link.tsx
+++ b/webui/src/components/markdown/markdown-link.tsx
@@ -106,7 +106,9 @@ export function MarkdownLink({ children, href, ...rest }: MarkdownLinkProps) {
     navigate({
       to: "/boards/$id",
       params: { id: boardId },
-      search: (prev: Record<string, unknown>) => ({ ...prev, center_around: targetId }),
+      // `center` is the param useCenterFromUrl actually consumes (selects + centers
+      // the node); `center_around` was a dead param with no reader.
+      search: (prev: Record<string, unknown>) => ({ ...prev, center: targetId }),
     })
   }
 

--- a/webui/src/features/agent/components/chat/note-widget-preview.tsx
+++ b/webui/src/features/agent/components/chat/note-widget-preview.tsx
@@ -68,7 +68,7 @@ export const NoteWidgetPreview = ({
           to='/boards/$id'
           params={{ id: boardId }}
           search={{
-            center_around: noteId,
+            center: noteId, // the param useCenterFromUrl consumes (center_around had no reader)
             current_chat_id: chatId || undefined,
             root_id: rootId || undefined,
           }}

--- a/webui/src/features/agent/components/chat/tool-step-row.tsx
+++ b/webui/src/features/agent/components/chat/tool-step-row.tsx
@@ -98,7 +98,7 @@ export const NoteToolResult = ({
           to='/boards/$id'
           params={{ id: boardId }}
           search={{
-            center_around: noteId,
+            center: noteId, // the param useCenterFromUrl consumes (center_around had no reader)
             current_chat_id: chatId || undefined,
             root_id: rootId || undefined,
           }}


### PR DESCRIPTION
## What

The "Open on board" link on agent note cards + widget previews, and the board deep-link handler in `MarkdownLink`, all wrote **`center_around`** in the URL search params — a param with **zero readers** anywhere in the app. The param `useCenterFromUrl` actually consumes (to select + center the node) is **`center`**.

So those links navigated to the board but never centered or highlighted the node — the click looked like it did nothing useful.

## Fix

Switch the three writers (`markdown-link.tsx`, `tool-step-row.tsx`, `note-widget-preview.tsx`) to `center`. Two of them already pass `root_id`, so the note's folder/layer opens too.

## Why it's separate

This is an independent one-liner bug fix, groundwork for a larger "surface + cite the notes the agent finds" change (design in `docs/plans/node-citations.md`), but correct and mergeable on its own — it makes the *existing* note-card navigation work today.

## Testing

Full suite green (1249), `check-all` clean. (The three call sites are the only `center_around` writers; there were no readers, confirmed by grep.)
