### PR TITLE
fix(repo): tag release commit with all manifests synced

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -4,6 +4,9 @@ version_scheme = "semver2"
 version = "0.3.86"
 version_files = [
   "VERSION",
+  "backend/pyproject.toml:^version = ",
+  'webui/package.json:"version":',
+  "webui/src-tauri/Cargo.toml:^version = ",
 ]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,36 +43,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version and sync manifests
+      - name: Bump version, sync manifests, and tag
         run: |
+          # cz bump updates every manifest listed in .cz.toml's version_files
+          # (VERSION + backend/webui/tauri) and creates the commit + tag in one
+          # step, so the tag points at a tree where all manifests already match.
           uv run --with commitizen cz bump --increment "${{ inputs.bump }}" --yes
-          python3 scripts/sync_version.py
-
-      - name: Check for release changes
-        id: release_changes
-        run: |
-          if git diff --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Commit release artifacts
-        if: steps.release_changes.outputs.has_changes == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          git add VERSION CHANGELOG.md backend/pyproject.toml webui/package.json webui/src-tauri/Cargo.toml
-          git commit -m "chore(repo): release v${VERSION}"
+          # Guard: fail the release if any tracked manifest drifted from VERSION
+          # (e.g. sync_version.py grew a manifest that version_files didn't).
+          python3 scripts/sync_version.py --check
 
       - name: Push release commit and tag
-        if: steps.release_changes.outputs.has_changes == 'true'
         run: |
           VERSION="$(cat VERSION)"
           git push origin HEAD:main
           git push origin "v${VERSION}"
 
       - name: Create GitHub release
-        if: steps.release_changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -81,16 +68,13 @@ jobs:
 
       - name: Save version for downstream jobs
         id: version
-        if: steps.release_changes.outputs.has_changes == 'true'
         run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
 
     outputs:
-      has_changes: ${{ steps.release_changes.outputs.has_changes }}
       version: ${{ steps.version.outputs.version }}
 
   docker:
     needs: release
-    if: needs.release.outputs.has_changes == 'true'
     uses: ./.github/workflows/docker-publish.yml
     with:
       version: ${{ needs.release.outputs.version }}
@@ -103,7 +87,6 @@ jobs:
   # `push: tags` in other workflows.
   desktop:
     needs: release
-    if: needs.release.outputs.has_changes == 'true'
     uses: ./.github/workflows/desktop-release.yml
     with:
       tag: v${{ needs.release.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,9 @@ version-check: ## Check whether repo manifests match VERSION
 	python3 scripts/sync_version.py --check
 
 .PHONY: version-bump
-version-bump: ## Bump repo version with commitizen, then sync manifests
+version-bump: ## Bump repo version with commitizen (updates all manifests) and verify sync
 	uv run --with commitizen cz bump
-	python3 scripts/sync_version.py
+	python3 scripts/sync_version.py --check
 
 # -------- CI / Tests --------
 # Lightweight targets so GitHub Actions and local dev share one entry point.


### PR DESCRIPTION
## Problem

The version shown in the app is always **one release behind** the real version (e.g. released `v0.3.86`, but the app displays `v0.3.85`).

**Root cause:** the release did the bump in two commits but tagged the wrong one.

1. `cz bump` updated only `VERSION` (the sole entry in `.cz.toml` `version_files`) and put the tag `v${VERSION}` on that commit.
2. `scripts/sync_version.py` then propagated the version into `backend/pyproject.toml`, `webui/package.json`, and `webui/src-tauri/Cargo.toml`, committed as a **separate, untagged** commit.

`docker-publish.yml` / `desktop-release.yml` build from the **tag**, and Vite bakes `__APP_VERSION__` from `webui/package.json` at build time — so the image shipped the stale `package.json` version, one behind the tag.

Proof at the last release tag:

```
v0.3.86 -> a2d480c   (the cz bump commit)
  VERSION            = 0.3.86  ✅
  webui/package.json = 0.3.85  ❌  <- one behind; fix lived in the untagged commit
```

## Fix (single tagged commit)

- **`.cz.toml`** — add the backend, webui, and tauri manifests to `version_files` so `cz bump` updates *and commits* them in the one commit it tags.
- **`release.yml`** — drop the second-commit / `has_changes` dance; push the single complete tagged commit + tag. `sync_version.py` becomes a `--check` guard that fails the release if any manifest drifted from `VERSION`.
- **`Makefile`** — `version-bump` uses `--check` for parity; `sync_version.py` is retained for the PR `version-check` and manual `version-sync`.

## Verification

Ran a real `cz bump` on the branch: one 6-file commit + tag. At the tag, **all four** manifests (`VERSION`, pyproject, `package.json`, Cargo) read the new version — matching the tag. Test tag/commit discarded.

## Notes

`cz bump` line-edits an already-canonical `package.json`, so `sync_version.py --check` stays green (the identical `--check` already gates every PR via `version-check.yml`).
