### PR TITLE
feat(agent): navigate tool + working folder (off-scene authoring)

### DIFF
--- a/webui/src/features/agent/engine/board-mutator.test.ts
+++ b/webui/src/features/agent/engine/board-mutator.test.ts
@@ -1,14 +1,24 @@
-import { beforeEach, describe, expect, it } from "vitest"
-import { asNodeId } from "@canvas-harness/core"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { asNodeId, type OpBatch } from "@canvas-harness/core"
 import type { CanvasStore } from "@canvas-harness/core"
 import { freshStore, resetIdb } from "@/test/canvas"
 import type { DimNodeData } from "@/features/board/model"
 import { labelText } from "@/features/board/model"
 import { resolveFamilyShade } from "@/features/board/lib/colors/tailwind"
-import { StoreMutator } from "./board-mutator"
+import { InMemoryEngine } from "@/features/board/persist/local/in-memory-engine"
+import { BoardPersistence } from "@/features/board/persist/local/board-persistence"
+import { setBoardPersistenceRef } from "@/features/board/persist/local/board-persistence-ref"
+import { setBoardSyncRef } from "@/features/board/harness/sync/board-sync-ref"
+import type { BoardSyncHandle } from "@/features/board/harness/sync/board-sync"
+import { StoreMutator, HeadlessMutator } from "./board-mutator"
 
 
 beforeEach(() => resetIdb())
+afterEach(() => {
+  // Module-singleton refs — isolate the HeadlessMutator tests.
+  setBoardPersistenceRef(null)
+  setBoardSyncRef(null)
+})
 
 
 const label = (store: CanvasStore, id: string): string =>
@@ -260,5 +270,77 @@ describe("StoreMutator", () => {
     const edge = store.getAllEdges().find((e) => String(e.id) === id)
     expect(edge).toBeTruthy()
     expect((edge?.data as { parentId?: string } | undefined)?.parentId).toBe("folder-1")
+  })
+})
+
+
+describe("HeadlessMutator", () => {
+  // A synced-board fixture: whole-board persistence + a spy sync ref that records
+  // how each off-scene batch enters the coordinator.
+  const setup = () => {
+    const engine = new InMemoryEngine()
+    const persistence = new BoardPersistence("b", { engine })
+    setBoardPersistenceRef(persistence)
+    const submitted: { scene?: boolean }[] = []
+    setBoardSyncRef({
+      submitLocalBatch: (_b: OpBatch, opts?: { scene?: boolean }) => submitted.push({ scene: opts?.scene }),
+    } as unknown as BoardSyncHandle)
+    const scene = freshStore("scene") // the user's visible layer (root)
+    return { persistence, submitted, scene }
+  }
+
+  it("createNote writes into the target layer off-scene — not in the visible store, synced scene:false", async () => {
+    const { persistence, submitted, scene } = setup()
+    const m = new HeadlessMutator(scene, "folder-1")
+    const res = await m.createNote({ content: "hi", label: "H" })
+    await persistence.flush()
+
+    expect(res.offScene).toBe(true)
+    // Never enters the user's visible store.
+    expect(scene.getNode(asNodeId(res.id))).toBeUndefined()
+    // Landed in the whole-board oplog, stamped into the target layer.
+    const whole = await persistence.load()
+    const node = whole.nodes.find((n) => String(n.id) === res.id)
+    expect(node?.data?.parentId).toBe("folder-1")
+    // Entered the sync intake as an off-scene batch (never the rebase set).
+    expect(submitted.length).toBeGreaterThan(0)
+    expect(submitted.every((s) => s.scene === false)).toBe(true)
+  })
+
+  it("accumulates within a session so a second note places below the first (shared off-scene store)", async () => {
+    const { scene } = setup()
+    const m = new HeadlessMutator(scene, "folder-1")
+    const a = await m.createNote({ content: "A" }) // auto-placed at origin
+    const b = await m.createNote({ content: "B" }) // auto-placed BENEATH A
+    expect(await m.hasNode(a.id)).toBe(true)
+    expect(await m.hasNode(b.id)).toBe(true)
+    expect(await m.hasNode("nope")).toBe(false)
+  })
+
+  it("createLink joins two off-scene notes in the target layer", async () => {
+    const { persistence, scene } = setup()
+    const m = new HeadlessMutator(scene, "folder-1")
+    const a = await m.createNote({ content: "A" })
+    const b = await m.createNote({ content: "B" })
+    const { id } = await m.createLink({ sourceId: a.id, targetId: b.id, label: "then" })
+    await persistence.flush()
+    const whole = await persistence.load()
+    const edge = whole.edges.find((e) => String(e.id) === id)
+    expect((edge?.data as { parentId?: string } | undefined)?.parentId).toBe("folder-1")
+  })
+
+  it("seeds from the existing layer so it can edit a note already in that folder", async () => {
+    const { persistence, scene } = setup()
+    // Seed a note into folder-1 via a separate headless session (as a prior turn would).
+    const seeded = await new HeadlessMutator(scene, "folder-1").createNote({ content: "old", label: "Old" })
+    await persistence.flush()
+    // A fresh session must see it (loaded from the oplog) and rewrite it in place.
+    const m = new HeadlessMutator(scene, "folder-1")
+    expect(await m.hasNode(seeded.id)).toBe(true)
+    await m.rewriteNote(seeded.id, { content: "new" })
+    await persistence.flush()
+    const whole = await persistence.load()
+    const node = whole.nodes.find((n) => String(n.id) === seeded.id)
+    expect(node?.content).toBe("new")
   })
 })

--- a/webui/src/features/agent/engine/board-mutator.ts
+++ b/webui/src/features/agent/engine/board-mutator.ts
@@ -515,6 +515,10 @@ export class HeadlessMutator implements BoardMutator {
   private async ensure(): Promise<StoreMutator> {
     if (this.inner) return this.inner
     const persistence = getBoardPersistenceRef()
+    // Flush first so the seed reflects THIS turn's own writes: an earlier navigate
+    // into the same folder recorded notes to the (debounced) oplog — re-seeding
+    // from an unflushed log would miss them (overlap + broken links on re-entry).
+    await persistence?.flush()
     const whole = persistence ? await persistence.load() : emptyContent()
     const layer = filterContentByLayer(whole, this.targetLayer)
     const offStore = createCanvasStore({
@@ -556,6 +560,17 @@ export class HeadlessMutator implements BoardMutator {
   async hasNode(id: string): Promise<boolean> {
     await this.ensure()
     return this.offStore?.getNode(asNodeId(id)) !== undefined
+  }
+
+  /**
+   * The off-scene store backing the working folder (seeds on first call). Lets
+   * read/edit/arrange tools operate on the working layer — its notes, including
+   * ones authored this turn — instead of the user's visible scene.
+   */
+  async layerStore(): Promise<CanvasStore> {
+    await this.ensure()
+    // ensure() always assigns offStore before returning.
+    return this.offStore as CanvasStore
   }
 
   /** Detach the change subscription. Best-effort — the off-scene store is local. */

--- a/webui/src/features/agent/engine/board-mutator.ts
+++ b/webui/src/features/agent/engine/board-mutator.ts
@@ -10,9 +10,14 @@
  * off-screen, cross-layer writer) can satisfy the same interface without the tool
  * code changing.
  */
-import { asEdgeId, asNodeId } from "@canvas-harness/core"
+import { asEdgeId, asNodeId, createCanvasStore } from "@canvas-harness/core"
 import type { CanvasStore, Node } from "@canvas-harness/core"
 import type { DimEdgeData, DimNodeData } from "@/features/board/model"
+import { filterContentByLayer } from "@/features/board/model/layer"
+import { contentToScene, emptyContent } from "@/features/board/persist/local/codec"
+import { getBoardPersistenceRef } from "@/features/board/persist/local/board-persistence-ref"
+import { getBoardSyncRef } from "@/features/board/harness/sync/board-sync-ref"
+import { generateUuid } from "@/lib/common"
 import { FAMILIES, pickRandomColorOfShade, resolveFamilyShade, toBaseHex } from "@/features/board/lib/colors/tailwind"
 import { hexToRgb } from "@/features/board/utils/color"
 import { AUTOFIT_DISABLED_TYPES } from "@/features/board/harness/convert/note-to-node"
@@ -70,8 +75,13 @@ export type LinkSpec = {
  * the signature; the impl decides how the write reaches persistence + sync.
  */
 export interface BoardMutator {
-  /** `placed` = pinned at an explicit/relational position (excluded from arrange). */
-  createNote(spec: NoteSpec): Promise<{ id: string; created: true; placed: boolean }>
+  /**
+   * `placed` = pinned at an explicit/relational position (excluded from arrange).
+   * `offScene` = written into a layer that isn't the visible scene (the agent's
+   * working folder ≠ the user's view) — the turn must NOT arrange/recenter it in
+   * the current view.
+   */
+  createNote(spec: NoteSpec): Promise<{ id: string; created: true; placed: boolean; offScene?: boolean }>
   rewriteNote(id: string, spec: NoteSpec): Promise<{ id: string; created: boolean }>
   patchNote(id: string, patch: { content?: string; label?: string }): Promise<void>
   createLink(spec: LinkSpec): Promise<{ id: string }>
@@ -463,5 +473,94 @@ export class StoreMutator implements BoardMutator {
       })
     })
     return { id: String(id) }
+  }
+}
+
+
+// ---- HeadlessMutator: writes into an OFF-SCENE layer (not the visible store) --
+
+/**
+ * Writes into a board layer that ISN'T the visible scene — the agent's working
+ * folder (§S8) when it differs from the user's on-screen layer. Lets the agent
+ * author into a subfolder *without moving the user's view*.
+ *
+ * Reuses `StoreMutator` verbatim against a throwaway off-scene store seeded with
+ * the target layer's content, so all build / placement / rewrite logic — and the
+ * store's correct `node.update.prev` computation — is shared, not duplicated. The
+ * off-scene store's local `change` batches are forwarded to the sync-correct
+ * intake: recorded to the whole-board oplog and pumped via
+ * `submitLocalBatch(batch, { scene: false })` (S7), so the write persists + syncs
+ * without ever entering the visible scene's rebase set. The off-scene store is
+ * never mounted, so nothing renders. Seeded lazily on the first write, and its
+ * clientId + id scheme match the scene store so ids/batches stay board-valid.
+ */
+export class HeadlessMutator implements BoardMutator {
+  private readonly sceneStore: CanvasStore
+  private readonly targetLayer: string | null
+  private inner: StoreMutator | null = null
+  private offStore: CanvasStore | null = null
+  private detachChange: (() => void) | null = null
+
+  constructor(sceneStore: CanvasStore, targetLayer: string | null) {
+    this.sceneStore = sceneStore
+    this.targetLayer = targetLayer
+  }
+
+  /**
+   * Seed the off-scene store from the whole-board oplog (filtered to the target
+   * layer) and wire its commits into the sync intake. Idempotent — the first
+   * write builds it; later writes reuse it, so notes created this turn accumulate
+   * for placement + linking.
+   */
+  private async ensure(): Promise<StoreMutator> {
+    if (this.inner) return this.inner
+    const persistence = getBoardPersistenceRef()
+    const whole = persistence ? await persistence.load() : emptyContent()
+    const layer = filterContentByLayer(whole, this.targetLayer)
+    const offStore = createCanvasStore({
+      clientId: this.sceneStore.clientId,
+      idGenerator: generateUuid,
+      initial: contentToScene(layer),
+    })
+    // Every off-scene commit records to the oplog and enters the sync intake as an
+    // off-scene batch — pumped + serverSeq-stamped, but never the in-scene rebase
+    // set (its ops aren't in the visible store). Mirrors the scene store's
+    // persistence.attach + attachSync, minus the render.
+    this.detachChange = offStore.subscribe("change", (batch) => {
+      persistence?.record(batch)
+      getBoardSyncRef()?.submitLocalBatch(batch, { scene: false })
+    })
+    this.offStore = offStore
+    this.inner = new StoreMutator(offStore, this.targetLayer)
+    return this.inner
+  }
+
+  async createNote(spec: NoteSpec): Promise<{ id: string; created: true; placed: boolean; offScene: true }> {
+    const r = await (await this.ensure()).createNote(spec)
+    return { ...r, offScene: true }
+  }
+
+  async rewriteNote(id: string, spec: NoteSpec): Promise<{ id: string; created: boolean }> {
+    return (await this.ensure()).rewriteNote(id, spec)
+  }
+
+  async patchNote(id: string, patch: { content?: string; label?: string }): Promise<void> {
+    return (await this.ensure()).patchNote(id, patch)
+  }
+
+  async createLink(spec: LinkSpec): Promise<{ id: string }> {
+    return (await this.ensure()).createLink(spec)
+  }
+
+  /** True if a node with `id` lives in the target layer (seeds on first call). */
+  async hasNode(id: string): Promise<boolean> {
+    await this.ensure()
+    return this.offStore?.getNode(asNodeId(id)) !== undefined
+  }
+
+  /** Detach the change subscription. Best-effort — the off-scene store is local. */
+  dispose(): void {
+    this.detachChange?.()
+    this.detachChange = null
   }
 }

--- a/webui/src/features/agent/engine/tools.test.ts
+++ b/webui/src/features/agent/engine/tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { asNodeId } from "@canvas-harness/core"
 import type { CanvasStore, Node } from "@canvas-harness/core"
 import { freshStore, resetIdb } from "@/test/canvas"
@@ -18,6 +18,7 @@ import {
   getNote,
   editNote,
   arrangeNotes,
+  navigate,
   searchNotes,
   listBoards,
   saveMemory,
@@ -25,6 +26,10 @@ import {
   deleteMemory,
   recallMemory,
 } from "./tools"
+import { HeadlessMutator, StoreMutator } from "./board-mutator"
+import { BoardPersistence } from "@/features/board/persist/local/board-persistence"
+import { setBoardPersistenceRef } from "@/features/board/persist/local/board-persistence-ref"
+import { setBoardSyncRef } from "@/features/board/harness/sync/board-sync-ref"
 
 
 // A LocalSearchIndex that returns a fixed id list (we test the id→result mapping,
@@ -646,5 +651,96 @@ describe("memory tools", () => {
     const del = (await deleteMemory.run({ id: "ghost" }, ctx)) as { ok: boolean }
     expect(upd.ok).toBe(false)
     expect(del.ok).toBe(false)
+  })
+})
+
+
+describe("navigate (working folder)", () => {
+  // A folder node lives on the WHOLE board (boardNotes); the visible store is the
+  // root layer. Navigating into the folder must route writes off-scene.
+  const folder = (id: string, label: string): Node =>
+    ({
+      id: asNodeId(id),
+      type: "folder",
+      x: 0, y: 0, w: 100, h: 50, angle: 0, groups: [],
+      data: { label: { markdown: label }, meta: { v: 1, createdAt: 0, updatedAt: 0 } },
+    }) as unknown as Node
+
+  beforeEach(() => {
+    // A whole-board persistence so the off-scene write path is exercised;
+    // no relay (persistence-only is sync-correct on a local board).
+    setBoardPersistenceRef(new BoardPersistence("b", { engine: new InMemoryEngine() }))
+    setBoardSyncRef(null)
+  })
+  afterEach(() => {
+    setBoardPersistenceRef(null)
+    setBoardSyncRef(null)
+  })
+
+  it("into a folder sets the working folder and routes writes off-scene", async () => {
+    const store = freshStore("c")
+    const nav: ToolContext = {
+      store,
+      rootId: null,
+      sceneRootId: null,
+      boardNotes: new Map([["F", folder("F", "Ideas")]]),
+    }
+    const res = (await navigate.run({ target: "F" }, nav)) as { working_folder: string; label: string }
+    expect(res.working_folder).toBe("F")
+    expect(res.label).toBe("Ideas")
+    expect(nav.rootId).toBe("F")
+    expect(nav.board).toBeInstanceOf(HeadlessMutator)
+
+    // A note created now lands in F, off-scene — never in the visible root store.
+    const note = (await createNote.run({ title: "T", body: "B" }, nav)) as { id: string; offScene?: boolean }
+    expect(note.offScene).toBe(true)
+    expect(store.getNode(asNodeId(note.id))).toBeUndefined()
+  })
+
+  it('navigating back to "root" restores store (visible) writes', async () => {
+    const store = freshStore("c")
+    const nav: ToolContext = {
+      store,
+      rootId: "F",
+      sceneRootId: null,
+      board: new HeadlessMutator(store, "F"),
+      boardNotes: new Map([["F", folder("F", "Ideas")]]),
+    }
+    await navigate.run({ target: "root" }, nav)
+    expect(nav.rootId).toBe(null)
+    expect(nav.board).toBeInstanceOf(StoreMutator)
+    // Now a create renders into the visible store.
+    const note = (await createNote.run({ title: "R", body: "B" }, nav)) as { id: string; offScene?: boolean }
+    expect(note.offScene).toBeUndefined()
+    expect(store.getNode(asNodeId(note.id))).toBeDefined()
+  })
+
+  it('"up" walks to the parent folder', async () => {
+    const store = freshStore("c")
+    const nav: ToolContext = {
+      store,
+      rootId: "child",
+      sceneRootId: null,
+      boardNotes: new Map([
+        ["parent", folder("parent", "Parent")],
+        ["child", { ...folder("child", "Child"), data: { ...(folder("child", "Child").data as object), parentId: "parent" } } as unknown as Node],
+      ]),
+    }
+    const res = (await navigate.run({ target: "up" }, nav)) as { working_folder: string }
+    expect(res.working_folder).toBe("parent")
+    expect(nav.rootId).toBe("parent")
+  })
+
+  it("rejects a non-folder or unknown target", async () => {
+    const store = freshStore("c")
+    const nav: ToolContext = {
+      store,
+      rootId: null,
+      sceneRootId: null,
+      boardNotes: new Map([["n1", { ...folder("n1", "x"), type: "rect" } as unknown as Node]]),
+    }
+    expect((await navigate.run({ target: "n1" }, nav)) as { error?: string }).toHaveProperty("error")
+    expect((await navigate.run({ target: "ghost" }, nav)) as { error?: string }).toHaveProperty("error")
+    expect(nav.rootId).toBe(null) // unchanged on error
   })
 })

--- a/webui/src/features/agent/engine/tools.test.ts
+++ b/webui/src/features/agent/engine/tools.test.ts
@@ -743,4 +743,46 @@ describe("navigate (working folder)", () => {
     expect((await navigate.run({ target: "ghost" }, nav)) as { error?: string }).toHaveProperty("error")
     expect(nav.rootId).toBe(null) // unchanged on error
   })
+
+  it("read/edit/rewrite/arrange act on the off-scene working folder, not the user's view", async () => {
+    const store = freshStore("c")
+    seed(store, "visible", { label: "OnScreen", content: "user note" }) // the user's on-screen layer
+    const nav: ToolContext = {
+      store,
+      rootId: null,
+      sceneRootId: null,
+      boardNotes: new Map([["F", folder("F", "Ideas")]]),
+    }
+    await navigate.run({ target: "F" }, nav)
+    const note = (await createNote.run({ title: "T", body: "hello" }, nav)) as { id: string }
+
+    // get_note reads the note authored off-scene (was "not found" before the fix).
+    expect(((await getNote.run({ note_id: note.id }, nav)) as { content: string }).content).toBe("hello")
+    // edit_note edits it in place, off-scene.
+    await editNote.run({ note_id: note.id, field: "content", old: "hello", new: "bye" }, nav)
+    expect(((await getNote.run({ note_id: note.id }, nav)) as { content: string }).content).toBe("bye")
+    // write_note rewrite targets the off-scene note (not a duplicate/error).
+    const rw = (await writeNote.run({ content: "rewritten", note_id: note.id }, nav)) as { created: boolean }
+    expect(rw.created).toBe(false)
+    // arrange_notes (no ids) tidies the working folder — the user's on-screen note
+    // is never relocated.
+    const visibleX = store.getNode(asNodeId("visible"))!.x
+    await arrangeNotes.run({}, nav)
+    expect(store.getNode(asNodeId("visible"))!.x).toBe(visibleX)
+  })
+
+  it("re-entering a folder in the same turn sees notes it wrote before leaving", async () => {
+    const store = freshStore("c")
+    const nav: ToolContext = {
+      store,
+      rootId: null,
+      sceneRootId: null,
+      boardNotes: new Map([["F", folder("F", "Ideas")]]),
+    }
+    await navigate.run({ target: "F" }, nav)
+    const note = (await createNote.run({ title: "T", body: "x" }, nav)) as { id: string }
+    await navigate.run({ target: "root" }, nav)
+    await navigate.run({ target: "F" }, nav) // a fresh session must re-seed from the oplog (incl. `note`)
+    expect(((await getNote.run({ note_id: note.id }, nav)) as { content?: string }).content).toBe("x")
+  })
 })

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -10,7 +10,7 @@
  */
 import { z } from "zod"
 import { asNodeId } from "@canvas-harness/core"
-import type { Node } from "@canvas-harness/core"
+import type { CanvasStore, Node } from "@canvas-harness/core"
 import type { DimNodeData } from "@/features/board/model"
 import { labelText } from "@/features/board/model"
 import { validateMiniAppSource } from "@/features/mini-app/validate"
@@ -28,6 +28,19 @@ import type { MemoryKind, MemoryScope } from "@/features/board/persist/local/idb
  * decoupled from the collab op pipeline (see board-mutator.ts).
  */
 const mutatorFor = (ctx: ToolContext): BoardMutator => ctx.board ?? new StoreMutator(ctx.store, ctx.rootId ?? null)
+
+
+/**
+ * The store for the agent's WORKING FOLDER: the off-scene layer store when the
+ * working folder isn't the user's visible layer (navigated away), else the
+ * visible `store`. Read/edit/arrange tools resolve through this so they act on
+ * the folder the agent is working in — including notes it authored this turn —
+ * and never touch the user's on-screen layer while navigated away.
+ */
+const workingLayerStore = async (ctx: ToolContext): Promise<CanvasStore> => {
+  const board = mutatorFor(ctx)
+  return board instanceof HeadlessMutator ? board.layerStore() : ctx.store
+}
 
 
 /**
@@ -136,7 +149,12 @@ export const writeNote = defineTool({
     near: NEAR_SCHEMA.optional().describe(NEAR_DESC),
   }),
   run: async ({ content, label, note_type, note_id, background_color, border_color, near }, ctx) => {
-    const existing = note_id ? ctx.store.getNode(asNodeId(note_id)) : undefined
+    const board = mutatorFor(ctx)
+    // Resolve existence in the WORKING folder (off-scene when navigated away), so a
+    // rewrite / re-edit of a note in that folder — incl. one created this turn —
+    // targets it instead of erroring or duplicating.
+    const store = await workingLayerStore(ctx)
+    const existing = note_id ? store.getNode(asNodeId(note_id)) : undefined
     // Validate a mini-app before persisting, so a malformed one is rejected with
     // line/col for the agent to fix this turn (not a silently-broken note). Key off
     // the RESULTING type: an explicit mini-app, OR a bare rewrite of an existing
@@ -150,14 +168,13 @@ export const writeNote = defineTool({
     }
 
     const spec = { content, label, type: note_type, near: nearFor(near), colors: colorsFor(background_color, border_color) }
-    const board = mutatorFor(ctx)
     if (note_id) {
-      // In the current layer → full rewrite (NOT a creation; the turn won't
+      // In the working folder → full rewrite (NOT a creation; the turn won't
       // re-arrange/recenter it). Existing but in ANOTHER folder → refuse rather
-      // than create a colliding duplicate (cross-folder writes aren't supported
-      // yet). Nowhere → a brand-new note with this explicit id.
+      // than create a colliding duplicate (navigate there first). Nowhere → a
+      // brand-new note with this explicit id.
       if (existing) return board.rewriteNote(note_id, spec)
-      if (resolveBoardNode(ctx, note_id)) return { error: "That note is in another folder. Open that folder before editing it." }
+      if (ctx.boardNotes?.get(note_id)) return { error: "That note is in another folder. Navigate into that folder before editing it." }
       return board.createNote({ ...spec, id: note_id })
     }
     return board.createNote(spec)
@@ -178,11 +195,14 @@ export const arrangeNotes = defineTool({
     note_ids: z.array(z.string()).optional().describe("Ids of the notes to arrange (a cluster). Omit to arrange all notes in the current view."),
   }),
   run: async ({ note_ids }, ctx) => {
-    const ids = note_ids && note_ids.length > 0 ? note_ids : ctx.store.getAllNodes().map((n) => String(n.id))
+    // Arrange within the WORKING folder — the off-scene layer store when navigated
+    // away — so tidying a subfolder never relocates the user's on-screen notes.
+    const store = await workingLayerStore(ctx)
+    const ids = note_ids && note_ids.length > 0 ? note_ids : store.getAllNodes().map((n) => String(n.id))
     if (ids.length > MAX_ARRANGE) {
       return { error: `Too many notes to arrange at once (${ids.length}). Pass a note_ids set for the specific cluster to tidy.` }
     }
-    const arranged = await arrangeNodesInPlace(ctx.store, ids)
+    const arranged = await arrangeNodesInPlace(store, ids)
     return { arranged }
   },
 })
@@ -244,9 +264,11 @@ export const getNote = defineTool({
     note_id: z.string().describe("Id of the note to read."),
   }),
   run: async ({ note_id }, ctx) => {
-    // Whole-board resolve so a note in another folder (not in the layer-scoped
-    // store) is still readable — search_notes can surface cross-folder ids.
-    const node = resolveBoardNode(ctx, note_id)
+    // Working folder first (its notes, incl. ones authored this turn off-scene),
+    // then the whole-board snapshot so a cross-folder id (e.g. from search_notes)
+    // is still readable.
+    const store = await workingLayerStore(ctx)
+    const node = store.getNode(asNodeId(note_id)) ?? ctx.boardNotes?.get(note_id)
     if (!node) return { error: "note not found" }
     return {
       id: note_id,
@@ -269,13 +291,14 @@ export const editNote = defineTool({
     replace_all: z.boolean().optional().describe("When true, replace every occurrence of `old` instead of requiring uniqueness."),
   }),
   run: async ({ note_id, field, old, new: replacement, replace_all }, ctx) => {
-    const node = ctx.store.getNode(asNodeId(note_id))
+    // Edit within the working folder (off-scene when navigated away).
+    const store = await workingLayerStore(ctx)
+    const node = store.getNode(asNodeId(note_id))
     if (!node) {
-      // A cross-folder note (resolvable whole-board but not in this layer) can't be
-      // edited from here yet — say so, consistent with write_note, instead of a
-      // bare "not found".
-      return resolveBoardNode(ctx, note_id)
-        ? { error: "That note is in another folder. Open that folder before editing it." }
+      // A cross-folder note (resolvable whole-board but not in this working folder)
+      // can't be edited from here — say so, consistent with write_note.
+      return ctx.boardNotes?.get(note_id)
+        ? { error: "That note is in another folder. Navigate into that folder before editing it." }
         : { error: "note not found" }
     }
 

--- a/webui/src/features/agent/engine/tools.ts
+++ b/webui/src/features/agent/engine/tools.ts
@@ -16,7 +16,7 @@ import { labelText } from "@/features/board/model"
 import { validateMiniAppSource } from "@/features/mini-app/validate"
 import { defineTool } from "./types"
 import type { Tool, ToolContext } from "./types"
-import { StoreMutator, type BoardMutator } from "./board-mutator"
+import { StoreMutator, HeadlessMutator, type BoardMutator } from "./board-mutator"
 import { arrangeNodesInPlace } from "@/features/board/harness/agent/arrange-created-nodes"
 import type { MemoryKind, MemoryScope } from "@/features/board/persist/local/idb"
 
@@ -107,12 +107,18 @@ export const linkNotes = defineTool({
     label: z.string().optional().describe("Optional short label on the edge, e.g. 'yes', 'no', 'then', 'reads', 'causes'."),
   }),
   run: async ({ sourceId, targetId, label }, ctx) => {
-    // Both endpoints must exist in the current layer (edges are layer-scoped) —
+    // Both endpoints must exist in the working folder (edges are layer-scoped) —
     // otherwise the edge would dangle at (0,0) on a phantom node. Fail clearly.
-    if (!ctx.store.getNode(asNodeId(sourceId)) || !ctx.store.getNode(asNodeId(targetId))) {
-      return { error: "link_notes: source or target note not found in the current board." }
+    // When the working folder is off-scene, check its layer, not the visible store.
+    const board = mutatorFor(ctx)
+    const bothExist =
+      board instanceof HeadlessMutator
+        ? (await board.hasNode(sourceId)) && (await board.hasNode(targetId))
+        : !!ctx.store.getNode(asNodeId(sourceId)) && !!ctx.store.getNode(asNodeId(targetId))
+    if (!bothExist) {
+      return { error: "link_notes: source or target note not found in the current working folder." }
     }
-    return mutatorFor(ctx).createLink({ sourceId, targetId, label })
+    return board.createLink({ sourceId, targetId, label })
   },
 })
 
@@ -178,6 +184,55 @@ export const arrangeNotes = defineTool({
     }
     const arranged = await arrangeNodesInPlace(ctx.store, ids)
     return { arranged }
+  },
+})
+
+
+export const navigate = defineTool({
+  name: "navigate",
+  description:
+    "Set your working folder — like `cd`. Afterward, create_note / write_note / link_notes write INTO this folder without moving the user's on-screen view. Returns the folder's current notes, so it doubles as looking inside a folder. target: a folder node's id to enter it, \"root\" for the top level, or \"up\" for the parent folder.",
+  parameters: z.object({
+    target: z
+      .string()
+      .describe('A folder node id to enter, "root" for the top level, or "up" to go to the parent folder.'),
+  }),
+  run: async ({ target }, ctx) => {
+    const nodes = ctx.boardNotes
+    const current = ctx.rootId ?? null
+    // Resolve the destination layer id (null = root).
+    let dest: string | null
+    if (target === "root") {
+      dest = null
+    } else if (target === "up") {
+      const node = current ? nodes?.get(current) : undefined
+      dest = (node?.data as DimNodeData | undefined)?.parentId ?? null
+    } else {
+      const node = nodes?.get(target)
+      if (!node) return { error: `navigate: no node with id ${target}` }
+      if (node.type !== "folder") return { error: `navigate: ${target} is not a folder` }
+      dest = target
+    }
+    // Switch the working folder + write routing. Release any prior off-scene
+    // session, then pick store (dest is the visible layer → renders) vs headless.
+    if (ctx.board instanceof HeadlessMutator) ctx.board.dispose()
+    ctx.rootId = dest
+    const sceneRoot = ctx.sceneRootId ?? null
+    ctx.board =
+      dest === sceneRoot ? new StoreMutator(ctx.store, dest) : new HeadlessMutator(ctx.store, dest)
+    // ls: the destination layer's notes from the whole-board snapshot (may lag
+    // this turn's own writes into the same folder).
+    const notes = [...(nodes?.values() ?? [])]
+      .filter((n) => ((n.data as DimNodeData | undefined)?.parentId ?? null) === dest)
+      .map((n) => ({
+        id: String(n.id),
+        title: labelText((n.data as DimNodeData | undefined)?.label),
+        type: n.type,
+      }))
+    const label = dest
+      ? labelText((nodes?.get(dest)?.data as DimNodeData | undefined)?.label) || "Folder"
+      : "root"
+    return { working_folder: dest ?? "root", label, note_count: notes.length, notes }
   },
 })
 
@@ -436,4 +491,4 @@ export const localTools: Tool[] = [createNote, updateNote, linkNotes, searchNote
 
 
 /** The note-building tools the chat agent uses (matches the system prompt's vocabulary). */
-export const agentBuildTools: Tool[] = [writeNote, editNote, getNote, linkNotes, arrangeNotes]
+export const agentBuildTools: Tool[] = [writeNote, editNote, getNote, linkNotes, arrangeNotes, navigate]

--- a/webui/src/features/agent/engine/types.ts
+++ b/webui/src/features/agent/engine/types.ts
@@ -89,12 +89,21 @@ export type ToolContext = {
    */
   board?: BoardMutator
   /**
-   * Current folder layer new notes/links belong to (null = root). Tools stamp
-   * it as `parentId` AT CREATION — the local analog of the backend passing
-   * `root_id` to `build_note`, so a note is born in the right sub-board rather
-   * than relying on a post-hoc rescope.
+   * The agent's **working folder** (null = root) — the layer new notes/links
+   * belong to, stamped as `parentId` AT CREATION. Starts at the user's layer but
+   * is MUTABLE mid-turn: the `navigate` tool sets it (like `cd`), decoupled from
+   * the on-screen layer. When it differs from `sceneRootId`, writes route through
+   * a headless off-scene mutator (see board-mutator.ts) so the user's view never
+   * moves.
    */
   rootId?: string | null
+  /**
+   * The layer the visible `store` is projecting (the user's on-screen view) —
+   * fixed for the turn. `mutatorFor` compares it to the working folder (`rootId`)
+   * to decide store (visible, renders) vs headless (off-scene) writes. Defaults
+   * to `rootId` when the runtime doesn't distinguish them (tests / lean ctx).
+   */
+  sceneRootId?: string | null
   /** The board this run acts on — memory tools bind board-scoped writes to it. */
   boardId?: string
   search?: LocalSearchIndex

--- a/webui/src/features/agent/local/use-local-submit-prompt.ts
+++ b/webui/src/features/agent/local/use-local-submit-prompt.ts
@@ -13,7 +13,7 @@ import { isOverQuotaError } from "@/features/agent/engine/services/run"
 import { createFlushGate } from "@/features/agent/utils/stream/throttle"
 import { useIsSignedIn } from "@/lib/auth"
 import { agentBuildTools, memoryTools, searchNotes } from "@/features/agent/engine/tools"
-import { StoreMutator } from "@/features/agent/engine/board-mutator"
+import { StoreMutator, HeadlessMutator } from "@/features/agent/engine/board-mutator"
 import { skillTools } from "@/features/agent/engine/skills"
 import { getSearchIndexRef } from "@/features/board/search/search-index-ref"
 import { buildWholeBoardSearch } from "@/features/board/search/use-search-index"
@@ -373,7 +373,22 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             () => useToolConfirm.getState().request(req),
           )
         const memory = (await getLocalStores()).memories
-        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx: { store, rootId, boardId, search, boardNotes, memory, confirmTool, board: new StoreMutator(store, rootId) } })) {
+        // `rootId` is the agent's working folder (mutable via `navigate`);
+        // `sceneRootId` is the user's on-screen layer (fixed) — the mutator routes
+        // off-scene writes when they diverge. Hoisted so the turn can dispose any
+        // headless session it left open.
+        const ctx = {
+          store,
+          rootId,
+          sceneRootId: rootId,
+          boardId,
+          search,
+          boardNotes,
+          memory,
+          confirmTool,
+          board: new StoreMutator(store, rootId) as StoreMutator | HeadlessMutator,
+        }
+        for await (const ev of runAgent({ system: systemWithDocs, userMessage: userMessageForAgent, history, tools, llm, ctx })) {
           // Streaming yields cumulative assistant_text / reasoning per token —
           // replace the previous snapshot in place instead of appending one event
           // per token. (assistant_text renders live; reasoning is shown at turn-end.)
@@ -387,7 +402,10 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             ev.type === "tool_result" &&
             (ev.toolName === "write_note" || ev.toolName === "create_note") &&
             ev.result && typeof ev.result === "object" && "id" in ev.result &&
-            (ev.result as { created?: unknown }).created === true
+            (ev.result as { created?: unknown }).created === true &&
+            // Off-scene writes (into a navigated-away working folder) aren't in the
+            // visible store — arranging/recentering them would target phantom nodes.
+            (ev.result as { offScene?: unknown }).offScene !== true
           ) {
             const id = String((ev.result as { id: unknown }).id)
             createdNodeIds.push(id)
@@ -420,6 +438,9 @@ export function useLocalSubmitPrompt(boardId: string, syncTranscript = false) {
             }
           }
         }
+        // Release any off-scene session the agent left open (its writes are already
+        // recorded + pumped; this just detaches the throwaway store's subscription).
+        if (ctx.board instanceof HeadlessMutator) ctx.board.dispose()
         render(false)
         // Post-turn arrange (frontend analog of backend rearrange_created_notes).
         // Only auto-placed notes — pinned (near/explicit) ones keep their spot.

--- a/webui/src/features/agent/local/use-local-transform.ts
+++ b/webui/src/features/agent/local/use-local-transform.ts
@@ -45,7 +45,9 @@ export function useLocalTransform() {
       if (!store || !sourceText.trim()) return { ok: false, createdIds: [] }
       const rootId = useBoardAppStore.getState().rootId
       const search = getSearchIndexRef() ?? undefined
-      const ctx = { store, rootId, search, board: new StoreMutator(store, rootId) }
+      // Transforms don't navigate (no `navigate` tool), so the working folder
+      // stays the scene layer — writes always go through the visible store.
+      const ctx = { store, rootId, sceneRootId: rootId, search, board: new StoreMutator(store, rootId) }
 
       const recenter = (ids: string[]): void => {
         if (ids.length === 0) return

--- a/webui/src/features/agent/prompts/plan-system.md
+++ b/webui/src/features/agent/prompts/plan-system.md
@@ -52,7 +52,7 @@ Use only these tools:
 - `link_notes(source_id, target_id, label?)`: draw a directed arrow between two existing notes in the current board
 - `arrange_notes(note_ids?)`: tidy notes into a clean auto-layout in place; omit `note_ids` to arrange the whole current board. Use when notes end up cluttered or overlapping.
 - `search_notes(query)`: full-text search existing notes on the board; returns each match's id, title, and a content snippet
-- `navigate(target)`: set your working folder — like `cd`. Afterward `write_note`/`link_notes` write INTO that folder without moving the user's view. `target` is a folder id, `"root"` (top level), or `"up"` (parent). Returns the folder's notes, so it also lets you look inside a folder. Use it to organize notes into an existing subfolder; navigate back with `"root"`/`"up"` when done.
+- `navigate(target)`: set your working folder — like `cd`. Afterward every note tool (`write_note`, `link_notes`, `edit_note`, `get_note`, `arrange_notes`) operates INSIDE that folder without moving the user's view. `target` is a folder id, `"root"` (top level), or `"up"` (parent). Returns the folder's notes, so it also lets you look inside a folder. Use it to organize notes into an existing subfolder; navigate back with `"root"`/`"up"` when done.
 - `save_memory(scope, kind, title, summary, body)`: remember a durable fact (scope `board` = about this board, `global` = about the user across boards)
 - `update_memory(id, …)` / `delete_memory(id)`: revise or drop a saved fact by its id (ids appear in the `## MEMORY` block)
 - `recall_memory(scope?, query?)`: look up saved facts (rarely needed — the memory index is already in your prompt)

--- a/webui/src/features/agent/prompts/plan-system.md
+++ b/webui/src/features/agent/prompts/plan-system.md
@@ -52,6 +52,7 @@ Use only these tools:
 - `link_notes(source_id, target_id, label?)`: draw a directed arrow between two existing notes in the current board
 - `arrange_notes(note_ids?)`: tidy notes into a clean auto-layout in place; omit `note_ids` to arrange the whole current board. Use when notes end up cluttered or overlapping.
 - `search_notes(query)`: full-text search existing notes on the board; returns each match's id, title, and a content snippet
+- `navigate(target)`: set your working folder — like `cd`. Afterward `write_note`/`link_notes` write INTO that folder without moving the user's view. `target` is a folder id, `"root"` (top level), or `"up"` (parent). Returns the folder's notes, so it also lets you look inside a folder. Use it to organize notes into an existing subfolder; navigate back with `"root"`/`"up"` when done.
 - `save_memory(scope, kind, title, summary, body)`: remember a durable fact (scope `board` = about this board, `global` = about the user across boards)
 - `update_memory(id, …)` / `delete_memory(id)`: revise or drop a saved fact by its id (ids appear in the `## MEMORY` block)
 - `recall_memory(scope?, query?)`: look up saved facts (rarely needed — the memory index is already in your prompt)


### PR DESCRIPTION
## What

S8 of the board-authoring plan: gives the agent a **working folder** — a mutable cursor, like a shell's `cwd` — decoupled from the user's on-screen layer. The agent can `navigate` into a folder and author there **without moving the user's view**, using the S7 headless sync intake.

## Design

- `ctx.rootId` becomes the **mutable working folder** (mutated mid-turn by `navigate`; `ctx` is a stable object across tool calls, so later calls see it). Added `ctx.sceneRootId` = the layer the visible store projects (the user's view, fixed for the turn).
- `mutatorFor(ctx)` routes per call: **working folder == scene layer → `StoreMutator`** (renders + syncs, unchanged); **≠ → `HeadlessMutator`** (off-scene).
- **`HeadlessMutator`** writes into a non-visible layer by reusing `StoreMutator` verbatim against a throwaway off-scene `createCanvasStore` seeded (from the whole-board oplog) with the target layer's content. Its local `change` batches are forwarded to the sync-correct intake: `persistence.record` + `getBoardSyncRef().submitLocalBatch(batch, { scene: false })`. Nothing renders; the store computes `node.update.prev` correctly, so no op is hand-built. clientId + id scheme match the scene store so batches/ids stay board-valid.
- **`navigate(target)`** tool (`folder_id | "root" | "up"`): resolves the destination, switches the working folder + write routing, and returns the folder's current contents (its `ls`). Listed in the agent prompt.
- `link_notes` resolves both endpoints in the working folder (the off-scene layer when headless), not just the visible store.
- Off-scene creates are excluded from the post-turn scene arrange/recenter (they aren't in the visible store).

Why reuse `StoreMutator` via an off-scene store rather than hand-build ops: `node.add`/`edge.add` are trivial, but `node.update` needs a correct `prev` slice that the store computes automatically — wrapping the store gets rewrite/patch parity and correct `prev` for free.

## Scope

In scope: `navigate` + headless create/link/rewrite/patch into the working folder. Out of scope (→ S9): `create_folder` + per-call `parent_id` overrides. Deferred: mid-turn re-scoping of the search index (navigate's return is the read mechanism); an on-finish "worked in Folder X" receipt card.

## Test plan

- `HeadlessMutator` tests: a create lands in the target layer off-scene (not in the visible store), is recorded to the whole-board oplog with the right `parentId`, and enters the sync intake `scene:false`; sessions accumulate; `createLink` joins two off-scene notes; a fresh session seeds from the oplog so it can rewrite a note already in that folder.
- `navigate` tests: entering a folder sets the working folder + routes writes off-scene; `"root"` restores visible writes; `"up"` walks to the parent; a non-folder / unknown target errors without changing the working folder.
- Full agent suite (554 tests) + `npm run check-all` pass.
