### PR TITLE
feat(agent): spatial context (position + size) for selected notes

### DIFF
--- a/webui/src/features/board/utils/context-text.test.ts
+++ b/webui/src/features/board/utils/context-text.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import type { NoteNode } from "@/features/board/types/flow"
+import { buildContextTextFromNodes } from "./context-text"
+
+
+// Minimal NoteNode whose `data` is the Dim0 Note-like shape the builder reads.
+const note = (over: Record<string, unknown> = {}): NoteNode =>
+  ({
+    id: "n1",
+    data: {
+      id: "n1",
+      label: { markdown: "Cats" },
+      style: { type: "rect" },
+      properties: {
+        nodePosition: { position: { x: 40.4, y: 12.6 } },
+        nodeSize: { size: { width: 320, height: 180 } },
+        ...(over.properties as object | undefined),
+      },
+      ...over,
+    },
+  }) as unknown as NoteNode
+
+
+describe("buildContextTextFromNodes", () => {
+  it("includes rounded position and size in the structured block", () => {
+    const text = buildContextTextFromNodes([note()])
+    expect(text).toContain("NoteId: n1")
+    expect(text).toContain("NoteType: rect")
+    expect(text).toContain("Pos: (40, 13)") // rounded
+    expect(text).toContain("Size: 320x180")
+    expect(text).toContain("Content: Cats")
+  })
+
+  it("omits Pos/Size when the note has no position/size", () => {
+    const bare = { id: "n2", data: { id: "n2", label: { markdown: "Dogs" }, style: { type: "rect" } } } as unknown as NoteNode
+    const text = buildContextTextFromNodes([bare])
+    expect(text).toContain("NoteId: n2")
+    expect(text).not.toContain("Pos:")
+    expect(text).not.toContain("Size:")
+  })
+
+  it("skipPrefix yields plain text only — no spatial block", () => {
+    const text = buildContextTextFromNodes([note()], { skipPrefix: true })
+    expect(text).toBe("Cats")
+    expect(text).not.toContain("Pos:")
+    expect(text).not.toContain("<SelectedNote>")
+  })
+})

--- a/webui/src/features/board/utils/context-text.ts
+++ b/webui/src/features/board/utils/context-text.ts
@@ -6,7 +6,13 @@ type NoteLike = {
   // Canonical shape is RichText; a legacy local board may hold a bare string.
   label?: { markdown?: string } | string
   content?: { markdown?: string }
-  properties?: { summary?: { text?: string } }
+  properties?: {
+    summary?: { text?: string }
+    // Spatial info (from the Dim0 Note) — gives the agent where/how big the
+    // selected note is, so it can reason about layout.
+    nodePosition?: { position?: { x?: number; y?: number } }
+    nodeSize?: { size?: { width?: number; height?: number } }
+  }
   style?: { type?: string }
 }
 
@@ -41,10 +47,16 @@ const buildStructuredNoteBlock = (node: NoteNode) => {
   const noteId = trimOrEmpty(data?.id || node.id)
   const noteType = trimOrEmpty(data?.style?.type)
   const plainText = buildPlainNodeText(node)
+  const pos = data?.properties?.nodePosition?.position
+  const size = data?.properties?.nodeSize?.size
+  const hasPos = pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)
+  const hasSize = size && Number.isFinite(size.width) && Number.isFinite(size.height)
   const lines = [
     "<SelectedNote>",
     noteId ? `NoteId: ${noteId}` : "",
     noteType ? `NoteType: ${noteType}` : "",
+    hasPos ? `Pos: (${Math.round(pos!.x!)}, ${Math.round(pos!.y!)})` : "",
+    hasSize ? `Size: ${Math.round(size!.width!)}x${Math.round(size!.height!)}` : "",
   ]
 
   if (plainText.startsWith("Title: ")) {


### PR DESCRIPTION
**PR of the board-authoring plan** (`docs/plans/agent-board-authoring-tools.md` §7, S4). **Stacked on #253** (→ #250) — merge those first.

## What

The agent now sees **where** and **how big** its selected notes are. Each `<SelectedNote>` context block gains:

```
Pos: (x, y)
Size: WxH
```

## Why

Spatial awareness is the read-side prerequisite for relational placement (S5 — "put this to the right of that") and lets the agent reason about layout / answer spatial questions now. Read from the Dim0 Note's `nodePosition`/`nodeSize`, so it's **theme-independent and always present**; omitted when a note has neither. The plain-text (`skipPrefix`) path used by the AI transforms is unchanged.

## Scope (deliberately tight)

Only the **consumable-now** piece — spatial info on the *focused* (selected) notes. Deferred, to avoid speculative infra, until the steps that actually consume them:
- whole-board `boardEdges` map, a **board-map summary** (cluster bounding boxes), and the **`BoardReader`** port → land with S5/S8, where they're read.
- color-in-context → dropped for now (reverse-resolving a family name from the theme-projected hex is unreliable in dark mode; positions are clean).

## Tests

New `context-text.test.ts`: Pos/Size present + rounded in the structured block; omitted when absent; `skipPrefix` still yields plain text with no spatial block. Agent + board suites green (533); `check-all` clean.
