### PR TITLE
feat(prompts): make skill-loading mandatory before write_note

### DIFF
--- a/webui/src/features/agent/engine/skills.ts
+++ b/webui/src/features/agent/engine/skills.ts
@@ -22,19 +22,19 @@ const skillTool = (name: SkillName, description: string): Tool =>
 
 export const learnGenerateDiagram = skillTool(
   "learn_generate_diagram",
-  "Load guidance before composing a structured multi-note answer (mindmap, taxonomy, schema, flowchart).",
+  "REQUIRED before a multi-note structured answer: call this ONCE to learn the brevity rule and shape vocabulary, then issue the parallel write_note + link_notes calls (mindmap, taxonomy, schema, flowchart).",
 )
 
 
 export const learnGenerateMiniApp = skillTool(
   "learn_generate_mini_app",
-  "Load guidance before authoring a sandboxed interactive React mini-app — the default custom-rendered artifact.",
+  'REQUIRED before authoring a sandboxed interactive React mini-app (the default custom-rendered artifact): call this first, then write one with write_note(note_type="mini-app").',
 )
 
 
 export const learnGenerateHtmlWidget = skillTool(
   "learn_generate_html_widget",
-  "Load guidance before authoring a raw-HTML widget note (legacy — prefer learn_generate_mini_app).",
+  'REQUIRED before authoring a legacy raw-HTML widget: call this first, then write one with write_note(note_type="widget") (legacy — prefer learn_generate_mini_app).',
 )
 
 

--- a/webui/src/features/agent/prompts/plan-system.md
+++ b/webui/src/features/agent/prompts/plan-system.md
@@ -80,10 +80,11 @@ Memory:
 - Pick `scope`: `board` for facts about this board's subject or structure; `global` for facts about the user that hold across boards. Pick `kind`: `user` (who they are), `feedback` (how to work with them), `project` (what a board is about), `reference` (a pointer to a resource).
 - If `save_memory` returns `over_cap`, it lists the current entries — `update_memory` to merge a related one or `delete_memory` a stale one, then retry (at most a few times). Saving is silent; never announce it in your reply.
 
-Diagrams and mini-apps:
-- For mini-app notes (the default custom-rendered artifact — chart, dashboard, diagram, flashcard, interactive control, …), first call `learn_generate_mini_app` to load skill instructions, then follow them when writing `note_type="mini-app"`. The source is validated via sucrase and rejected with line/col if malformed — fix and retry once if rejected.
-- Before composing any **multi-note structured answer** (mindmap, taxonomy, schema, flowchart), first call `learn_generate_diagram` ONCE. It teaches the brevity rule (short content per node) and the shape vocabulary (rectangle / ellipse / diamond) so the result reads at a glance. Then issue the parallel `write_note`s + `link_notes`.
-- For legacy raw-HTML widget notes (rare; only when the user explicitly asks for raw HTML or you're editing an existing widget), first call `learn_generate_html_widget`, then write `note_type="widget"`.
+Diagrams and mini-apps — skill-gated (MANDATORY):
+- You MUST call the matching `learn_generate_*` skill BEFORE the `write_note`/`link_notes` calls that build its output, in the same turn. NEVER write a mini-app, a legacy widget, or a multi-note diagram without loading its skill first — even when you are confident you know the format. The call is cheap, and the guidance it returns OVERRIDES your generic note-writing habits. If you skip it, stop and load the skill before writing.
+- **mini-app** (`note_type="mini-app"` — the default custom-rendered artifact: chart, dashboard, diagram, flashcard, interactive control, …): call `learn_generate_mini_app` first, then follow its instructions when writing the note. The source is validated via sucrase and rejected with line/col if malformed — fix and retry once if rejected.
+- **multi-note structured answer** (mindmap, taxonomy, schema, flowchart): call `learn_generate_diagram` ONCE first. It teaches the brevity rule (short content per node) and the shape vocabulary (rectangle / ellipse / diamond) so the result reads at a glance. Then issue the parallel `write_note`s + `link_notes`.
+- **legacy raw-HTML widget** (`note_type="widget"`; rare — only when the user explicitly asks for raw HTML or you're editing an existing widget): call `learn_generate_html_widget` first, then write the note.
 
 ## YOUR REPLY
 The chat reply is a distilled answer that stands on its own — the reader should learn something from it even if they never look at the board.


### PR DESCRIPTION
## Problem

The browser agent almost never loads its `learn_generate_*` skills before building a mini-app / widget / multi-note diagram — so you never see a skill-load step in the chat, and the model authors those formats from generic habits instead of the skill's guidance.

Root cause (confirmed by tracing the pipeline + comparing prompts): the rendering, event emission, and skill registration are all correct — the model simply isn't *calling* the skills. Both the system prompt and the tool descriptions framed "first call the skill, then write" as a **soft** suggestion (an arrow in the format menu, an ordered "first... then" sentence). Nothing said MUST. The old backend prompt was equally soft, so this is a longstanding behavior, not a regression from the port.

## Change

Harden the instruction into a real rule at two levels:

- **`plan-system.md`** — the "Diagrams and mini-apps" section is now `skill-gated (MANDATORY)`: *you MUST call the matching `learn_generate_*` skill BEFORE the `write_note`/`link_notes` that build its output; never write a mini-app, legacy widget, or multi-note diagram without loading its skill first, even when confident.* The per-format bullets keep their specifics (sucrase validation, the diagram brevity rule, the legacy-widget caveat).
- **`skills.ts`** — each tool description now leads with `REQUIRED before ...` and re-states the follow-up (`then write one with write_note(note_type="mini-app")`, etc.), reinforcing the order at the tool-schema level. This restores the explicit follow-up naming the backend descriptions had but the frontend port dropped.

## Effect

The model should now reliably call the skill first — which both improves output quality and makes the skill-load visible in the steps list (rendered as e.g. "Learn interactive React mini-app skill").

## Verification

`check-all` clean; prompt + agent-loop tests pass (49). Skill payloads and registration are unchanged — this is purely instruction wording.
