### PR TITLE
fix(agent): re-expand doc source card when its title is cited

### DIFF
--- a/webui/src/components/markdown/markdown-link.test.tsx
+++ b/webui/src/components/markdown/markdown-link.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => () => {} }))
 
-import { MarkdownLink } from "./markdown-link"
+import { MarkdownLink, REVEAL_SOURCE_EVENT } from "./markdown-link"
 
 
 describe("MarkdownLink — #doc- citation", () => {
@@ -52,6 +52,22 @@ describe("MarkdownLink — #doc- citation", () => {
 
     expect(details.open).toBe(true)
     expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+  })
+
+
+  it("dispatches REVEAL_SOURCE_EVENT on a non-<details> target (React-controlled card) and scrolls", () => {
+    const card = document.createElement("div")
+    card.id = "doc-abc"
+    document.body.appendChild(card)
+    const onReveal = vi.fn()
+    card.addEventListener(REVEAL_SOURCE_EVENT, onReveal)
+
+    act(() => root.render(<MarkdownLink href="#doc-abc">Report.pdf</MarkdownLink>))
+    act(() => container.querySelector("a")?.click())
+
+    expect(onReveal).toHaveBeenCalledTimes(1)
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+    card.remove()
   })
 })
 

--- a/webui/src/components/markdown/markdown-link.tsx
+++ b/webui/src/components/markdown/markdown-link.tsx
@@ -8,6 +8,10 @@ const boardLinkRe = /^\/boards\/([^/]+)\/([^/]+)\/([^/]+)$/
 const PAGE_HREF_PREFIX = "page://"
 const DOC_HREF_PREFIX = "#doc-"
 
+// Dispatched on a Sources card when a linkified title targets it, so a
+// React-controlled card (no DOM `open` attribute) can reveal its passages.
+export const REVEAL_SOURCE_EVENT = "reveal-source"
+
 // Schemes we allow on a rendered <a href>. Everything else (javascript:,
 // data:, vbscript:, blob:, file:, …) is treated as unsafe and neutralized.
 // page:// and #doc- are handled by dedicated branches before this gate.
@@ -79,7 +83,10 @@ export function MarkdownLink({ children, href, ...rest }: MarkdownLinkProps) {
       event.preventDefault()
       const el = document.getElementById(href.slice(1)) // "#doc-x" → "doc-x"
       if (!el) return
+      // The card is React-controlled: ask it to open its passages via an event
+      // (legacy <details> cards still honor the DOM `open` attribute).
       if (el instanceof HTMLDetailsElement) el.open = true
+      else el.dispatchEvent(new CustomEvent(REVEAL_SOURCE_EVENT))
       el.scrollIntoView({ behavior: "smooth", block: "start" })
     }
     return (

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { ChevronDownIcon, DocumentFileIcon } from "@/components/icons"
 import { REVEAL_SOURCE_EVENT } from "@/components/markdown/markdown-link"
+import { useBoardAppStore } from "@/features/board/harness/store/board-app-store"
 import { docAnchorId, type DocSource } from "../../utils/doc-sources"
 
 
@@ -16,6 +17,7 @@ import { docAnchorId, type DocSource } from "../../utils/doc-sources"
  */
 const DocSourceItem = ({ source, anchorId }: { source: DocSource; anchorId: string }) => {
   const navigate = useNavigate()
+  const setViewMode = useBoardAppStore((s) => s.setViewMode)
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -28,6 +30,10 @@ const DocSourceItem = ({ source, anchorId }: { source: DocSource; anchorId: stri
   }, [])
 
   const locate = (): void => {
+    // Surface the board first — the chat can be open over files/list view, where
+    // the canvas (and useCenterFromUrl) isn't showing, so the URL patch alone
+    // would no-op.
+    setViewMode("board")
     void navigate({ to: ".", replace: true, search: (prev: Record<string, unknown>) => ({ ...prev, center: source.docId }) })
   }
 

--- a/webui/src/features/agent/components/chat/doc-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/doc-sources-view.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { ChevronDownIcon, DocumentFileIcon } from "@/components/icons"
+import { REVEAL_SOURCE_EVENT } from "@/components/markdown/markdown-link"
 import { docAnchorId, type DocSource } from "../../utils/doc-sources"
 
 
@@ -9,18 +10,29 @@ import { docAnchorId, type DocSource } from "../../utils/doc-sources"
  * IS the docId, so `?center=<docId>` centers it via useCenterFromUrl); the
  * chevron expands the passages that grounded the answer, kept separate so a row
  * click always navigates. The `anchorId` lets a linkified title in the answer
- * scroll to THIS message's source card (not an older one's).
+ * scroll to THIS message's source card (not an older one's) and dispatches
+ * `REVEAL_SOURCE_EVENT` on it — the listener below opens the passages, since the
+ * card is React-controlled and can't be revealed via a DOM `open` attribute.
  */
 const DocSourceItem = ({ source, anchorId }: { source: DocSource; anchorId: string }) => {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const reveal = (): void => setOpen(true)
+    el.addEventListener(REVEAL_SOURCE_EVENT, reveal)
+    return () => el.removeEventListener(REVEAL_SOURCE_EVENT, reveal)
+  }, [])
 
   const locate = (): void => {
     void navigate({ to: ".", replace: true, search: (prev: Record<string, unknown>) => ({ ...prev, center: source.docId }) })
   }
 
   return (
-    <div id={anchorId} className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
+    <div ref={ref} id={anchorId} className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
       <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
         <button
           type="button"

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -21,7 +21,7 @@ const NoteSourceItem = ({ source }: { source: NoteSource }) => {
   }
 
   return (
-    <div className="scroll-mt-16 rounded-lg border border-border/60 bg-transparent">
+    <div className="rounded-lg border border-border/60 bg-transparent">
       <div className="flex items-center gap-2 px-2 py-1.5 text-xs">
         <button
           type="button"

--- a/webui/src/features/agent/components/chat/note-sources-view.tsx
+++ b/webui/src/features/agent/components/chat/note-sources-view.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { ChevronDownIcon, NoteIcon } from "@/components/icons"
 import { centerNoteSearch } from "@/features/board/utils/center-note"
+import { useBoardAppStore } from "@/features/board/harness/store/board-app-store"
 import type { NoteSource } from "../../utils/note-sources"
 
 
@@ -14,9 +15,14 @@ import type { NoteSource } from "../../utils/note-sources"
  */
 const NoteSourceItem = ({ source }: { source: NoteSource }) => {
   const navigate = useNavigate()
+  const setViewMode = useBoardAppStore((s) => s.setViewMode)
   const [open, setOpen] = useState(false)
 
   const locate = (): void => {
+    // Surface the board first — the chat can be open over files/list view, where
+    // the canvas (and useCenterFromUrl) isn't showing, so the URL patch alone
+    // would no-op.
+    setViewMode("board")
     void navigate({ to: ".", replace: true, search: centerNoteSearch(source.parentId, source.noteId) })
   }
 

--- a/webui/src/features/agent/utils/note-sources.test.ts
+++ b/webui/src/features/agent/utils/note-sources.test.ts
@@ -4,6 +4,9 @@ import type { NoteRef } from "../types/tool-outputs"
 import { extractNoteSources } from "./note-sources"
 
 
+// The step name is "memory_search" (not "search_notes"): toToolName remaps the
+// engine's search_notes tool to that canonical ToolName before it reaches the
+// steps extractNoteSources reads, so this fixture matches the real pipeline.
 const noteSearchStep = (refs: NoteRef[]): ReasoningStep =>
   ({ type: "tool_call", id: `t-${refs[0]?.noteId ?? "x"}`, name: "memory_search", thought: "", state: "completed", eventMessages: [], output: { type: "note_search", references: refs } }) as ReasoningStep
 


### PR DESCRIPTION
## Regression

PR #240 (source-card row-click UX) converted the **document** source card from a native `<details>` to a React-controlled `<div>` with a chevron. But `markdown-link.tsx` reveals a cited card's passages via `HTMLDetailsElement.open = true` — which is now always false for the div. So clicking a **linkified document title** in the answer scrolled to the card but left its grounding passages **collapsed**, contradicting the code comment ("opening it if collapsed").

Caught by `/code-review high`.

## Fix

- `markdown-link.tsx` now dispatches a `REVEAL_SOURCE_EVENT` CustomEvent on the target when it isn't a `<details>` (legacy `<details>` cards still honor the DOM `open` attribute, so nothing else regresses).
- `DocSourceItem` listens for that event on its root and opens its passages — the React-controlled equivalent of `open = true`. Row-click-to-navigate UX is unchanged.
- Drop the inert `scroll-mt-16` from the **note** card: note cards carry no anchor id and their titles are never linkified, so nothing ever scrolls to them (also flagged by the review).

## Tests

Added a case to `markdown-link.test.tsx`: clicking a `#doc-<id>` link whose target is a non-`<details>` element dispatches `REVEAL_SOURCE_EVENT` once and still scrolls. Full file green (22), `check-all` clean.

## Not included (deferred / out of scope)

- Dedup of `NoteSourceItem`/`DocSourceItem` into one shared component (review nit) — larger refactor, deferred.
- Two `use-board-keyboard.ts` Escape-handler findings from the review — unrelated pre-existing code, not touched by these PRs.
