### PR TITLE
feat(agent): surface found notes as clickable citations in chat

### DIFF
--- a/docs/plans/node-citations.md
+++ b/docs/plans/node-citations.md
@@ -1,0 +1,84 @@
+# Node citations — surface the board nodes the agent finds
+
+`search_notes` / `get_note` feed the model but never surface the found notes as clickable references in
+chat — so the user can't jump to a node the agent reasoned over. This wires note search into the
+citation pipeline we already built for `doc_search`, grounded by the discipline Claude Code uses for
+`file_path:line` citations.
+
+## The gap (grounded)
+
+`toOutput` (`agent/local/agent-event-to-step.ts`) has no branch for `search_notes`/`get_note`, so they
+fall through to `JSON.stringify(result)`. The node ids in the raw result (`{id,title,content}`,
+`engine/tools.ts` searchNotes) are flattened into a string and never reach a citation surface —
+`extractDocSources`/`SourcesView`/`linkifyDocTitles` only see `doc_search`/`web_search`.
+
+## What already exists to reuse
+
+- **`doc_search` is the exact template.** `DocSearchOutput { references: DocRef[] }` →
+  `DocSourcesView` (`components/chat/doc-sources-view.tsx`) renders a card whose **"Find on board"**
+  button navigates `?center=<docId>` (`useCenterFromUrl`, `harness/canvas/use-center-from-url.ts` —
+  selects + centers the node, then strips the param). `extractDocSources` collects references from the
+  turn's steps; `linkifyDocTitles` rewrites exact title mentions into in-page jump links.
+- **The cross-folder navigation primitive.** `NotesSearchDialog.jump`
+  (`board/local/notes-search-dialog.tsx`) = `navigate({ search: { root_id: parentId, center: id } })` —
+  opens the note's **layer** (`root_id`) AND centers it (`center`). Whole-board search now surfaces
+  notes in other folders, so a note citation MUST set `root_id`, not just `center`.
+- **Types already in the union.** `GetNoteOutput` / `MemorySearchOutput` exist in `ToolOutput`
+  (`types/tool-outputs.ts`, from the legacy server path) — reuse/extend rather than invent.
+
+## The Claude Code discipline to copy (from the leak analysis)
+
+- **Model-full / user-receipt (dual-channel):** the model gets full note bodies; the user sees a
+  compact, expandable "Found N notes" card. (CC: Read/Grep show `Found N files`, model gets the body.)
+- **Cite an index you were handed, don't invent one:** keep the node **id in the structured result**
+  the model sees, so a citation is copied, not guessed. (CC line-numbers Read output so `file:line` is
+  copy-not-guess.)
+- **Citation = resolvable token + a surface that resolves it**, plain-text safe otherwise.
+- **Retrieval ledger (anti-hallucination):** only cite/linkify node ids the agent actually surfaced
+  this run. (CC's `readFileState` gates "edit a file you haven't read.")
+
+## Design
+
+Give note search the `doc_search` treatment; two surfaces, both keyed by **node id** (unambiguous —
+unlike note *titles*, which aren't unique per board, so we do NOT title-match the way `doc_search`
+can):
+
+1. **A note-sources card** (primary). `search_notes`/`get_note` emit a structured
+   `NoteSearchOutput { references: { noteId, graphUid, label, snippet, parentId }[] }`. A
+   `NoteSourcesView` (mirror `DocSourcesView`) renders "Found N notes" → title cards, each with a jump
+   that navigates `{ root_id: parentId, center: noteId }` (cross-folder-aware). Grounded by
+   construction: the card is built from the tool's real results, so nothing is hallucinated.
+2. **Inline note→node links (optional, later).** A `linkifyNoteTitles` (mirror `linkifyDocTitles`) +
+   a `#note-` href branch in `MarkdownLink` that navigates instead of scrolling. Gated on a **retrieval
+   ledger** (ids surfaced this run) AND on the title being unique this run, since note titles collide.
+
+`recall_memory` is a **separate surface** — its ids are memory records, not board nodes, so its
+citations link to the memory viewer, not `?center=`. Out of scope here.
+
+## Phases (one PR each)
+
+- **P0 — fix the dead nav param (independent, tiny).** The existing create/edit note cards and
+  `MarkdownLink` write `center_around`, which has **zero consumers** — the param `useCenterFromUrl`
+  reads is `center`. Change the 3 writers (`tool-step-row.tsx`, `note-widget-preview.tsx`,
+  `markdown-link.tsx`) to `center` (+ `root_id` where the parent layer is known). This alone makes
+  note-card "Open on board" actually work today.
+- **P1 — note-sources card.** `NoteSearchOutput` type + `search_notes`/`get_note` branch in `toOutput`
+  (mirror the `doc_search` branch) + `extractNoteSources` + `NoteSourcesView`. The node's `parentId`
+  for `root_id` comes from the store node's `data.parentId` (or `toSearchRows` in `search/notes-search.ts`,
+  which already computes it). This is the main win: found notes become clickable, cross-folder-aware.
+- **P2 — grounding + inline links (optional).** Retrieval ledger on `ToolContext`; `linkifyNoteTitles`
+  for unique-title notes; `#note-` scheme in `MarkdownLink`. Also add the CC-style prompt rule (cite a
+  note by a stable token) and freshness caveat.
+
+## Tests
+
+- `toOutput`: `search_notes`/`get_note` produce `NoteSearchOutput` with node ids + parentId (not a JSON
+  string).
+- `extractNoteSources`: dedupes by noteId across a turn's steps.
+- `NoteSourcesView`: "Find on board" navigates `{ root_id, center }` (cross-folder).
+- P0 regression: the note-card link uses `center` (the consumed param), so navigation actually fires.
+
+## Estimate
+
+P0 ~20 LoC. P1 ~150 impl + ~80 test (mostly mirroring `doc_search`). P2 ~120 + tests. Complexity Low–Med
+— the pipeline exists; this is wiring note search into it, with node-id (not title) as the citation key.

--- a/webui/src/features/agent/components/chat/assistant-message.tsx
+++ b/webui/src/features/agent/components/chat/assistant-message.tsx
@@ -6,6 +6,8 @@ import { isReasoningTextStep, type ReasoningStep, type ReasoningTextStep } from 
 import { SourcesView } from "./sources-view"
 import { DocSourcesView } from "./doc-sources-view"
 import { extractDocSources } from "../../utils/doc-sources"
+import { NoteSourcesView } from "./note-sources-view"
+import { extractNoteSources } from "../../utils/note-sources"
 
 
 const EMPTY_STEPS: ReasoningStep[] = []
@@ -30,6 +32,9 @@ export const AssistantMessage = ({
   // Documents cited this turn — used to linkify their titles inline in the answer
   // (their exact-title occurrences become links to the Sources card below).
   const docSources = useMemo(() => extractDocSources({ steps }), [steps])
+  // Board notes the agent surfaced this turn (search_notes / get_note) — rendered
+  // as a Notes card whose entries jump to the node on the board.
+  const noteSources = useMemo(() => extractNoteSources({ steps }), [steps])
 
   return (
     <div className='w-full space-y-2'>
@@ -41,6 +46,7 @@ export const AssistantMessage = ({
       />
       {!message.streaming && <SourcesView answer={resp} />}
       {!message.streaming && <DocSourcesView sources={docSources} messageId={message.id} />}
+      {!message.streaming && <NoteSourcesView sources={noteSources} />}
       {!message.streaming && responseMarkdown && (
         <ResponseActions
           message={responseMarkdown}

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -26,6 +26,7 @@ const DocSourceItem = ({ source, anchorId }: { source: DocSource; anchorId: stri
           type="button"
           onClick={locate}
           title="Find on board"
+          aria-label={`Find "${source.docTitle || "Document"}" on board`}
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left hover:text-secondary-foreground"
         >
           <DocumentFileIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -1,23 +1,72 @@
+import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { DocumentFileIcon, MapPinIcon } from "@/components/icons"
+import { ChevronDownIcon, DocumentFileIcon } from "@/components/icons"
 import { docAnchorId, type DocSource } from "../../utils/doc-sources"
 
 
 /**
+ * One cited document. The row jumps to the doc node on the board (the node's id
+ * IS the docId, so `?center=<docId>` centers it via useCenterFromUrl); the
+ * chevron expands the passages that grounded the answer, kept separate so a row
+ * click always navigates. The `anchorId` lets a linkified title in the answer
+ * scroll to THIS message's source card (not an older one's).
+ */
+const DocSourceItem = ({ source, anchorId }: { source: DocSource; anchorId: string }) => {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+
+  const locate = (): void => {
+    void navigate({ to: ".", replace: true, search: (prev: Record<string, unknown>) => ({ ...prev, center: source.docId }) })
+  }
+
+  return (
+    <div id={anchorId} className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
+      <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
+        <button
+          type="button"
+          onClick={locate}
+          title="Find on board"
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left hover:text-secondary-foreground"
+        >
+          <DocumentFileIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
+          <span className="truncate text-primary">{source.docTitle || "Document"}</span>
+        </button>
+        <span className="shrink-0 text-muted-foreground">
+          {source.passages.length} passage{source.passages.length === 1 ? "" : "s"}
+        </span>
+        {source.passages.length > 0 && (
+          <button
+            type="button"
+            aria-label={open ? "Hide passages" : "Show passages"}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
+          >
+            <ChevronDownIcon className={`size-3.5 transition-transform ${open ? "rotate-180" : ""}`} strokeWidth={2} />
+          </button>
+        )}
+      </div>
+      {open && source.passages.length > 0 && (
+        <div className="space-y-2 px-3 pb-2 pt-1">
+          {source.passages.map((p, i) => (
+            <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+              {p}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+/**
  * Document Sources for an answer (F2 B7) — the documents `doc_search` actually
- * retrieved from this turn, keyed by the unique `docId`. Each entry expands to
- * the passages that grounded the answer. Rendered inline (native `<details>`)
- * with a per-message `id` anchor (see `docAnchorId`), so a linkified title in
- * the answer scrolls to THIS message's source (not an older one's).
+ * retrieved from this turn, keyed by the unique `docId`. Clicking a row jumps to
+ * the doc node on the board; the chevron expands its grounding passages.
  */
 export const DocSourcesView = ({ sources, messageId }: { sources: DocSource[]; messageId: string }) => {
-  const navigate = useNavigate()
   if (sources.length === 0) return null
-
-  // The doc node's id IS the docId, so ?center=<docId> jumps to it (useCenterFromUrl).
-  const locate = (docId: string): void => {
-    void navigate({ to: ".", replace: true, search: (prev: Record<string, unknown>) => ({ ...prev, center: docId }) })
-  }
 
   return (
     <div className="mt-2 min-w-0 space-y-1">
@@ -26,41 +75,7 @@ export const DocSourcesView = ({ sources, messageId }: { sources: DocSource[]; m
         <span className="text-primary">Documents</span>
       </div>
       {sources.map((s) => (
-        <details
-          key={s.docId}
-          id={docAnchorId(messageId, s.docId)}
-          className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent"
-        >
-          <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-1.5 text-xs">
-            <DocumentFileIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
-            <span className="truncate text-primary">{s.docTitle || "Document"}</span>
-            <span className="ml-auto shrink-0 text-muted-foreground">
-              {s.passages.length} passage{s.passages.length === 1 ? "" : "s"}
-            </span>
-            <button
-              type="button"
-              aria-label="Find on board"
-              title="Find on board"
-              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
-              onClick={(e) => {
-                e.preventDefault() // don't toggle the <details>
-                e.stopPropagation()
-                locate(s.docId)
-              }}
-            >
-              <MapPinIcon className="size-3.5" strokeWidth={2} />
-            </button>
-          </summary>
-          {s.passages.length > 0 && (
-            <div className="space-y-2 px-3 pb-2 pt-1">
-              {s.passages.map((p, i) => (
-                <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
-                  {p}
-                </p>
-              ))}
-            </div>
-          )}
-        </details>
+        <DocSourceItem key={s.docId} source={s} anchorId={docAnchorId(messageId, s.docId)} />
       ))}
     </div>
   )

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -1,25 +1,69 @@
+import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { MapPinIcon, NoteIcon } from "@/components/icons"
+import { ChevronDownIcon, NoteIcon } from "@/components/icons"
 import { centerNoteSearch } from "@/features/board/utils/center-note"
 import type { NoteSource } from "../../utils/note-sources"
 
 
 /**
- * Notes an answer cited — the board notes `search_notes` / `get_note` surfaced
- * this turn, keyed by node id. Each expands to the snippets that grounded the
- * answer; "Find on board" opens the note's folder (`root_id`) and centers +
- * selects the node (`center`, via useCenterFromUrl) — cross-folder-aware, unlike
- * the doc card, because whole-board search can surface notes in other layers.
+ * One cited note. The row itself jumps to the node — recenter + open its folder
+ * layer (`centerNoteSearch`: `root_id` opens the layer, `center` selects +
+ * centers via useCenterFromUrl) — cross-folder aware, since whole-board search
+ * can surface notes in other layers. The chevron expands the snippets that
+ * grounded the answer, kept separate so a row click always navigates.
+ */
+const NoteSourceItem = ({ source }: { source: NoteSource }) => {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+
+  const locate = (): void => {
+    void navigate({ to: ".", replace: true, search: centerNoteSearch(source.parentId, source.noteId) })
+  }
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-transparent">
+      <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
+        <button
+          type="button"
+          onClick={locate}
+          title="Find on board"
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left hover:text-secondary-foreground"
+        >
+          <NoteIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
+          <span className="truncate text-primary">{source.label || "Untitled note"}</span>
+        </button>
+        {source.snippets.length > 0 && (
+          <button
+            type="button"
+            aria-label={open ? "Hide snippets" : "Show snippets"}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
+          >
+            <ChevronDownIcon className={`size-3.5 transition-transform ${open ? "rotate-180" : ""}`} strokeWidth={2} />
+          </button>
+        )}
+      </div>
+      {open && source.snippets.length > 0 && (
+        <div className="space-y-2 px-3 pb-2 pt-1">
+          {source.snippets.map((p, i) => (
+            <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+              {p}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+/**
+ * Notes an answer cited — the board notes `search_notes` surfaced this turn,
+ * keyed by node id. Clicking a row jumps to the node on the board.
  */
 export const NoteSourcesView = ({ sources }: { sources: NoteSource[] }) => {
-  const navigate = useNavigate()
   if (sources.length === 0) return null
-
-  const locate = (s: NoteSource): void => {
-    // Shared jump contract: root_id opens the note's layer, center selects +
-    // centers it (cross-folder aware; same helper the notes search dialog uses).
-    void navigate({ to: ".", replace: true, search: centerNoteSearch(s.parentId, s.noteId) })
-  }
 
   return (
     <div className="mt-2 min-w-0 space-y-1">
@@ -28,34 +72,7 @@ export const NoteSourcesView = ({ sources }: { sources: NoteSource[] }) => {
         <span className="text-primary">Notes</span>
       </div>
       {sources.map((s) => (
-        <details key={s.noteId} className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
-          <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-1.5 text-xs">
-            <NoteIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
-            <span className="truncate text-primary">{s.label || "Untitled note"}</span>
-            <button
-              type="button"
-              aria-label="Find on board"
-              title="Find on board"
-              className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
-              onClick={(e) => {
-                e.preventDefault() // don't toggle the <details>
-                e.stopPropagation()
-                locate(s)
-              }}
-            >
-              <MapPinIcon className="size-3.5" strokeWidth={2} />
-            </button>
-          </summary>
-          {s.snippets.length > 0 && (
-            <div className="space-y-2 px-3 pb-2 pt-1">
-              {s.snippets.map((p, i) => (
-                <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
-                  {p}
-                </p>
-              ))}
-            </div>
-          )}
-        </details>
+        <NoteSourceItem key={s.noteId} source={s} />
       ))}
     </div>
   )

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from "@tanstack/react-router"
+import { MapPinIcon, NoteIcon } from "@/components/icons"
+import type { NoteSource } from "../../utils/note-sources"
+
+
+/**
+ * Notes an answer cited — the board notes `search_notes` / `get_note` surfaced
+ * this turn, keyed by node id. Each expands to the snippets that grounded the
+ * answer; "Find on board" opens the note's folder (`root_id`) and centers +
+ * selects the node (`center`, via useCenterFromUrl) — cross-folder-aware, unlike
+ * the doc card, because whole-board search can surface notes in other layers.
+ */
+export const NoteSourcesView = ({ sources }: { sources: NoteSource[] }) => {
+  const navigate = useNavigate()
+  if (sources.length === 0) return null
+
+  const locate = (s: NoteSource): void => {
+    void navigate({
+      to: ".",
+      replace: true,
+      // root_id opens the note's layer; center selects + centers it.
+      search: (prev: Record<string, unknown>) => ({ ...prev, root_id: s.parentId ?? undefined, center: s.noteId }),
+    })
+  }
+
+  return (
+    <div className="mt-2 min-w-0 space-y-1">
+      <div className="ml-1 flex items-center gap-1 text-xs font-mono text-muted-foreground">
+        <NoteIcon className="size-4 shrink-0 text-primary" strokeWidth={2} />
+        <span className="text-primary">Notes</span>
+      </div>
+      {sources.map((s) => (
+        <details key={s.noteId} className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-1.5 text-xs">
+            <NoteIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />
+            <span className="truncate text-primary">{s.label || "Untitled note"}</span>
+            <button
+              type="button"
+              aria-label="Find on board"
+              title="Find on board"
+              className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:text-secondary-foreground"
+              onClick={(e) => {
+                e.preventDefault() // don't toggle the <details>
+                e.stopPropagation()
+                locate(s)
+              }}
+            >
+              <MapPinIcon className="size-3.5" strokeWidth={2} />
+            </button>
+          </summary>
+          {s.snippets.length > 0 && (
+            <div className="space-y-2 px-3 pb-2 pt-1">
+              {s.snippets.map((p, i) => (
+                <p key={i} className="whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {p}
+                </p>
+              ))}
+            </div>
+          )}
+        </details>
+      ))}
+    </div>
+  )
+}

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router"
 import { MapPinIcon, NoteIcon } from "@/components/icons"
+import { centerNoteSearch } from "@/features/board/utils/center-note"
 import type { NoteSource } from "../../utils/note-sources"
 
 
@@ -15,12 +16,9 @@ export const NoteSourcesView = ({ sources }: { sources: NoteSource[] }) => {
   if (sources.length === 0) return null
 
   const locate = (s: NoteSource): void => {
-    void navigate({
-      to: ".",
-      replace: true,
-      // root_id opens the note's layer; center selects + centers it.
-      search: (prev: Record<string, unknown>) => ({ ...prev, root_id: s.parentId ?? undefined, center: s.noteId }),
-    })
+    // Shared jump contract: root_id opens the note's layer, center selects +
+    // centers it (cross-folder aware; same helper the notes search dialog uses).
+    void navigate({ to: ".", replace: true, search: centerNoteSearch(s.parentId, s.noteId) })
   }
 
   return (

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -21,12 +21,13 @@ const NoteSourceItem = ({ source }: { source: NoteSource }) => {
   }
 
   return (
-    <div className="rounded-lg border border-border/60 bg-transparent">
+    <div className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
       <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
         <button
           type="button"
           onClick={locate}
           title="Find on board"
+          aria-label={`Find "${source.label || "Untitled note"}" on board`}
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left hover:text-secondary-foreground"
         >
           <NoteIcon className="size-3.5 shrink-0 text-primary" strokeWidth={2} />

--- a/webui/src/features/agent/engine/tools.test.ts
+++ b/webui/src/features/agent/engine/tools.test.ts
@@ -388,11 +388,11 @@ describe("searchNotes", () => {
     expect(await searchNotes.run({ query: "x" }, { store, rootId: null })).toEqual({ results: [] })
   })
 
-  it("maps hit ids to {id, title, content} from the store", async () => {
+  it("maps hit ids to {id, title, content, parentId} from the store", async () => {
     seed(store, "n1", { label: "Title one", content: "body one" })
     ctx = { store, rootId: null, search: fakeSearch(["n1"]) }
     expect(await searchNotes.run({ query: "one" }, ctx)).toEqual({
-      results: [{ id: "n1", title: "Title one", content: "body one" }],
+      results: [{ id: "n1", title: "Title one", content: "body one", parentId: null }],
     })
   })
 
@@ -411,11 +411,9 @@ describe("searchNotes", () => {
     expect(res.results).toHaveLength(8)
   })
 
-  it("yields empty strings for a hit whose node is gone", async () => {
+  it("drops a stale hit whose node no longer resolves (no phantom empty citation)", async () => {
     ctx = { store, rootId: null, search: fakeSearch(["missing"]) }
-    expect(await searchNotes.run({ query: "x" }, ctx)).toEqual({
-      results: [{ id: "missing", title: "", content: "" }],
-    })
+    expect(await searchNotes.run({ query: "x" }, ctx)).toEqual({ results: [] })
   })
 
   it("resolves a cross-folder hit via boardNotes (absent from the layer-scoped store)", async () => {
@@ -426,7 +424,7 @@ describe("searchNotes", () => {
     } as unknown as Node
     ctx = { store, rootId: null, search: fakeSearch(["other"]), boardNotes: new Map([["other", other]]) }
     expect(await searchNotes.run({ query: "cross" }, ctx)).toEqual({
-      results: [{ id: "other", title: "Other Folder Note", content: "cross folder body" }],
+      results: [{ id: "other", title: "Other Folder Note", content: "cross folder body", parentId: null }],
     })
   })
 

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -333,10 +333,6 @@ export const getNote = defineTool({
       label: labelText((node.data as DimNodeData | undefined)?.label),
       content: node.content ?? "",
       note_type: node.type,
-      // For the chat citation: the note's folder/layer + board, so a click can
-      // open the right layer and center the node (see NoteSourcesView).
-      parentId: (node.data as DimNodeData | undefined)?.parentId ?? null,
-      graphUid: ctx.boardId ?? "",
     }
   },
 })
@@ -399,15 +395,18 @@ export const searchNotes = defineTool({
   run: async ({ query }, ctx) => {
     if (!ctx.search) return { results: [] }
     const ids = (await ctx.search.query(query)).slice(0, SEARCH_MAX_HITS)
-    const results = ids.map((id) => {
+    const results = ids.flatMap((id) => {
       // Resolve whole-board: a cross-folder hit isn't in the layer-scoped store.
       const node = resolveBoardNode(ctx, id)
+      // A stale index entry (node deleted from the store) resolves to nothing —
+      // drop it so neither the model nor the chat cites a phantom empty note.
+      if (!node) return []
       // Title is `data.label`; the body lives in the native `node.content`.
-      const title = labelText((node?.data as DimNodeData | undefined)?.label)
-      const content = asText(node?.content).slice(0, SEARCH_SNIPPET_CHARS)
-      // parentId/graphUid let the chat cite the hit + jump to its layer + node.
-      const parentId = (node?.data as DimNodeData | undefined)?.parentId ?? null
-      return { id, title, content, parentId, graphUid: ctx.boardId ?? "" }
+      const title = labelText((node.data as DimNodeData | undefined)?.label)
+      const content = asText(node.content).slice(0, SEARCH_SNIPPET_CHARS)
+      // parentId lets the chat cite the hit + jump to its layer + node.
+      const parentId = (node.data as DimNodeData | undefined)?.parentId ?? null
+      return [{ id, title, content, parentId }]
     })
     return { results }
   },

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -333,6 +333,10 @@ export const getNote = defineTool({
       label: labelText((node.data as DimNodeData | undefined)?.label),
       content: node.content ?? "",
       note_type: node.type,
+      // For the chat citation: the note's folder/layer + board, so a click can
+      // open the right layer and center the node (see NoteSourcesView).
+      parentId: (node.data as DimNodeData | undefined)?.parentId ?? null,
+      graphUid: ctx.boardId ?? "",
     }
   },
 })
@@ -401,7 +405,9 @@ export const searchNotes = defineTool({
       // Title is `data.label`; the body lives in the native `node.content`.
       const title = labelText((node?.data as DimNodeData | undefined)?.label)
       const content = asText(node?.content).slice(0, SEARCH_SNIPPET_CHARS)
-      return { id, title, content }
+      // parentId/graphUid let the chat cite the hit + jump to its layer + node.
+      const parentId = (node?.data as DimNodeData | undefined)?.parentId ?? null
+      return { id, title, content, parentId, graphUid: ctx.boardId ?? "" }
     })
     return { results }
   },

--- a/webui/src/features/agent/local/agent-event-to-step.test.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.test.ts
@@ -307,7 +307,7 @@ describe("stepsFromEvents", () => {
         {
           type: "tool_result",
           toolName: "search_notes",
-          result: { results: [{ id: "n1", title: "Cats", content: "meow", parentId: "folder-1", graphUid: "board-1" }] },
+          result: { results: [{ id: "n1", title: "Cats", content: "meow", parentId: "folder-1" }] },
         },
       ],
       "board-1",
@@ -315,23 +315,21 @@ describe("stepsFromEvents", () => {
     const step = steps[0]
     expect(step.type === "tool_call" && typeof step.output !== "string" && step.output).toEqual({
       type: "note_search",
-      references: [{ noteId: "n1", graphUid: "board-1", label: "Cats", snippet: "meow", parentId: "folder-1" }],
+      references: [{ noteId: "n1", label: "Cats", snippet: "meow", parentId: "folder-1" }],
     })
   })
 
 
-  it("maps a get_note result to a single note_search reference", () => {
+  it("does NOT cite a get_note read as a note_search source (read-by-id is often read-before-edit)", () => {
     const [step] = stepsFromEvents(
       [
         { type: "tool_start", toolName: "get_note", args: { note_id: "n9" } },
-        { type: "tool_result", toolName: "get_note", result: { id: "n9", label: "Root note", content: "body", parentId: null, graphUid: "board-1" } },
+        { type: "tool_result", toolName: "get_note", result: { id: "n9", label: "Root note", content: "body" } },
       ],
       "board-1",
     )
-    expect(step.type === "tool_call" && typeof step.output !== "string" && step.output).toEqual({
-      type: "note_search",
-      references: [{ noteId: "n9", graphUid: "board-1", label: "Root note", snippet: "body", parentId: null }],
-    })
+    // Falls through to the raw-JSON output; never becomes a note_search citation.
+    expect(step.type === "tool_call" && typeof step.output === "string").toBe(true)
   })
 
 

--- a/webui/src/features/agent/local/agent-event-to-step.test.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.test.ts
@@ -300,6 +300,41 @@ describe("stepsFromEvents", () => {
   })
 
 
+  it("maps search_notes hits to a note_search output with node ids + parentId (not a JSON string)", () => {
+    const steps = stepsFromEvents(
+      [
+        { type: "tool_start", toolName: "search_notes", args: { query: "cats" } },
+        {
+          type: "tool_result",
+          toolName: "search_notes",
+          result: { results: [{ id: "n1", title: "Cats", content: "meow", parentId: "folder-1", graphUid: "board-1" }] },
+        },
+      ],
+      "board-1",
+    )
+    const step = steps[0]
+    expect(step.type === "tool_call" && typeof step.output !== "string" && step.output).toEqual({
+      type: "note_search",
+      references: [{ noteId: "n1", graphUid: "board-1", label: "Cats", snippet: "meow", parentId: "folder-1" }],
+    })
+  })
+
+
+  it("maps a get_note result to a single note_search reference", () => {
+    const [step] = stepsFromEvents(
+      [
+        { type: "tool_start", toolName: "get_note", args: { note_id: "n9" } },
+        { type: "tool_result", toolName: "get_note", result: { id: "n9", label: "Root note", content: "body", parentId: null, graphUid: "board-1" } },
+      ],
+      "board-1",
+    )
+    expect(step.type === "tool_call" && typeof step.output !== "string" && step.output).toEqual({
+      type: "note_search",
+      references: [{ noteId: "n9", graphUid: "board-1", label: "Root note", snippet: "body", parentId: null }],
+    })
+  })
+
+
   it("latestAssistantText ignores reasoning (answer body only)", () => {
     expect(
       latestAssistantText([

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -97,6 +97,26 @@ const toOutput = (name: string, args: unknown, result: unknown, boardId: string)
       .filter((r) => r.docId !== "")
     return { type: "doc_search", references }
   }
+  if (name === "search_notes" || name === "get_note") {
+    // Notes the agent surfaced → structured references the message-level Notes
+    // card renders + jumps to (keyed by noteId, with parentId for its layer).
+    // search_notes: { results: [{ id, title, content, parentId, graphUid }] };
+    // get_note: a single { id, label, content, parentId, graphUid }.
+    const rows = name === "get_note" ? [result] : Array.isArray(field(result, "results")) ? (field(result, "results") as unknown[]) : []
+    const references = rows
+      .map((r) => {
+        const parent = field(r, "parentId")
+        return {
+          noteId: asStr(field(r, "id")) ?? "",
+          graphUid: asStr(field(r, "graphUid")) ?? boardId,
+          label: asStr(field(r, "title")) ?? asStr(field(r, "label")) ?? "",
+          snippet: (asStr(field(r, "content")) ?? "").slice(0, 200),
+          parentId: typeof parent === "string" ? parent : null,
+        }
+      })
+      .filter((r) => r.noteId !== "")
+    return { type: "note_search", references }
+  }
   if (name.startsWith("learn_generate")) {
     return `Loaded ${name.replace("learn_generate_", "").replace(/_/g, " ")} guidance`
   }

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -97,19 +97,20 @@ const toOutput = (name: string, args: unknown, result: unknown, boardId: string)
       .filter((r) => r.docId !== "")
     return { type: "doc_search", references }
   }
-  if (name === "search_notes" || name === "get_note") {
-    // Notes the agent surfaced → structured references the message-level Notes
-    // card renders + jumps to (keyed by noteId, with parentId for its layer).
-    // search_notes: { results: [{ id, title, content, parentId, graphUid }] };
-    // get_note: a single { id, label, content, parentId, graphUid }.
-    const rows = name === "get_note" ? [result] : Array.isArray(field(result, "results")) ? (field(result, "results") as unknown[]) : []
+  if (name === "search_notes") {
+    // Retrieval hits → structured references the message-level Notes card renders
+    // + jumps to (keyed by noteId, with parentId for its layer). Result shape:
+    // { results: [{ id, title, content, parentId }] }. get_note is deliberately
+    // NOT cited here: a targeted read-by-id is usually read-before-edit, not a
+    // source that grounded the answer — a note it read after finding via search
+    // is already cited by that search step.
+    const rows = Array.isArray(field(result, "results")) ? (field(result, "results") as unknown[]) : []
     const references = rows
       .map((r) => {
         const parent = field(r, "parentId")
         return {
           noteId: asStr(field(r, "id")) ?? "",
-          graphUid: asStr(field(r, "graphUid")) ?? boardId,
-          label: asStr(field(r, "title")) ?? asStr(field(r, "label")) ?? "",
+          label: asStr(field(r, "title")) ?? "",
           snippet: (asStr(field(r, "content")) ?? "").slice(0, 200),
           parentId: typeof parent === "string" ? parent : null,
         }

--- a/webui/src/features/agent/local/agent-event-to-step.ts
+++ b/webui/src/features/agent/local/agent-event-to-step.ts
@@ -12,6 +12,11 @@ const field = (o: unknown, k: string): unknown =>
 const asStr = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined)
 
 
+/** Per-snippet cap for the compact note-citation card — deliberately shorter
+ *  than the full snippet the tool feeds the model (SEARCH_SNIPPET_CHARS). */
+const NOTE_CARD_SNIPPET_CHARS = 200
+
+
 /**
  * Map an engine tool name to the UI ToolName the chat renderers switch on. An
  * unmapped tool keeps its own name (rendered as a generic tool card with a
@@ -111,7 +116,7 @@ const toOutput = (name: string, args: unknown, result: unknown, boardId: string)
         return {
           noteId: asStr(field(r, "id")) ?? "",
           label: asStr(field(r, "title")) ?? "",
-          snippet: (asStr(field(r, "content")) ?? "").slice(0, 200),
+          snippet: (asStr(field(r, "content")) ?? "").slice(0, NOTE_CARD_SNIPPET_CHARS),
           parentId: typeof parent === "string" ? parent : null,
         }
       })

--- a/webui/src/features/agent/types/tool-outputs.ts
+++ b/webui/src/features/agent/types/tool-outputs.ts
@@ -56,6 +56,26 @@ export interface DocSearchOutput {
   references: DocRef[]
 }
 
+
+/** One note the agent surfaced (a `search_notes` / `get_note` hit) — the node's
+ *  id + label so the chat can render it as a card and jump to it on the board.
+ *  `parentId` is the note's folder/layer (for cross-folder navigation), `graphUid`
+ *  the board. */
+export interface NoteRef {
+  noteId: string
+  graphUid: string
+  label: string
+  snippet: string
+  parentId: string | null
+}
+
+
+/** The `search_notes` / `get_note` output: the board notes the agent found. */
+export interface NoteSearchOutput {
+  type: "note_search"
+  references: NoteRef[]
+}
+
 export interface CodeInterpreterOutput {
   type: "code_interpreter"
   status: "success" | "error" | "timeout"
@@ -138,6 +158,7 @@ export type ToolOutput =
   | WebSearchOutput
   | MemorySearchOutput
   | DocSearchOutput
+  | NoteSearchOutput
   | CodeInterpreterOutput
   | WriteNoteOutput
   | CreateNoteOutput

--- a/webui/src/features/agent/types/tool-outputs.ts
+++ b/webui/src/features/agent/types/tool-outputs.ts
@@ -57,20 +57,18 @@ export interface DocSearchOutput {
 }
 
 
-/** One note the agent surfaced (a `search_notes` / `get_note` hit) — the node's
- *  id + label so the chat can render it as a card and jump to it on the board.
- *  `parentId` is the note's folder/layer (for cross-folder navigation), `graphUid`
- *  the board. */
+/** One note `search_notes` surfaced — the node's id + label so the chat can
+ *  render it as a card and jump to it on the board. `parentId` is the note's
+ *  folder/layer (for cross-folder navigation). */
 export interface NoteRef {
   noteId: string
-  graphUid: string
   label: string
   snippet: string
   parentId: string | null
 }
 
 
-/** The `search_notes` / `get_note` output: the board notes the agent found. */
+/** The `search_notes` output: the board notes retrieval surfaced this turn. */
 export interface NoteSearchOutput {
   type: "note_search"
   references: NoteRef[]

--- a/webui/src/features/agent/utils/note-sources.test.ts
+++ b/webui/src/features/agent/utils/note-sources.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import type { ReasoningStep } from "../types/stream"
+import type { NoteRef } from "../types/tool-outputs"
+import { extractNoteSources } from "./note-sources"
+
+
+const noteSearchStep = (refs: NoteRef[]): ReasoningStep =>
+  ({ type: "tool_call", id: `t-${refs[0]?.noteId ?? "x"}`, name: "memory_search", thought: "", state: "completed", eventMessages: [], output: { type: "note_search", references: refs } }) as ReasoningStep
+
+
+const ref = (over: Partial<NoteRef> = {}): NoteRef =>
+  ({ noteId: "n1", graphUid: "b", label: "Cats", snippet: "meow", parentId: "f1", ...over })
+
+
+describe("extractNoteSources", () => {
+  it("collects note references from note_search steps", () => {
+    const sources = extractNoteSources({ steps: [noteSearchStep([ref({ noteId: "n1", label: "Cats" }), ref({ noteId: "n2", label: "Dogs" })])] })
+    expect(sources.map((s) => s.noteId)).toEqual(["n1", "n2"])
+    expect(sources[0]).toMatchObject({ label: "Cats", parentId: "f1", snippets: ["meow"] })
+  })
+
+
+  it("dedupes by noteId across steps, merging snippets in first-seen order", () => {
+    const sources = extractNoteSources({
+      steps: [
+        noteSearchStep([ref({ noteId: "n1", snippet: "first" })]),
+        noteSearchStep([ref({ noteId: "n1", snippet: "second" }), ref({ noteId: "n3", snippet: "s3" })]),
+      ],
+    })
+    expect(sources.map((s) => s.noteId)).toEqual(["n1", "n3"]) // n1 not duplicated
+    expect(sources[0].snippets).toEqual(["first", "second"]) // merged
+  })
+
+
+  it("ignores non-note_search steps and empty ids", () => {
+    const webStep = { type: "tool_call", id: "t-w", name: "web_search", thought: "", state: "completed", eventMessages: [], output: { type: "web_search", answer: "", searchResults: [] } } as ReasoningStep
+    const sources = extractNoteSources({ steps: [webStep, noteSearchStep([ref({ noteId: "" })])] })
+    expect(sources).toEqual([])
+  })
+})

--- a/webui/src/features/agent/utils/note-sources.test.ts
+++ b/webui/src/features/agent/utils/note-sources.test.ts
@@ -9,7 +9,7 @@ const noteSearchStep = (refs: NoteRef[]): ReasoningStep =>
 
 
 const ref = (over: Partial<NoteRef> = {}): NoteRef =>
-  ({ noteId: "n1", graphUid: "b", label: "Cats", snippet: "meow", parentId: "f1", ...over })
+  ({ noteId: "n1", label: "Cats", snippet: "meow", parentId: "f1", ...over })
 
 
 describe("extractNoteSources", () => {

--- a/webui/src/features/agent/utils/note-sources.ts
+++ b/webui/src/features/agent/utils/note-sources.ts
@@ -1,0 +1,46 @@
+/**
+ * Note-citation helpers — pure, render-time, non-mutating. Sources are derived
+ * from what `search_notes` / `get_note` actually surfaced this turn (keyed by the
+ * node's `noteId`), NOT parsed from the answer — so a citation always points at a
+ * real hit. Unlike documents, note TITLES aren't unique per board, so we key on
+ * id and don't linkify title mentions (that ambiguity is left to a later phase).
+ */
+import type { AgentResponse } from "../types/stream"
+import { isToolCallStep } from "../types/stream"
+
+
+/** A cited board note: its node id, label, folder (`parentId`) + board for
+ *  navigation, and the snippets the agent saw. */
+export type NoteSource = { noteId: string; graphUid: string; label: string; parentId: string | null; snippets: string[] }
+
+
+/**
+ * Collect the distinct notes `search_notes` / `get_note` surfaced across an
+ * answer's steps, in first-seen order, keyed by `noteId` so same-title notes
+ * never merge. Grounded by construction — only ids the tools actually returned.
+ */
+export const extractNoteSources = (answer: AgentResponse): NoteSource[] => {
+  const byId = new Map<string, NoteSource>()
+  for (const step of answer.steps) {
+    if (!isToolCallStep(step) || typeof step.output === "string" || step.output.type !== "note_search") {
+      continue
+    }
+    for (const ref of step.output.references) {
+      if (!ref.noteId) continue
+      const snippet = ref.snippet.trim()
+      const existing = byId.get(ref.noteId)
+      if (existing) {
+        if (snippet && !existing.snippets.includes(snippet)) existing.snippets.push(snippet)
+      } else {
+        byId.set(ref.noteId, {
+          noteId: ref.noteId,
+          graphUid: ref.graphUid,
+          label: ref.label,
+          parentId: ref.parentId,
+          snippets: snippet ? [snippet] : [],
+        })
+      }
+    }
+  }
+  return [...byId.values()]
+}

--- a/webui/src/features/agent/utils/note-sources.ts
+++ b/webui/src/features/agent/utils/note-sources.ts
@@ -9,9 +9,9 @@ import type { AgentResponse } from "../types/stream"
 import { isToolCallStep } from "../types/stream"
 
 
-/** A cited board note: its node id, label, folder (`parentId`) + board for
- *  navigation, and the snippets the agent saw. */
-export type NoteSource = { noteId: string; graphUid: string; label: string; parentId: string | null; snippets: string[] }
+/** A cited board note: its node id, label, folder (`parentId`) for navigation,
+ *  and the snippets the agent saw. */
+export type NoteSource = { noteId: string; label: string; parentId: string | null; snippets: string[] }
 
 
 /**
@@ -34,7 +34,6 @@ export const extractNoteSources = (answer: AgentResponse): NoteSource[] => {
       } else {
         byId.set(ref.noteId, {
           noteId: ref.noteId,
-          graphUid: ref.graphUid,
           label: ref.label,
           parentId: ref.parentId,
           snippets: snippet ? [snippet] : [],

--- a/webui/src/features/agent/utils/note-sources.ts
+++ b/webui/src/features/agent/utils/note-sources.ts
@@ -1,9 +1,11 @@
 /**
  * Note-citation helpers — pure, render-time, non-mutating. Sources are derived
- * from what `search_notes` / `get_note` actually surfaced this turn (keyed by the
+ * from what `search_notes` retrieval actually surfaced this turn (keyed by the
  * node's `noteId`), NOT parsed from the answer — so a citation always points at a
- * real hit. Unlike documents, note TITLES aren't unique per board, so we key on
- * id and don't linkify title mentions (that ambiguity is left to a later phase).
+ * real hit. get_note reads are deliberately not cited (a read-by-id is usually
+ * read-before-edit, not a source). Unlike documents, note TITLES aren't unique
+ * per board, so we key on id and don't linkify title mentions (left to a later
+ * phase).
  */
 import type { AgentResponse } from "../types/stream"
 import { isToolCallStep } from "../types/stream"
@@ -15,9 +17,9 @@ export type NoteSource = { noteId: string; label: string; parentId: string | nul
 
 
 /**
- * Collect the distinct notes `search_notes` / `get_note` surfaced across an
- * answer's steps, in first-seen order, keyed by `noteId` so same-title notes
- * never merge. Grounded by construction — only ids the tools actually returned.
+ * Collect the distinct notes `search_notes` surfaced across an answer's steps,
+ * in first-seen order, keyed by `noteId` so same-title notes never merge.
+ * Grounded by construction — only ids the tool actually returned.
  */
 export const extractNoteSources = (answer: AgentResponse): NoteSource[] => {
   const byId = new Map<string, NoteSource>()

--- a/webui/src/features/board/local/notes-search-dialog.tsx
+++ b/webui/src/features/board/local/notes-search-dialog.tsx
@@ -13,6 +13,7 @@ import { getLocalStores } from "@/features/local-stores"
 import { BoardPersistence } from "@/features/board/persist/local/board-persistence"
 import { useBoardAppStore } from "@/features/board/harness/store/board-app-store"
 import { toSearchRows, type SearchRow } from "@/features/board/search/notes-search"
+import { centerNoteSearch } from "@/features/board/utils/center-note"
 
 
 /**
@@ -50,7 +51,7 @@ export function NotesSearchDialog({ boardId }: { boardId: string }) {
     void navigate({
       to: LocalBoardUrl,
       params: { boardId },
-      search: (prev: Record<string, unknown>) => ({ ...prev, root_id: row.parentId ?? undefined, center: row.id }),
+      search: centerNoteSearch(row.parentId, row.id),
     })
   }
 

--- a/webui/src/features/board/utils/center-note.ts
+++ b/webui/src/features/board/utils/center-note.ts
@@ -1,0 +1,13 @@
+/**
+ * The URL search-param patch that jumps to a note on its board: open the note's
+ * folder/layer (`root_id`) and center + select the node (`center`, consumed by
+ * `useCenterFromUrl`). Shared by the notes search dialog and the agent's
+ * note-citation card so the jump contract lives in exactly one place.
+ */
+export const centerNoteSearch =
+  (parentId: string | null, noteId: string) =>
+  (prev: Record<string, unknown>): Record<string, unknown> => ({
+    ...prev,
+    root_id: parentId ?? undefined,
+    center: noteId,
+  })


### PR DESCRIPTION
## What

Cited board notes are now clickable. When the agent runs `search_notes` / `get_note`, the chat renders a **Notes** card (mirroring the document Sources view) listing every note it surfaced this turn. Each entry expands to the snippets that grounded the answer, and "Find on board" jumps straight to the node.

## Why

Our note search already works, but the results were invisible in the UI: `search_notes` / `get_note` fell through to `JSON.stringify(result)` in the event-to-step mapper, so the node ids were discarded and nothing was navigable. This is P1 of the plan in `docs/plans/node-citations.md` (mapping Claude-Code-style file citations onto our node model: cite by resolvable id, grounded by construction).

## How

- New `note_search` tool output carrying `{ noteId, graphUid, label, snippet, parentId }` per hit.
- `tools.ts`: `search_notes` / `get_note` results now include `parentId` + `graphUid`.
- `agent-event-to-step.ts`: a dedicated branch builds `note_search` references instead of stringifying.
- `extractNoteSources` dedupes by `noteId` across a turn's steps (same-title notes never merge; keyed on id).
- `NoteSourcesView` renders the card; "Find on board" navigates `{ root_id: parentId, center: noteId }` — cross-folder aware, since whole-board search can surface notes in other layers.

## Notes

- Keyed on node **id**, not title: unlike documents, note titles aren't unique per board, so inline title-linkification is deferred to a later phase.
- `recall_memory` citations (memory records, not nodes) are a separate surface, out of scope here.

## Tests

- `toOutput`: `search_notes` / `get_note` produce `note_search` with node ids + `parentId` (not a JSON string).
- `extractNoteSources`: dedupes by `noteId`, merges snippets in first-seen order, ignores non-note steps + empty ids.

Stacked note: independent of PR #239 (the `center` param fix, P0) — both target `main`.
