### PR TITLE
fix(drawify): use handwriting font for drawn nodes and links

### DIFF
--- a/backend/topix/agents/drawify/drawify.py
+++ b/backend/topix/agents/drawify/drawify.py
@@ -82,7 +82,7 @@ def _convert_drawn_node(node: DrawnNode, z_index: int) -> Note:
     )
     note.style.type = _node_type_from_drawn(node.type)
     note.style.font_size = _font_size_from_label(node.font_size)
-    note.style.font_family = FontFamily.INFORMAL
+    note.style.font_family = FontFamily.HANDWRITING
     note.style.roundness = _roundness_from_drawn(node.rounded)
 
     if node.background:
@@ -109,7 +109,7 @@ def _convert_drawn_edge(edge: DrawnEdge, id_map: dict[str, str]) -> Link | None:
     )
     link.style.source_arrowhead = _arrowhead_from_label(edge.tail)
     link.style.target_arrowhead = _arrowhead_from_label(edge.head)
-    link.style.font_family = FontFamily.INFORMAL
+    link.style.font_family = FontFamily.HANDWRITING
 
     if edge.label:
         link.label = RichText(markdown=edge.label)


### PR DESCRIPTION
## What

Drawify's drawn nodes and links now use the **handwriting** font instead of **informal**.

## Why

`convert_drawify_output_to_notes_links` explicitly set `font_family = FontFamily.INFORMAL` on both notes (`drawify.py:85`) and links (`:112`), overriding the `Style` default of `FontFamily.HANDWRITING`. The frontend keeps drawify's style verbatim (`storeMindMap({ preserveStyle: true })`), so that override reached the canvas — drawn output rendered in the informal font rather than the board's default hand-drawn look.

## Change

Two lines: `FontFamily.INFORMAL` → `FontFamily.HANDWRITING` on the note and the link. (Left as explicit assignments, matching the surrounding style-setting lines, rather than dropping to the implicit default.)

## Testing

No test pins drawify's font (the only `font_family` assertions in the suite are for an unrelated `serif` op-apply case). `ruff` wasn't available in my environment, but the change is a swap between two existing, already-imported `FontFamily` enum members — no import, formatting, or line-length impact.
