### PR TITLE
refactor(agent): introduce BoardMutator write port (behavior-neutral)

### DIFF
--- a/webui/src/features/agent/engine/board-mutator.test.ts
+++ b/webui/src/features/agent/engine/board-mutator.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { asNodeId } from "@canvas-harness/core"
+import type { CanvasStore } from "@canvas-harness/core"
+import { freshStore, resetIdb } from "@/test/canvas"
+import type { DimNodeData } from "@/features/board/model"
+import { labelText } from "@/features/board/model"
+import { StoreMutator } from "./board-mutator"
+
+
+beforeEach(() => resetIdb())
+
+
+const label = (store: CanvasStore, id: string): string =>
+  labelText((store.getNode(asNodeId(id))?.data as DimNodeData | undefined)?.label)
+const body = (store: CanvasStore, id: string): string => store.getNode(asNodeId(id))?.content ?? ""
+
+
+describe("StoreMutator", () => {
+  it("createNote adds a rect note with label/content/parentId and returns created:true", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, "folder-1")
+    const res = await m.createNote({ content: "the body", label: "Title", type: "rectangle" })
+
+    expect(res.created).toBe(true)
+    const node = store.getNode(asNodeId(res.id))
+    expect(node?.type).toBe("rect")
+    expect(body(store, res.id)).toBe("the body")
+    expect(label(store, res.id)).toBe("Title")
+    expect((node?.data as DimNodeData | undefined)?.parentId).toBe("folder-1")
+  })
+
+  it("createNote honors an explicit id and position", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    const res = await m.createNote({ id: "n-explicit", content: "x", x: 500, y: 640 })
+    expect(res.id).toBe("n-explicit")
+    const node = store.getNode(asNodeId("n-explicit"))
+    expect({ x: node?.x, y: node?.y }).toEqual({ x: 500, y: 640 })
+  })
+
+  it("rewriteNote replaces content + label of an existing note (created:false)", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    const { id } = await m.createNote({ content: "old", label: "Old" })
+    const res = await m.rewriteNote(id, { content: "new body", label: "New" })
+    expect(res.created).toBe(false)
+    expect(body(store, id)).toBe("new body")
+    expect(label(store, id)).toBe("New")
+  })
+
+  it("rewriteNote on a missing id falls through to a create", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    const res = await m.rewriteNote("ghost", { content: "born here" })
+    expect(res.created).toBe(true)
+    expect(res.id).toBe("ghost")
+    expect(body(store, "ghost")).toBe("born here")
+  })
+
+  it("patchNote updates only the fields provided", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    const { id } = await m.createNote({ content: "keep", label: "Keep" })
+    await m.patchNote(id, { content: "changed" })
+    expect(body(store, id)).toBe("changed")
+    expect(label(store, id)).toBe("Keep") // untouched
+    await m.patchNote(id, { label: "Renamed" })
+    expect(label(store, id)).toBe("Renamed")
+    expect(body(store, id)).toBe("changed") // untouched
+  })
+
+  it("createLink attaches an edge at node centers with the parent layer", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, "folder-1")
+    const a = await m.createNote({ content: "A" })
+    const c = await m.createNote({ content: "C" })
+    const { id } = await m.createLink({ sourceId: a.id, targetId: c.id, label: "then" })
+
+    const edge = store.getAllEdges().find((e) => String(e.id) === id)
+    expect(edge).toBeTruthy()
+    expect((edge?.data as { parentId?: string } | undefined)?.parentId).toBe("folder-1")
+  })
+})

--- a/webui/src/features/agent/engine/board-mutator.ts
+++ b/webui/src/features/agent/engine/board-mutator.ts
@@ -1,0 +1,251 @@
+/**
+ * BoardMutator — the agent's content-level write port (S1 of the board-authoring
+ * plan). Tools express intent in domain verbs (createNote / rewriteNote /
+ * patchNote / createLink); the *implementation* owns how that reaches the board.
+ *
+ * `StoreMutator` is the current impl: it writes through the live canvas `store`
+ * exactly as the tools did inline before this port existed — so a write still
+ * flows through the same undo + persistence + sync pipeline as a human edit, with
+ * identical bytes. This is a pure decoupling: later impls (e.g. a headless,
+ * off-screen, cross-layer writer) can satisfy the same interface without the tool
+ * code changing.
+ */
+import { asEdgeId, asNodeId } from "@canvas-harness/core"
+import type { CanvasStore, Node } from "@canvas-harness/core"
+import type { DimEdgeData, DimNodeData } from "@/features/board/model"
+import { pickRandomColorOfShade } from "@/features/board/lib/colors/tailwind"
+import { AUTOFIT_DISABLED_TYPES } from "@/features/board/harness/convert/note-to-node"
+import { dim0LinkStyleToCanvas, dim0StyleToCanvas } from "@/features/board/harness/convert/style"
+import {
+  adaptEdgeColors,
+  adaptNodeColors,
+  applyColorsToEdgeStyle,
+  applyColorsToStyle,
+  pickStoredEdgeColors,
+  type StoredColors,
+  type StoredEdgeColors,
+} from "@/features/board/harness/theme/color-adapter"
+import { getBoardThemeMode } from "@/features/board/harness/theme/theme-mode-ref"
+import { createDefaultLinkStyle, createDefaultStyle } from "@/features/board/types/style"
+import { beneathBorderOrigin } from "@/features/board/harness/agent/beneath-border"
+import { estimateNoteSize } from "./note-size"
+
+
+/** A note to create or fully rewrite. `type` is the prompt-level note_type. */
+export type NoteSpec = {
+  id?: string
+  content: string
+  label?: string
+  type?: string
+  /** Optional explicit position; omitted → beneath the current board border. */
+  x?: number
+  y?: number
+}
+
+
+/** A directed link between two existing notes. */
+export type LinkSpec = {
+  sourceId: string
+  targetId: string
+  label?: string
+}
+
+
+/**
+ * Content-level board write port. Domain verbs only — no ops, batches, or seq in
+ * the signature; the impl decides how the write reaches persistence + sync.
+ */
+export interface BoardMutator {
+  createNote(spec: NoteSpec): Promise<{ id: string; created: true }>
+  rewriteNote(id: string, spec: NoteSpec): Promise<{ id: string; created: boolean }>
+  patchNote(id: string, patch: { content?: string; label?: string }): Promise<void>
+  createLink(spec: LinkSpec): Promise<{ id: string }>
+}
+
+
+// ---- construction helpers (moved verbatim from tools.ts) -------------------
+
+/**
+ * A random Tailwind-200 fill per note (mirrors the backend's
+ * `random.choice(TAILWIND_200_ADAPTED)`). Stored as `_storedColors` so the theme
+ * hooks project the display style for the current mode.
+ */
+const randomNoteColors = (): StoredColors => ({
+  backgroundColor: pickRandomColorOfShade(200)?.hex ?? "#dbeafe",
+  strokeColor: "#00000000",
+  textColor: "#000000",
+})
+
+
+// Default box size per canvas node type (mirrors backend get_default_note_size).
+const DEFAULT_SIZE: Record<string, { w: number; h: number }> = {
+  rect: { w: 320, h: 180 },
+  ellipse: { w: 320, h: 320 },
+  diamond: { w: 340, h: 340 },
+  sheet: { w: 440, h: 440 },
+  "mini-app": { w: 720, h: 440 },
+  widget: { w: 480, h: 320 },
+  "code-sandbox": { w: 560, h: 360 },
+}
+
+
+/** Content-fit size for a note, falling back to the type's default box. */
+const noteGeometry = (nodeType: string, content: string): { w: number; h: number } => {
+  const base = DEFAULT_SIZE[nodeType] ?? { w: 320, h: 180 }
+  const fitted = estimateNoteSize(nodeType, base.w, content)
+  return fitted ? { w: fitted.width, h: fitted.height } : base
+}
+
+
+/** Fresh SyncMeta stamp for a created/updated entity. */
+const meta = (): DimNodeData["meta"] => {
+  const t = Date.now()
+  return { v: 1, createdAt: t, updatedAt: t }
+}
+
+
+/**
+ * Canonical canvas style for a live-created rectangle — mirrors the convert layer
+ * so a freshly inserted node renders identically to its reloaded / peer-synced form.
+ */
+const canonicalNodeStyle = (colors: StoredColors) => {
+  const base = dim0StyleToCanvas(createDefaultStyle({ type: "rectangle" }))
+  const mode = getBoardThemeMode()
+  const display = mode === "dark" ? adaptNodeColors(colors, "dark") : colors
+  return applyColorsToStyle(base, display)
+}
+
+
+/** Canonical edge `style` (theme-adapted) + the light-space `_storedColors`. */
+const canonicalEdge = (): { style: ReturnType<typeof dim0LinkStyleToCanvas>; storedColors: StoredEdgeColors } => {
+  const base = dim0LinkStyleToCanvas(createDefaultLinkStyle())
+  const storedColors = pickStoredEdgeColors(base)
+  const mode = getBoardThemeMode()
+  const style = mode === "light" ? base : applyColorsToEdgeStyle(base, adaptEdgeColors(storedColors, mode))
+  return { style, storedColors }
+}
+
+
+// Map a prompt-level note_type to a canvas node type. Unknown → rectangle.
+const NODE_TYPE: Record<string, string> = {
+  rectangle: "rect",
+  rect: "rect",
+  sheet: "sheet",
+  "mini-app": "mini-app",
+  widget: "widget",
+  "code-sandbox": "code-sandbox",
+}
+const toNodeType = (t: string): string => NODE_TYPE[t] ?? "rect"
+
+
+// ---- StoreMutator: writes through the live store (today's behavior) ---------
+
+/**
+ * Writes through the live canvas store — the current-layer producer. Reproduces
+ * the exact node/edge construction the tools did inline, so behavior is identical
+ * (same undo + persistence + sync pipeline).
+ */
+export class StoreMutator implements BoardMutator {
+  private readonly store: CanvasStore
+  private readonly rootId: string | null
+
+  constructor(store: CanvasStore, rootId: string | null) {
+    this.store = store
+    this.rootId = rootId
+  }
+
+  async createNote(spec: NoteSpec): Promise<{ id: string; created: true }> {
+    const nodeType = toNodeType(spec.type ?? "")
+    const autoFitStyle = AUTOFIT_DISABLED_TYPES.has(nodeType) ? { autoFit: false } : undefined
+    const storedColors = randomNoteColors()
+    const { w, h } = noteGeometry(nodeType, spec.content)
+    const origin = beneathBorderOrigin(this.store)
+    // Plain rectangles are painted by the lib from `style`; custom types paint via
+    // their own view and only need autoFit disabled at birth.
+    const style = nodeType === "rect"
+      ? { ...canonicalNodeStyle(storedColors), ...(autoFitStyle ?? {}) }
+      : autoFitStyle
+    const id = asNodeId(spec.id || this.store.generateId())
+    this.store.batch(() => {
+      this.store.addNode({
+        id,
+        type: nodeType,
+        x: spec.x ?? origin.x,
+        y: spec.y ?? origin.y,
+        w,
+        h,
+        angle: 0,
+        groups: [],
+        content: spec.content,
+        ...(style ? { style } : {}),
+        data: {
+          label: { markdown: spec.label ?? "" },
+          parentId: this.rootId ?? undefined,
+          meta: meta(),
+          _storedColors: storedColors,
+        } satisfies DimNodeData,
+      })
+    })
+    return { id: String(id), created: true }
+  }
+
+  async rewriteNote(id: string, spec: NoteSpec): Promise<{ id: string; created: boolean }> {
+    const nid = asNodeId(id)
+    const node = this.store.getNode(nid)
+    // No such node → treat as a create with this id (mirrors write_note fallthrough).
+    if (!node) return this.createNote({ ...spec, id })
+    const nodeType = toNodeType(spec.type ?? "")
+    const autoFitStyle = AUTOFIT_DISABLED_TYPES.has(nodeType) ? { autoFit: false } : undefined
+    const prev = node.data as DimNodeData | undefined
+    this.store.batch(() =>
+      this.store.updateNode(nid, {
+        type: nodeType,
+        content: spec.content,
+        data: { ...prev, label: spec.label ? { markdown: spec.label } : (prev?.label ?? { markdown: "" }), meta: meta() },
+        ...(autoFitStyle ? { style: { ...(node.style ?? {}), ...autoFitStyle } } : {}),
+      }),
+    )
+    return { id: String(nid), created: false }
+  }
+
+  async patchNote(id: string, patch: { content?: string; label?: string }): Promise<void> {
+    const nid = asNodeId(id)
+    const node = this.store.getNode(nid)
+    if (!node) return
+    const prev = node.data as DimNodeData | undefined
+    const next: Partial<Node> = {}
+    if (patch.content !== undefined) next.content = patch.content
+    if (patch.label !== undefined) next.data = { ...prev, label: { markdown: patch.label }, meta: meta() }
+    this.store.batch(() => this.store.updateNode(nid, next))
+  }
+
+  async createLink(spec: LinkSpec): Promise<{ id: string }> {
+    const id = asEdgeId(this.store.generateId())
+    const src = asNodeId(spec.sourceId)
+    const tgt = asNodeId(spec.targetId)
+    // Attach at each node's CENTER (local frame from top-left); canvas-harness
+    // auto-clips the center→center line to each node's border.
+    const center = (nodeId: typeof src): { x: number; y: number } => {
+      const node = this.store.getNode(nodeId)
+      return node ? { x: node.w / 2, y: node.h / 2 } : { x: 0, y: 0 }
+    }
+    const { style, storedColors } = canonicalEdge()
+    this.store.batch(() => {
+      this.store.addEdge({
+        id,
+        source: { nodeId: src, localOffset: center(src) },
+        target: { nodeId: tgt, localOffset: center(tgt) },
+        pathStyle: "bezier",
+        groups: [],
+        style,
+        data: {
+          label: spec.label || undefined,
+          parentId: this.rootId ?? undefined,
+          meta: meta(),
+          _storedColors: storedColors,
+        } satisfies DimEdgeData,
+      })
+    })
+    return { id: String(id) }
+  }
+}

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -9,117 +9,24 @@
  * as a human edit. No server round-trips for these.
  */
 import { z } from "zod"
-import { asEdgeId, asNodeId } from "@canvas-harness/core"
+import { asNodeId } from "@canvas-harness/core"
 import type { Node } from "@canvas-harness/core"
-import type { DimEdgeData, DimNodeData } from "@/features/board/model"
+import type { DimNodeData } from "@/features/board/model"
 import { labelText } from "@/features/board/model"
-import { pickRandomColorOfShade } from "@/features/board/lib/colors/tailwind"
-import { AUTOFIT_DISABLED_TYPES } from "@/features/board/harness/convert/note-to-node"
-import { dim0LinkStyleToCanvas, dim0StyleToCanvas } from "@/features/board/harness/convert/style"
-import {
-  adaptEdgeColors,
-  adaptNodeColors,
-  applyColorsToEdgeStyle,
-  applyColorsToStyle,
-  pickStoredEdgeColors,
-  type StoredColors,
-  type StoredEdgeColors,
-} from "@/features/board/harness/theme/color-adapter"
-import { getBoardThemeMode } from "@/features/board/harness/theme/theme-mode-ref"
-import { createDefaultLinkStyle, createDefaultStyle } from "@/features/board/types/style"
-import { beneathBorderOrigin } from "@/features/board/harness/agent/beneath-border"
 import { validateMiniAppSource } from "@/features/mini-app/validate"
 import { defineTool } from "./types"
 import type { Tool, ToolContext } from "./types"
-import { estimateNoteSize } from "./note-size"
+import { StoreMutator, type BoardMutator } from "./board-mutator"
 import type { MemoryKind, MemoryScope } from "@/features/board/persist/local/idb"
 
 
 /**
- * A random Tailwind-200 fill per note (mirrors the backend's
- * `random.choice(TAILWIND_200_ADAPTED)` in notes/service.py). Stored as
- * `_storedColors` so the harness theme hooks project the display style for the
- * current mode — without this, agent notes render with the lib's non-theme-aware
- * default (always light). Black text reads on every light-200 swatch; the dark
- * variant is derived on theme flip.
+ * The board write port for a tool call: the ctx-provided `BoardMutator`, or a
+ * default `StoreMutator` over the live store when absent (tests / lean ctx).
+ * Tools write through this — never `store` directly — so the runtime stays
+ * decoupled from the collab op pipeline (see board-mutator.ts).
  */
-const randomNoteColors = (): StoredColors => ({
-  backgroundColor: pickRandomColorOfShade(200)?.hex ?? "#dbeafe",
-  strokeColor: "#00000000",
-  textColor: "#000000",
-})
-
-
-// Default box size per canvas node type (mirrors backend get_default_note_size).
-const DEFAULT_SIZE: Record<string, { w: number; h: number }> = {
-  rect: { w: 320, h: 180 },
-  ellipse: { w: 320, h: 320 },
-  diamond: { w: 340, h: 340 },
-  sheet: { w: 440, h: 440 },
-  "mini-app": { w: 720, h: 440 },
-  widget: { w: 480, h: 320 },
-  "code-sandbox": { w: 560, h: 360 },
-}
-
-
-/** Content-fit size for a note, falling back to the type's default box. */
-const noteGeometry = (nodeType: string, content: string): { w: number; h: number } => {
-  const base = DEFAULT_SIZE[nodeType] ?? { w: 320, h: 180 }
-  const fitted = estimateNoteSize(nodeType, base.w, content)
-  return fitted ? { w: fitted.width, h: fitted.height } : base
-}
-
-
-/** Fresh SyncMeta stamp for a created/updated entity. */
-const meta = (): DimNodeData["meta"] => {
-  const t = Date.now()
-  return { v: 1, createdAt: t, updatedAt: t }
-}
-
-
-/**
- * Canonical canvas style for a live-created rectangle / edge — mirrors the
- * convert layer (`noteToNode` / `linkToEdge`) so a freshly inserted object
- * renders identically to its reloaded / peer-synced form. Without it the harness
- * paints with its own library defaults (rounded corners, extra roughness), so
- * the live board drifted from the persisted one until reload. Keep the field
- * logic in sync with note-to-node.ts / link-to-edge.ts.
- */
-const canonicalNodeStyle = (colors: StoredColors) => {
-  const base = dim0StyleToCanvas(createDefaultStyle({ type: "rectangle" }))
-  const mode = getBoardThemeMode()
-  const display = mode === "dark" ? adaptNodeColors(colors, "dark") : colors
-  return applyColorsToStyle(base, display)
-}
-
-
-/**
- * Canonical edge `style` (theme-adapted for display) plus the canonical
- * light-space `_storedColors` that must ride on `data` — mirrors `linkToEdge`.
- * The stored colors are the source of truth on save; without them `edgeToLink`
- * would persist the dark-adapted display hex as canonical and corrupt the color
- * for a light-mode peer / on reload.
- */
-const canonicalEdge = (): { style: ReturnType<typeof dim0LinkStyleToCanvas>; storedColors: StoredEdgeColors } => {
-  const base = dim0LinkStyleToCanvas(createDefaultLinkStyle())
-  const storedColors = pickStoredEdgeColors(base)
-  const mode = getBoardThemeMode()
-  const style = mode === "light" ? base : applyColorsToEdgeStyle(base, adaptEdgeColors(storedColors, mode))
-  return { style, storedColors }
-}
-
-
-// Map a prompt-level note_type to a canvas node type. Shapes the agent can't
-// render distinctly (ellipse/diamond) fall back to the default rectangle.
-const NODE_TYPE: Record<string, string> = {
-  rectangle: "rect",
-  rect: "rect",
-  sheet: "sheet",
-  "mini-app": "mini-app",
-  widget: "widget",
-  "code-sandbox": "code-sandbox",
-}
-const toNodeType = (t: string): string => NODE_TYPE[t] ?? "rect"
+const mutatorFor = (ctx: ToolContext): BoardMutator => ctx.board ?? new StoreMutator(ctx.store, ctx.rootId ?? null)
 
 
 /**
@@ -142,30 +49,8 @@ export const createNote = defineTool({
     x: z.number().optional().describe("Optional x canvas position; defaults beneath existing content (auto-arranged after the turn)."),
     y: z.number().optional().describe("Optional y canvas position; defaults beneath existing content (auto-arranged after the turn)."),
   }),
-  run: async ({ id, title = "", body = "", x, y }, ctx) => {
-    const nodeId = asNodeId(id || ctx.store.generateId())
-    const { w, h } = noteGeometry("rect", body)
-    // Default new notes beneath the current graph border (mirrors the backend's
-    // compute_note_position); explicit coords from the model still win.
-    const origin = beneathBorderOrigin(ctx.store)
-    const storedColors = randomNoteColors()
-    ctx.store.batch(() => {
-      ctx.store.addNode({
-        id: nodeId,
-        type: "rect",
-        x: x ?? origin.x,
-        y: y ?? origin.y,
-        w,
-        h,
-        angle: 0,
-        groups: [],
-        content: body,
-        style: canonicalNodeStyle(storedColors),
-        data: { label: { markdown: title }, parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
-      })
-    })
-    return { id: String(nodeId), created: true }
-  },
+  run: async ({ id, title = "", body = "", x, y }, ctx) =>
+    mutatorFor(ctx).createNote({ id, content: body, label: title, type: "rect", x, y }),
 })
 
 
@@ -178,17 +63,12 @@ export const updateNote = defineTool({
     body: z.string().optional().describe("New body; omit to leave unchanged."),
   }),
   run: async ({ id, title, body }, ctx) => {
-    const nid = asNodeId(id)
-    const node = ctx.store.getNode(nid)
-    if (!node) return { error: "note not found" }
-
-    const patch: Partial<Node> = {}
-    if (typeof body === "string") patch.content = body
-    if (typeof title === "string") {
-      patch.data = { ...(node.data as DimNodeData | undefined), label: { markdown: title }, meta: meta() }
-    }
-    ctx.store.batch(() => ctx.store.updateNode(nid, patch))
-    return { id: String(nid) }
+    if (!ctx.store.getNode(asNodeId(id))) return { error: "note not found" }
+    await mutatorFor(ctx).patchNote(id, {
+      ...(typeof body === "string" ? { content: body } : {}),
+      ...(typeof title === "string" ? { label: title } : {}),
+    })
+    return { id }
   },
 })
 
@@ -201,40 +81,7 @@ export const linkNotes = defineTool({
     targetId: z.string().describe("Exact id of the note the arrow points to."),
     label: z.string().optional().describe("Optional short label on the edge, e.g. 'yes', 'no', 'then', 'reads', 'causes'."),
   }),
-  run: async ({ sourceId, targetId, label }, ctx) => {
-    const id = asEdgeId(ctx.store.generateId())
-    const src = asNodeId(sourceId)
-    const tgt = asNodeId(targetId)
-    // Attach at each node's CENTER (local frame is from top-left). canvas-harness
-    // auto-clips the center→center line to each node's border, so the endpoint
-    // lands at the border facing the peer — the backend's _edge_anchor_offset,
-    // for free, and it re-clips live as `arrangeCreatedNodes` moves the nodes.
-    const center = (nodeId: typeof src): { x: number; y: number } => {
-      const node = ctx.store.getNode(nodeId)
-      return node ? { x: node.w / 2, y: node.h / 2 } : { x: 0, y: 0 }
-    }
-    // Canonical edge style (arrowhead, stroke, roughness) so the live edge
-    // matches its reloaded form — the lib default is otherwise rougher — plus the
-    // canonical stored colors so a dark-mode edge saves the right (light) color.
-    const { style, storedColors } = canonicalEdge()
-    ctx.store.batch(() => {
-      ctx.store.addEdge({
-        id,
-        source: { nodeId: src, localOffset: center(src) },
-        target: { nodeId: tgt, localOffset: center(tgt) },
-        pathStyle: "bezier",
-        groups: [],
-        style,
-        data: {
-          label: label || undefined,
-          parentId: ctx.rootId ?? undefined,
-          meta: meta(),
-          _storedColors: storedColors,
-        } satisfies DimEdgeData,
-      })
-    })
-    return { id: String(id) }
-  },
+  run: async ({ sourceId, targetId, label }, ctx) => mutatorFor(ctx).createLink({ sourceId, targetId, label }),
 })
 
 
@@ -248,71 +95,22 @@ export const writeNote = defineTool({
     note_id: z.string().optional().describe("Existing note id to fully rewrite; omit to create a new note."),
   }),
   run: async ({ content, label, note_type, note_id }, ctx) => {
-    const nodeType = toNodeType(note_type ?? "")
-
-    // Custom types render only a preview of `content`, so disable the lib's
-    // grow-to-fit AT CREATION (mirrors backend note_to_wire_node). Setting it
-    // here — not just via the reactive stamp hook — means the node is born with
-    // autoFit off and the lib never grows it before the flag lands.
-    const autoFitStyle = AUTOFIT_DISABLED_TYPES.has(nodeType) ? { autoFit: false } : undefined
-
     // Validate a mini-app before persisting, so a malformed one is rejected with
     // line/col for the agent to fix this turn (not a silently-broken note).
-    if (nodeType === "mini-app") {
+    if (note_type === "mini-app") {
       const v = validateMiniAppSource(content)
       if (!v.ok) {
         return { error: `mini-app invalid: ${v.message}${v.line ? ` (line ${v.line}:${v.column})` : ""}` }
       }
     }
 
-    if (note_id) {
-      const id = asNodeId(note_id)
-      const node = ctx.store.getNode(id)
-      if (node) {
-        const prev = node.data as DimNodeData | undefined
-        ctx.store.batch(() =>
-          ctx.store.updateNode(id, {
-            type: nodeType,
-            content,
-            data: { ...prev, label: label ? { markdown: label } : (prev?.label ?? { markdown: "" }), meta: meta() },
-            ...(autoFitStyle ? { style: { ...(node.style ?? {}), ...autoFitStyle } } : {}),
-          }),
-        )
-        // Rewrote an existing (user-placed) note — NOT a creation, so the turn
-        // must not re-arrange or recenter it.
-        return { id: String(id), created: false }
-      }
-    }
-
-    const id = asNodeId(note_id || ctx.store.generateId())
-    const { w, h } = noteGeometry(nodeType, content)
-    // Born beneath the current graph border (mirrors the backend's
-    // compute_note_position); a multi-note turn is re-laid-out afterward.
-    const origin = beneathBorderOrigin(ctx.store)
-    const storedColors = randomNoteColors()
-    // Plain rectangles are painted by the lib from `style`, so give them the same
-    // canonical style the convert layer would (else the live render uses the lib's
-    // rounded/rough defaults until reload). Custom types paint via their own
-    // node-type view, so they only need autoFit disabled at birth.
-    const style = nodeType === "rect"
-      ? { ...canonicalNodeStyle(storedColors), ...(autoFitStyle ?? {}) }
-      : autoFitStyle
-    ctx.store.batch(() => {
-      ctx.store.addNode({
-        id,
-        type: nodeType,
-        x: origin.x,
-        y: origin.y,
-        w,
-        h,
-        angle: 0,
-        groups: [],
-        content,
-        ...(style ? { style } : {}),
-        data: { label: { markdown: label ?? "" }, parentId: ctx.rootId ?? undefined, meta: meta(), _storedColors: storedColors } satisfies DimNodeData,
-      })
-    })
-    return { id: String(id), created: true }
+    const spec = { content, label, type: note_type }
+    const board = mutatorFor(ctx)
+    // Existing note → full rewrite (NOT a creation, so the turn won't re-arrange or
+    // recenter it); otherwise create (born beneath the border, arranged post-turn).
+    return note_id && ctx.store.getNode(asNodeId(note_id))
+      ? board.rewriteNote(note_id, spec)
+      : board.createNote({ ...spec, id: note_id })
   },
 })
 
@@ -349,10 +147,10 @@ export const editNote = defineTool({
     replace_all: z.boolean().optional().describe("When true, replace every occurrence of `old` instead of requiring uniqueness."),
   }),
   run: async ({ note_id, field, old, new: replacement, replace_all }, ctx) => {
-    const id = asNodeId(note_id)
-    const node = ctx.store.getNode(id)
+    const node = ctx.store.getNode(asNodeId(note_id))
     if (!node) return { error: "note not found" }
 
+    // Compute the replacement here (tool logic); the write goes through the port.
     const prev = node.data as DimNodeData | undefined
     const current = field === "label" ? labelText(prev?.label) : node.content ?? ""
 
@@ -363,12 +161,8 @@ export const editNote = defineTool({
     }
     const updated = replace_all === true ? current.split(old).join(replacement) : current.replace(old, replacement)
 
-    ctx.store.batch(() =>
-      field === "label"
-        ? ctx.store.updateNode(id, { data: { ...prev, label: { markdown: updated }, meta: meta() } })
-        : ctx.store.updateNode(id, { content: updated }),
-    )
-    return { id: String(id) }
+    await mutatorFor(ctx).patchNote(note_id, field === "label" ? { label: updated } : { content: updated })
+    return { id: note_id }
   },
 })
 

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -10,6 +10,7 @@ import { z } from "zod"
 import type { CanvasStore, Node } from "@canvas-harness/core"
 import type { BoardRegistry } from "@/features/board/persist/local/board-registry"
 import type { MemoryRepo } from "@/features/board/persist/local/memory-repo"
+import type { BoardMutator } from "./board-mutator"
 import type { LocalSearchIndex } from "@/features/board/search/local-index"
 
 
@@ -81,6 +82,12 @@ export interface LlmClient {
 /** Capabilities a tool may need. Search/registry are optional (board-scoped). */
 export type ToolContext = {
   store: CanvasStore
+  /**
+   * Content-level write port (S1). Tools write through this, not `store`
+   * directly, so the runtime is decoupled from the collab op pipeline. Defaults
+   * (via `mutatorFor`) to a `StoreMutator` over `store`+`rootId` when absent.
+   */
+  board?: BoardMutator
   /**
    * Current folder layer new notes/links belong to (null = root). Tools stamp
    * it as `parentId` AT CREATION — the local analog of the backend passing

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -13,6 +13,7 @@ import { isOverQuotaError } from "@/features/agent/engine/services/run"
 import { createFlushGate } from "@/features/agent/utils/stream/throttle"
 import { useIsSignedIn } from "@/lib/auth"
 import { agentBuildTools, memoryTools, searchNotes } from "@/features/agent/engine/tools"
+import { StoreMutator } from "@/features/agent/engine/board-mutator"
 import { skillTools } from "@/features/agent/engine/skills"
 import { getSearchIndexRef } from "@/features/board/search/search-index-ref"
 import { buildWholeBoardSearch } from "@/features/board/search/use-search-index"
@@ -366,7 +367,7 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             () => useToolConfirm.getState().request(req),
           )
         const memory = (await getLocalStores()).memories
-        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, boardId, search, boardNotes, memory, confirmTool } })) {
+        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, boardId, search, boardNotes, memory, confirmTool, board: new StoreMutator(store, rootId) } })) {
           // Streaming yields cumulative assistant_text / reasoning per token —
           // replace the previous snapshot in place instead of appending one event
           // per token. (assistant_text renders live; reasoning is shown at turn-end.)

--- a/webui/src/features/agent/local/use-local-transform.ts
+++ b/webui/src/features/agent/local/use-local-transform.ts
@@ -6,6 +6,7 @@ import { arrangeCreatedNodes } from "@/features/board/harness/agent/arrange-crea
 import { getSearchIndexRef } from "@/features/board/search/search-index-ref"
 import { runAgent } from "@/features/agent/engine/agent-loop"
 import { linkNotes, writeNote } from "@/features/agent/engine/tools"
+import { StoreMutator } from "@/features/agent/engine/board-mutator"
 import { resolveAgentLlm } from "@/features/agent/engine/services/local-llm"
 import type { AgentEvent } from "@/features/agent/engine/types"
 import { useByokStore } from "@/features/agent/byok/byok-store"
@@ -44,7 +45,7 @@ export function useLocalTransform() {
       if (!store || !sourceText.trim()) return { ok: false, createdIds: [] }
       const rootId = useBoardAppStore.getState().rootId
       const search = getSearchIndexRef() ?? undefined
-      const ctx = { store, rootId, search }
+      const ctx = { store, rootId, search, board: new StoreMutator(store, rootId) }
 
       const recenter = (ids: string[]): void => {
         if (ids.length === 0) return


### PR DESCRIPTION
**PR 1 of the agent board-authoring plan** (`docs/plans/agent-board-authoring-tools.md`, §6d/§9c). Behavior-neutral.

## Why

The agent writes via `store.addNode/updateNode/addEdge`. The store's `change` event fans out to persistence **and** the sync outbox (→ relay, oplog seq, rebase) — so a tool that just wants "add a note" is transitively wired into collab conflict-resolution machinery it should know nothing about. That coupling is incidental, and it's what makes cross-layer / headless writes (subfolders, working-folder, cross-layer arrange) scary.

## What

Introduce a **content-level write port** the agent runtime depends on instead of the store:

- **`BoardMutator`** (`engine/board-mutator.ts`) — domain verbs only, no ops/batches/seq: `createNote` / `rewriteNote` / `patchNote` / `createLink`.
- **`StoreMutator`** — the current impl: writes through the live store *exactly* as the tools did inline (same undo + persistence + sync pipeline, identical bytes). The note/edge construction logic — geometry, `randomNoteColors`, canonical style, `meta`, `parentId`, type mapping — **moves out of the tools into the mutator**, so "how a note is born" lives in one place.
- Tools are thinned to `ctx.board.*` (via `mutatorFor(ctx)`, which defaults to a `StoreMutator` over `store`+`rootId` when `ctx.board` is absent). `ctx.store` stays for reads (`get_note`/`search_notes`/existence guards) and for the mutator's current-layer writes.
- `ctx.board` wired at the two agent runtimes (`use-local-submit-prompt`, `use-local-transform`).

## Why it's safe

Pure decoupling — no behavior change. The existing `tools.test.ts` builds `ctx` **without** `board`, so it runs through the `StoreMutator` fallback and asserts the same store state as before. **All tool tests passing unchanged is the proof.**

## Follow-ups (not here)

Every later capability becomes "add a `BoardMutator` impl/method" behind the port: the headless sync-correct emit (S7), `navigate`/working folder (S8), `create_folder`/`parent_id` (S9), and the `position`/`color`/`curve` params (S2–S5). `arrangeCreatedNodes` + the mindmap drain still write the store directly — they migrate to `updatePositions` later.

## Tests

New `board-mutator.test.ts` locks the port (create/rewrite/patch/createLink incl. explicit id/position, rewrite-of-missing → create, partial patch). `check-all` clean; full agent suite green (519).
