### PR TITLE
feat(models): route normal to DeepSeek V4 Flash, classifier to gpt-oss-120b

### DIFF
--- a/backend/test/unit/config/test_catalog.py
+++ b/backend/test/unit/config/test_catalog.py
@@ -140,6 +140,23 @@ def test_default_model_code_by_tier(clean_keys):
     assert smart_resolved.tier == "pro"
 
 
+def test_resolved_by_id(clean_keys):
+    """resolved_by_id returns the reachable model for an id, else None."""
+    clean_keys.setenv("OPENROUTER_API_KEY", "or-x")
+    r = catalog.resolved_by_id("gpt-oss-120b")
+    assert r is not None
+    assert r.id == "gpt-oss-120b"
+    assert r.call == "openrouter/openai/gpt-oss-120b"
+    # Unknown id → None.
+    assert catalog.resolved_by_id("no-such-model") is None
+
+
+def test_resolved_by_id_unreachable_is_none(clean_keys):
+    """An OpenRouter-only model is None when only the OpenAI key is present."""
+    clean_keys.setenv("OPENAI_API_KEY", "sk-x")
+    assert catalog.resolved_by_id("gpt-oss-120b") is None
+
+
 @pytest.mark.parametrize(
     "given",
     [

--- a/backend/test/unit/config/test_catalog.py
+++ b/backend/test/unit/config/test_catalog.py
@@ -100,8 +100,9 @@ def test_nitro_only_on_non_openai_anthropic_routes(clean_keys):
     # OpenAI + Anthropic via OpenRouter: no :nitro.
     assert ":nitro" not in by_id["gpt-5.4"].call
     assert ":nitro" not in by_id["claude-opus-4.8"].call
-    # Everyone else via OpenRouter: :nitro.
-    for mid in ("glm-5.2", "gemma-4-31b", "qwen3.6-plus", "deepseek-v4-pro", "kimi-k2.6", "minimax-m2.7"):
+    # Everyone else via OpenRouter: :nitro — including gpt-oss (open-weight,
+    # multi-provider) despite its vendor-branded openai/ slug.
+    for mid in ("glm-5.2", "gemma-4-31b", "qwen3.6-plus", "deepseek-v4-pro", "kimi-k2.6", "minimax-m2.7", "gpt-oss-120b"):
         assert by_id[mid].call.endswith(":nitro"), mid
 
 
@@ -146,7 +147,7 @@ def test_resolved_by_id(clean_keys):
     r = catalog.resolved_by_id("gpt-oss-120b")
     assert r is not None
     assert r.id == "gpt-oss-120b"
-    assert r.call == "openrouter/openai/gpt-oss-120b"
+    assert r.call == "openrouter/openai/gpt-oss-120b:nitro"
     # Unknown id → None.
     assert catalog.resolved_by_id("no-such-model") is None
 

--- a/backend/test/unit/config/test_catalog_integrity.py
+++ b/backend/test/unit/config/test_catalog_integrity.py
@@ -67,7 +67,12 @@ def test_nitro_only_on_non_openai_anthropic_openrouter_routes():
         for r in m.routes:
             if r.via != "openrouter":
                 continue
-            single_provider = r.model.startswith(("openai/", "anthropic/"))
+            # Proprietary OpenAI/Anthropic models are single-provider on OpenRouter
+            # (no nitro). Open-weight models are multi-provider even when the slug
+            # is vendor-branded (e.g. openai/gpt-oss-*), so they keep nitro.
+            single_provider = (
+                r.model.startswith(("openai/", "anthropic/")) and "gpt-oss" not in r.model
+            )
             has_nitro = r.model.endswith(":nitro")
             if single_provider and has_nitro:
                 violations.append(("unexpected :nitro", m.id, r.model))

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -15,7 +15,11 @@ from pydantic import BaseModel
 
 from topix.config import catalog
 
-AUTO_MODEL_TIMEOUT_SECONDS = 5
+# Cap on the classify call, which runs synchronously on the hot path before the
+# plan agent — so this is worst-case dead time. Kept tight since the classifier
+# rides the fast gpt-oss-120b:nitro route; a slow provider cold-start just falls
+# back to "medium".
+AUTO_MODEL_TIMEOUT_SECONDS = 3
 
 # Cheap/fast open model for the throwaway complexity classify — pinned so it stays
 # independent of the (possibly slower) base model. Falls back to the lite default

--- a/backend/topix/agents/assistant/auto_model.py
+++ b/backend/topix/agents/assistant/auto_model.py
@@ -15,7 +15,12 @@ from pydantic import BaseModel
 
 from topix.config import catalog
 
-AUTO_MODEL_TIMEOUT_SECONDS = 2
+AUTO_MODEL_TIMEOUT_SECONDS = 5
+
+# Cheap/fast open model for the throwaway complexity classify — pinned so it stays
+# independent of the (possibly slower) base model. Falls back to the lite default
+# when unavailable (e.g. no OpenRouter key).
+CLASSIFIER_MODEL_ID = "gpt-oss-120b"
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +183,11 @@ async def classify_auto_model_complexity(messages: list[dict[str, str]]) -> Comp
     native Anthropic/Gemini/Mistral/DeepSeek key), not just OpenAI-compatible ones.
     """
     started_at = time.perf_counter()
-    fast = catalog.default_resolved("lite") or catalog.default_resolved()
+    fast = (
+        catalog.resolved_by_id(CLASSIFIER_MODEL_ID)
+        or catalog.default_resolved("lite")
+        or catalog.default_resolved()
+    )
     if fast is None:
         logger.info("Auto model classifier skipped (no model available)")
         return "medium"

--- a/backend/topix/config/catalog.py
+++ b/backend/topix/config/catalog.py
@@ -241,6 +241,11 @@ def normalize_code(model: str) -> str | None:
     return None
 
 
+def resolved_by_id(model_id: str) -> Resolved | None:
+    """Return the reachable model with this canonical id, or None (unknown / no key)."""
+    return next((r for r in available_llms() if r.id == model_id), None)
+
+
 def default_resolved(tier: str | None = None) -> Resolved | None:
     """Best available model, optionally constrained to a tier (falls back to any)."""
     models = available_llms()

--- a/backend/topix/models.yml
+++ b/backend/topix/models.yml
@@ -8,8 +8,10 @@
 #
 # Adding a model = one entry here. No code change.
 #
-# OpenRouter routes use the `:nitro` throughput variant EXCEPT for OpenAI and
-# Anthropic models (single-provider on OpenRouter; nitro adds nothing there).
+# OpenRouter routes use the `:nitro` throughput variant EXCEPT for proprietary
+# OpenAI and Anthropic models (single-provider on OpenRouter; nitro adds nothing
+# there). Open-weight models keep :nitro even when the slug is vendor-branded
+# (e.g. `openai/gpt-oss-*`), since many providers serve them.
 
 providers:
   # LLM providers. `prefix` is prepended to the route's model string to form the
@@ -66,12 +68,15 @@ llm:
     tier: lite
     routes:
       - { via: openrouter, model: deepseek/deepseek-v4-flash:nitro }
+  # gpt-oss is OpenAI-branded but OPEN-WEIGHT and multi-provider on OpenRouter, so
+  # (unlike proprietary openai/* models) it keeps :nitro to route to the fastest
+  # provider — important for the latency-sensitive classifier.
   - id: gpt-oss-120b
     label: GPT-OSS 120B
     family: openai
     tier: lite
     routes:
-      - { via: openrouter, model: openai/gpt-oss-120b }
+      - { via: openrouter, model: openai/gpt-oss-120b:nitro }
 
   - id: gpt-5.4-mini
     label: GPT-5.4 Mini

--- a/backend/topix/models.yml
+++ b/backend/topix/models.yml
@@ -52,6 +52,27 @@ llm:
     routes:
       - { via: openai,     model: gpt-5.4 }
       - { via: openrouter, model: openai/gpt-5.4 }
+
+  # --- Auto-routing base + classifier ---
+  # `deepseek-v4-flash` is the first *lite* entry, so it's the normal/base auto
+  # default (OpenRouter, nitro; falls through to gpt-5.4-mini with no OpenRouter
+  # key). `gpt-oss-120b` is pinned as the complexity-classifier model in
+  # auto_model.py (resolved by id, not tier order), so its position here does not
+  # affect the base default. `gpt-5.5` stays the first entry overall → the no-tier
+  # fallback + complex/pro default.
+  - id: deepseek-v4-flash
+    label: DeepSeek V4 Flash
+    family: deepseek
+    tier: lite
+    routes:
+      - { via: openrouter, model: deepseek/deepseek-v4-flash:nitro }
+  - id: gpt-oss-120b
+    label: GPT-OSS 120B
+    family: openai
+    tier: lite
+    routes:
+      - { via: openrouter, model: openai/gpt-oss-120b }
+
   - id: gpt-5.4-mini
     label: GPT-5.4 Mini
     family: openai
@@ -126,19 +147,14 @@ llm:
     routes:
       - { via: openrouter, model: qwen/qwen3.6-plus:nitro }
 
-  # --- DeepSeek V4 (OpenRouter only) ---
+  # --- DeepSeek V4 (OpenRouter only). deepseek-v4-flash is the auto base, listed
+  #     up in the "Auto-routing base + classifier" block above. ---
   - id: deepseek-v4-pro
     label: DeepSeek V4 Pro
     family: deepseek
     tier: pro
     routes:
       - { via: openrouter, model: deepseek/deepseek-v4-pro:nitro }
-  - id: deepseek-v4-flash
-    label: DeepSeek V4 Flash
-    family: deepseek
-    tier: lite
-    routes:
-      - { via: openrouter, model: deepseek/deepseek-v4-flash:nitro }
 
   # --- Mistral (native preferred, OpenRouter fallback with :nitro) ---
   - id: mistral-large

--- a/docs/plans/model-routing-deepseek-base.md
+++ b/docs/plans/model-routing-deepseek-base.md
@@ -1,0 +1,50 @@
+# Auto base → DeepSeek V4 Flash; classifier → gpt-oss-120b
+
+Alternative to the GLM base (#268), which regressed: GLM 5.3 Flash via OpenRouter
+didn't emit real `tool_calls` (agent hallucinated the tool loop as text) and was
+too slow for the 2s classifier timeout. DeepSeek V4 Flash tests clean for tool
+calling; gpt-oss-120b is a cheap, fast, tool/structured-output-capable classifier.
+
+## Desired routing
+- **normal (lite) → DeepSeek V4 Flash** (`deepseek/deepseek-v4-flash:nitro`, OpenRouter)
+  when an OpenRouter key is present; falls through to `gpt-5.4-mini` with no key.
+- **complex (pro) → gpt-5.5** (unchanged — 5.5 > 5.4).
+- **classifier → gpt-oss-120b** (`openai/gpt-oss-120b`, OpenRouter): $0.03/$0.17,
+  native structured output; decoupled from the base so it stays cheap/fast.
+- **no-tier fallback** stays a strong pro (`gpt-5.5`, the first entry) — the lesson
+  from #268's review (don't let a lite model become `default_resolved(None)`).
+
+## Changes
+
+### `backend/topix/models.yml`
+- Move `deepseek-v4-flash` up to be the **first lite** entry (right after the OpenAI
+  pro block, before `gpt-5.4-mini`) → the normal/base auto-default.
+- Add `gpt-oss-120b` (tier `lite`, route `openai/gpt-oss-120b`, **no** `:nitro` — the
+  `openai/` prefix is treated as single-provider by the nitro-rule test) right after
+  it. Position doesn't affect the base (classifier resolves it by id), but it must
+  come after deepseek so deepseek stays first-lite.
+- Remove `deepseek-v4-flash` from the DeepSeek section (keep `deepseek-v4-pro`).
+- `gpt-5.5` stays first overall/first pro (no-tier + complex default unchanged).
+
+### `backend/topix/config/catalog.py`
+- Add `resolved_by_id(model_id) -> Resolved | None` (first reachable model with that id).
+
+### `backend/topix/agents/assistant/auto_model.py`
+- Pin the classifier: `fast = catalog.resolved_by_id("gpt-oss-120b") or
+  default_resolved("lite") or default_resolved()`.
+- Bump `AUTO_MODEL_TIMEOUT_SECONDS` 2 → 5 (OpenRouter first-token latency headroom;
+  the common case still returns fast).
+
+## Tests
+- `test_catalog`: add a `resolved_by_id` test; the existing tier-default/openrouter
+  tests still hold (deepseek/gpt-oss are OpenRouter-only; `glm-5.2` untouched here).
+- Integrity: gpt-oss-120b has a valid tier, no `:nitro` on the `openai/` route,
+  unique id.
+
+## Out of scope
+- The BYOK signed-out default (handled separately in #268). This PR is the managed
+  auto base + classifier only.
+- GLM base (#268) stays open for the user's own testing; this is the alternative.
+
+## Verify
+`ruff check topix test/unit` + `pytest test/unit`, then `/code-review high`.


### PR DESCRIPTION
## What

Alternative to the GLM base in #268, which regressed in testing: GLM 5.3 Flash via OpenRouter did not emit real `tool_calls` (the agent hallucinated the whole tool loop as text, so nothing hit the board) and was too slow for the 2s classifier timeout (it took ~2030ms, so the classifier always fell back to `medium` and complex routing died).

DeepSeek V4 Flash tests clean for tool calling. This routes:

- **normal (lite) -> DeepSeek V4 Flash** (`deepseek/deepseek-v4-flash:nitro`, OpenRouter) when an OpenRouter key is present; falls through to `gpt-5.4-mini` with no key.
- **complex (pro) -> gpt-5.5** (unchanged).
- **classifier -> gpt-oss-120b** (`openai/gpt-oss-120b`): open-weight, native structured output, ~$0.03/$0.17 per M tokens. Pinned by id so it stays independent of the base model.

## How

- `models.yml`: `deepseek-v4-flash` becomes the first `lite` entry (auto base); add `gpt-oss-120b` (lite, no `:nitro` since the `openai/` route is single-provider). `gpt-5.5` stays the first entry overall, so the no-tier fallback and complex default are unchanged (the no-tier-default lesson from #268's review).
- `catalog.resolved_by_id(id)`: resolve a specific model by canonical id.
- `auto_model.py`: pin the classifier to `gpt-oss-120b`, falling back to the lite default then any model. Bump `AUTO_MODEL_TIMEOUT_SECONDS` 2 -> 5 for OpenRouter first-token latency headroom.

## BYOK fallback

DeepSeek and gpt-oss are OpenRouter-only, so with no OpenRouter key the base falls to `gpt-5.4-mini` and the classifier to the lite default, both native OpenAI. No one is stranded.

## Test plan

- `ruff check topix test/unit`: clean
- `pytest test/unit`: 706 passed (added `resolved_by_id` tests)

## Notes

- #268 (GLM base) stays open for separate testing; this is the alternative to merge if DeepSeek wins.
- The signed-out BYOK default is out of scope here (handled in #268).