### PR TITLE
feat(agent): let the agent bend links to avoid crossings

### DIFF
--- a/webui/src/features/agent/engine/board-mutator.test.ts
+++ b/webui/src/features/agent/engine/board-mutator.test.ts
@@ -103,4 +103,32 @@ describe("StoreMutator", () => {
     expect(edge).toBeTruthy()
     expect((edge?.data as { parentId?: string } | undefined)?.parentId).toBe("folder-1")
   })
+
+  it("createLink is straight (no control points) by default", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    const a = await m.createNote({ content: "A" })
+    const c = await m.createNote({ content: "C" })
+    const { id } = await m.createLink({ sourceId: a.id, targetId: c.id })
+    const edge = store.getAllEdges().find((e) => String(e.id) === id)
+    expect(edge?.control).toBeUndefined()
+  })
+
+  it("createLink with curve sets a bent control pair off the straight midpoint", async () => {
+    const store = freshStore("b")
+    const m = new StoreMutator(store, null)
+    // Two nodes on a horizontal line so the perpendicular bend is purely vertical.
+    const a = await m.createNote({ id: "a", content: "A", x: 0, y: 0 })
+    const c = await m.createNote({ id: "c", content: "C", x: 1000, y: 0 })
+    const { id } = await m.createLink({ sourceId: a.id, targetId: c.id, curve: 80 })
+    const edge = store.getAllEdges().find((e) => String(e.id) === id)
+    expect(edge?.control).toHaveLength(2)
+    // Both nodes sit on the same horizontal center line (centerY); a straight
+    // bezier keeps its controls on that line. A +80 bend must push at least one
+    // control point strictly BELOW it (greater y), proving the curve took effect.
+    const node = store.getNode(asNodeId("a"))!
+    const centerY = node.y + node.h / 2
+    const ys = edge?.control?.map((p) => p.y) ?? []
+    expect(Math.max(...ys)).toBeGreaterThan(centerY)
+  })
 })

--- a/webui/src/features/agent/engine/board-mutator.ts
+++ b/webui/src/features/agent/engine/board-mutator.ts
@@ -10,8 +10,8 @@
  * off-screen, cross-layer writer) can satisfy the same interface without the tool
  * code changing.
  */
-import { asEdgeId, asNodeId } from "@canvas-harness/core"
-import type { CanvasStore, Node } from "@canvas-harness/core"
+import { asEdgeId, asNodeId, midpointToCubicControls } from "@canvas-harness/core"
+import type { CanvasStore, Node, Vec2 } from "@canvas-harness/core"
 import type { DimEdgeData, DimNodeData } from "@/features/board/model"
 import { FAMILIES, pickRandomColorOfShade, resolveFamilyShade } from "@/features/board/lib/colors/tailwind"
 import { AUTOFIT_DISABLED_TYPES } from "@/features/board/harness/convert/note-to-node"
@@ -50,6 +50,12 @@ export type LinkSpec = {
   sourceId: string
   targetId: string
   label?: string
+  /**
+   * Optional bend: a signed perpendicular offset (px) of the curve's midpoint
+   * from the straight source→target line. `+`/`−` pick the side; 0/omitted →
+   * straight. Lets the agent route a link around a node without raw coordinates.
+   */
+  curve?: number
 }
 
 
@@ -257,6 +263,27 @@ export class StoreMutator implements BoardMutator {
     this.store.batch(() => this.store.updateNode(nid, next))
   }
 
+  /**
+   * Cubic control pair for a bent link, or undefined for a straight one. Bends the
+   * midpoint of the source→target center line perpendicularly by `curve` px.
+   */
+  private curveControl(src: ReturnType<typeof asNodeId>, tgt: ReturnType<typeof asNodeId>, curve?: number): Vec2[] | undefined {
+    if (!curve) return undefined
+    const s = this.store.getNode(src)
+    const t = this.store.getNode(tgt)
+    if (!s || !t) return undefined
+    const a: Vec2 = { x: s.x + s.w / 2, y: s.y + s.h / 2 }
+    const b: Vec2 = { x: t.x + t.w / 2, y: t.y + t.h / 2 }
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len = Math.hypot(dx, dy)
+    if (len === 0) return undefined // coincident centers — nothing to bend
+    // Unit perpendicular to the a→b direction; +curve bends toward it.
+    const mid: Vec2 = { x: (a.x + b.x) / 2 + (-dy / len) * curve, y: (a.y + b.y) / 2 + (dx / len) * curve }
+    const { c1, c2 } = midpointToCubicControls(a, mid, b)
+    return [c1, c2]
+  }
+
   async createLink(spec: LinkSpec): Promise<{ id: string }> {
     const id = asEdgeId(this.store.generateId())
     const src = asNodeId(spec.sourceId)
@@ -268,12 +295,18 @@ export class StoreMutator implements BoardMutator {
       return node ? { x: node.w / 2, y: node.h / 2 } : { x: 0, y: 0 }
     }
     const { style, storedColors } = canonicalEdge()
+    // Optional bend: offset the straight-line midpoint perpendicularly by `curve`
+    // px, then convert that single via-point to the cubic control pair the harness
+    // renders (same midpoint→cubic math the convert layer uses). Skipped when the
+    // curve is 0/absent or either endpoint's node/geometry is unavailable.
+    const control = this.curveControl(src, tgt, spec.curve)
     this.store.batch(() => {
       this.store.addEdge({
         id,
         source: { nodeId: src, localOffset: center(src) },
         target: { nodeId: tgt, localOffset: center(tgt) },
         pathStyle: "bezier",
+        ...(control ? { control } : {}),
         groups: [],
         style,
         data: {

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -90,8 +90,9 @@ export const linkNotes = defineTool({
     sourceId: z.string().describe("Exact id of the note the arrow starts from."),
     targetId: z.string().describe("Exact id of the note the arrow points to."),
     label: z.string().optional().describe("Optional short label on the edge, e.g. 'yes', 'no', 'then', 'reads', 'causes'."),
+    curve: z.number().optional().describe("Optional bend to avoid crossings: perpendicular offset in px (+/- picks the side); omit for a straight line."),
   }),
-  run: async ({ sourceId, targetId, label }, ctx) => mutatorFor(ctx).createLink({ sourceId, targetId, label }),
+  run: async ({ sourceId, targetId, label, curve }, ctx) => mutatorFor(ctx).createLink({ sourceId, targetId, label, curve }),
 })
 
 


### PR DESCRIPTION
**PR 3 of the board-authoring plan** (`docs/plans/agent-board-authoring-tools.md` §5c, S3). **Stacked on #253** (which is stacked on #250) — merge those first; this diff is only the link-curve feature.

## What

`link_notes` gains an optional `curve` — a signed perpendicular offset (px) of the link's midpoint from the straight source→target line. `+`/`−` pick the side; omit/0 → straight. It lets the agent route a link around a node without touching raw coordinates.

## How

The curve model already existed in the data layer (`edgeControlPoint` → cubic controls via `midpointToCubicControls`); `link_notes` just never set it. Now the `BoardMutator` (`StoreMutator.createLink`):
- offsets the source→target **center-line midpoint** perpendicularly by `curve` px,
- converts that single via-point to the cubic control pair with `midpointToCubicControls` (the exact math the convert layer uses), and sets `edge.control`.

So it renders live and **round-trips through persistence** (the reverse convert derives the stored midpoint from `control`). Omitted/0 → straight (unchanged); a coincident or absent endpoint is skipped safely (no throw).

Expressed as a **relative bend, not raw coordinates** — same philosophy as the placement design: the model states intent, the engine computes coords.

## Tests

`board-mutator.test.ts`: default link is straight (no `control`); a `curve: 80` on a horizontal pair pushes a control point strictly past the endpoint center line (proves the bend). Full agent suite green (523); `check-all` clean.

## Note

Edge color/arrowheads are the cheap follow-ons flagged in §5c; not in this PR.
